### PR TITLE
feat: imagepreview 适配 taro

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -954,6 +954,7 @@
           "desc": "图片预览",
           "sort": 23,
           "show": true,
+          "taro": true,
           "author": "yangjinjun3"
         }
       ]

--- a/src/packages/imagepreview/demo.taro.tsx
+++ b/src/packages/imagepreview/demo.taro.tsx
@@ -25,29 +25,6 @@ const images = [
   },
 ]
 
-const videos = [
-  {
-    source: {
-      src: 'https://storage.jd.com/about/big-final.mp4?Expires=3730193075&AccessKey=3LoYX1dQWa6ZXzQl&Signature=ViMFjz%2BOkBxS%2FY1rjtUVqbopbJI%3D',
-      type: 'video/mp4',
-    },
-    options: {
-      muted: true,
-      controls: true,
-    },
-  },
-  {
-    source: {
-      src: 'https://storage.jd.com/about/big-final.mp4?Expires=3730193075&AccessKey=3LoYX1dQWa6ZXzQl&Signature=ViMFjz%2BOkBxS%2FY1rjtUVqbopbJI%3D',
-      type: 'video/mp4',
-    },
-    options: {
-      muted: true,
-      controls: true,
-    },
-  },
-]
-
 const ImagePreviewDemo = () => {
   const [translated] = useTranslate<T>({
     'zh-CN': {
@@ -69,7 +46,6 @@ const ImagePreviewDemo = () => {
   const [showPreview1, setShowPreview1] = useState(false)
   const [showPreview2, setShowPreview2] = useState(false)
   const [showPreview3, setShowPreview3] = useState(false)
-  const [showPreview4, setShowPreview4] = useState(false)
 
   const showFn1 = () => {
     setShowPreview1(true)
@@ -83,10 +59,6 @@ const ImagePreviewDemo = () => {
     setShowPreview3(true)
   }
 
-  const showFn4 = () => {
-    setShowPreview4(true)
-  }
-
   const hideFn1 = () => {
     setShowPreview1(false)
   }
@@ -97,10 +69,6 @@ const ImagePreviewDemo = () => {
 
   const hideFn3 = () => {
     setShowPreview3(false)
-  }
-
-  const hideFn4 = () => {
-    setShowPreview4(false)
   }
 
   return (
@@ -126,14 +94,6 @@ const ImagePreviewDemo = () => {
           onClose={hideFn3}
         />
         <Cell title={translated.withPagination} isLink onClick={showFn3} />
-        <h2>{translated.withVideos}</h2>
-        <ImagePreview
-          images={images}
-          videos={videos}
-          show={showPreview4}
-          onClose={hideFn4}
-        />
-        <Cell title={translated.withVideos} isLink onClick={showFn4} />
       </div>
     </>
   )

--- a/src/packages/imagepreview/imagepreview.scss
+++ b/src/packages/imagepreview/imagepreview.scss
@@ -1,3 +1,6 @@
+@import '../popup/popup.scss';
+@import '../swiper/swiper.scss';
+@import '../video/video.scss';
 .nut-imagepreview {
   width: 100%;
 

--- a/src/packages/imagepreview/imagepreview.taro.tsx
+++ b/src/packages/imagepreview/imagepreview.taro.tsx
@@ -7,7 +7,6 @@ import React, {
   TouchEvent,
 } from 'react'
 import Popup from '@/packages/popup/index.taro'
-import Video from '@/packages/video/index.taro'
 import Swiper from '@/packages/swiper/index.taro'
 import SwiperItem from '@/packages/swiperitem/index.taro'
 
@@ -257,24 +256,19 @@ export const ImagePreview: FunctionComponent<Partial<ImagePreviewProps>> = (
           paginationColor={paginationColor}
           paginationVisible={paginationVisible}
         >
-          {videos &&
-            videos.length > 0 &&
-            videos.map((item, index) => {
-              return (
-                <SwiperItem key={index}>
-                  <Video source={item.source} options={item.options} />
-                </SwiperItem>
-              )
-            })}
-          {images &&
-            images.length > 0 &&
-            images.map((item, index) => {
-              return (
-                <SwiperItem key={index}>
-                  <img src={item.src} alt="" className="nut-imagepreview-img" />
-                </SwiperItem>
-              )
-            })}
+          {images && images.length > 0
+            ? images.map((item, index) => {
+                return (
+                  <SwiperItem key={index}>
+                    <img
+                      src={item.src}
+                      alt=""
+                      className="nut-imagepreview-img"
+                    />
+                  </SwiperItem>
+                )
+              })
+            : []}
         </Swiper>
       </div>
       <div className="nut-imagepreview-index">

--- a/src/packages/imagepreview/imagepreview.tsx
+++ b/src/packages/imagepreview/imagepreview.tsx
@@ -257,24 +257,30 @@ export const ImagePreview: FunctionComponent<Partial<ImagePreviewProps>> = (
           paginationColor={paginationColor}
           paginationVisible={paginationVisible}
         >
-          {videos &&
-            videos.length > 0 &&
-            videos.map((item, index) => {
-              return (
-                <SwiperItem key={index}>
-                  <Video source={item.source} options={item.options} />
-                </SwiperItem>
-              )
-            })}
-          {images &&
-            images.length > 0 &&
-            images.map((item, index) => {
-              return (
-                <SwiperItem key={index}>
-                  <img src={item.src} alt="" className="nut-imagepreview-img" />
-                </SwiperItem>
-              )
-            })}
+          {(videos && videos.length > 0
+            ? videos.map((item, index) => {
+                return (
+                  <SwiperItem key={index}>
+                    <Video source={item.source} options={item.options} />
+                  </SwiperItem>
+                )
+              })
+            : []
+          ).concat(
+            images && images.length > 0
+              ? images.map((item, index) => {
+                  return (
+                    <SwiperItem key={index}>
+                      <img
+                        src={item.src}
+                        alt=""
+                        className="nut-imagepreview-img"
+                      />
+                    </SwiperItem>
+                  )
+                })
+              : []
+          )}
         </Swiper>
       </div>
       <div className="nut-imagepreview-index">

--- a/src/packages/swiper/swiper.scss
+++ b/src/packages/swiper/swiper.scss
@@ -1,3 +1,4 @@
+@import '../swiperitem/swiperitem.scss';
 .nut-swiper {
   position: relative;
   z-index: 1;

--- a/src/packages/swiper/swiper.taro.tsx
+++ b/src/packages/swiper/swiper.taro.tsx
@@ -467,6 +467,11 @@ export const Swiper = React.forwardRef<
       stopAutoPlay()
     }
   }, [])
+  useReady(() => {
+    nextTick(() => {
+      init()
+    })
+  })
   const itemStyle = (index: any) => {
     const style: IStyle = {}
     const _direction = propSwiper.direction || direction

--- a/src/packages/swiper/swiper.taro.tsx
+++ b/src/packages/swiper/swiper.taro.tsx
@@ -458,18 +458,15 @@ export const Swiper = React.forwardRef<
     autoplay()
   }, [children])
   useEffect(() => {
-    init()
+    nextTick(() => {
+      init()
+    })
   }, [propSwiper.initPage])
   useEffect(() => {
     return () => {
       stopAutoPlay()
     }
   }, [])
-  useReady(() => {
-    nextTick(() => {
-      init()
-    })
-  })
   const itemStyle = (index: any) => {
     const style: IStyle = {}
     const _direction = propSwiper.direction || direction

--- a/src/sites/mobile-taro/src/app.config.ts
+++ b/src/sites/mobile-taro/src/app.config.ts
@@ -71,6 +71,7 @@ const subPackages = [
       'pages/progress/index',
       'pages/audio/index',
       'pages/animatingnumbers/index',
+      'pages/imagepreview/index',
     ],
   },
   {


### PR DESCRIPTION
包含以下修改：
1、imagepreview.scss 中增加 popup、swiper、video 样式导入
2、imagepreview demo.taro 中移除 video 组件的使用（不支持）
3、修改 imagepreview 中使用 swiperItem 的方式，兼容 swiper 内部关于 children 的操作
4、swiper 中 useEffect 内调用 init 时增加 nextTick，解决 imagepreview 无法获取 rect 的问题