### PR TITLE
fix: 支持css粘性布局，引起的左右布局bug修复

### DIFF
--- a/src/packages/tabs/demo.taro.tsx
+++ b/src/packages/tabs/demo.taro.tsx
@@ -229,6 +229,7 @@ const TabsDemo = () => {
         </Tabs>
         <h2>{translated.title5}</h2>
         <Tabs
+          style={{ height: '300px' }}
           value={tab5value}
           onChange={({ paneKey }) => {
             setTab5value(paneKey)
@@ -245,6 +246,7 @@ const TabsDemo = () => {
         </Tabs>
         <h2>{translated.title6}</h2>
         <Tabs
+          style={{ height: '300px' }}
           value={tab6value}
           onChange={({ paneKey }) => {
             setTab6value(paneKey)

--- a/src/packages/tabs/demo.tsx
+++ b/src/packages/tabs/demo.tsx
@@ -231,6 +231,7 @@ const TabsDemo = () => {
         </Tabs>
         <h2>{translated.title5}</h2>
         <Tabs
+          style={{ height: '300px' }}
           value={tab5value}
           onChange={({ paneKey }) => {
             setTab5value(paneKey)
@@ -247,6 +248,7 @@ const TabsDemo = () => {
         </Tabs>
         <h2>{translated.title6}</h2>
         <Tabs
+          style={{ height: '300px' }}
           value={tab6value}
           onChange={({ paneKey }) => {
             setTab6value(paneKey)

--- a/src/packages/tabs/doc.en-US.md
+++ b/src/packages/tabs/doc.en-US.md
@@ -200,7 +200,7 @@ const App = () => {
   const list5 = Array.from(new Array(2).keys());
   return (
     <>
-      <Tabs value={tab5value} onChange={({ paneKey }) => {
+      <Tabs style={{ height: '300px' }} value={tab5value} onChange={({ paneKey }) => {
         setTab5value(paneKey)
       }} titleScroll direction="vertical">
         {list5.map(item => <TabPane key={item}
@@ -227,7 +227,7 @@ const App = () => {
   const list5 = Array.from(new Array(2).keys());
   return (
     <>
-      <Tabs value={tab6value} onChange={({ paneKey }) => {
+      <Tabs style={{ height: '300px' }} value={tab6value} onChange={({ paneKey }) => {
         setTab6value(paneKey)
       }} type="smile" titleScroll direction="vertical">
         {list5.map(item => <TabPane key={item}

--- a/src/packages/tabs/doc.md
+++ b/src/packages/tabs/doc.md
@@ -247,7 +247,7 @@ const App = () => {
   const list5 = Array.from(new Array(2).keys());
   return (
     <>
-      <Tabs value={tab5value} onChange={({ paneKey }) => {
+      <Tabs style={{ height: '300px' }} value={tab5value} onChange={({ paneKey }) => {
         setTab5value(paneKey)
       }} titleScroll direction="vertical">
         {list5.map(item => <TabPane key={item}
@@ -274,7 +274,7 @@ const App = () => {
   const list5 = Array.from(new Array(2).keys());
   return (
     <>
-      <Tabs value={tab6value} onChange={({ paneKey }) => {
+      <Tabs style={{ height: '300px' }} value={tab6value} onChange={({ paneKey }) => {
         setTab6value(paneKey)
       }} type="smile" titleScroll direction="vertical">
         {list5.map(item => <TabPane key={item}

--- a/src/packages/tabs/doc.zh-TW.md
+++ b/src/packages/tabs/doc.zh-TW.md
@@ -167,7 +167,7 @@ const App = () => {
   const list5 = Array.from(new Array(2).keys());
   return (
     <>
-      <Tabs value={tab5value} onChange={({ paneKey }) => {
+      <Tabs style={{ height: '300px' }} value={tab5value} onChange={({ paneKey }) => {
         setTab5value(paneKey)
       }} titleScroll direction="vertical">
         {list5.map(item => <TabPane key={item}
@@ -194,7 +194,7 @@ const App = () => {
   const list5 = Array.from(new Array(2).keys());
   return (
     <>
-      <Tabs value={tab6value} onChange={({ paneKey }) => {
+      <Tabs style={{ height: '300px' }} value={tab6value} onChange={({ paneKey }) => {
         setTab6value(paneKey)
       }} type="smile" titleScroll direction="vertical">
         {list5.map(item => <TabPane key={item}

--- a/src/packages/tabs/tabs.scss
+++ b/src/packages/tabs/tabs.scss
@@ -13,6 +13,7 @@
     width: 100%;
 
     .nut-tabs__titles {
+      box-sizing: border-box;
       flex-direction: column;
       height: 100%;
       padding: 10px 0 !important;
@@ -63,8 +64,11 @@
     }
 
     .nut-tabs__content {
-      flex: 1;
       flex-direction: column;
+      &__wrap {
+        flex: 1;
+      }
+      height: 100%;
 
       .nut-tabpane {
         height: 100%;
@@ -80,6 +84,7 @@
     background: $tabs-titles-background-color;
     border-radius: $tabs-titles-border-radius;
     flex-shrink: 0;
+    overflow: hidden;
 
     &.large {
       .nut-tabs__titles-item {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

日常 bug 修复

之前支持的css粘性布局 更改了 页面结构，没有考虑到对左右布局样式的影响，以及 tab标签部分 标签过多并且没有开启滚动支持情况下，页面宽度超出问题。

此次提交 主要修复以上问题，并补充了左右布局demo部分样式，与vue版本demo对齐。
