### PR TITLE
docs: 修复 datepicker 文档中示例代码错误

### DIFF
--- a/src/packages/datepicker/doc.md
+++ b/src/packages/datepicker/doc.md
@@ -295,7 +295,7 @@ const App = () => {
   };
   return ( 
     <>   
-      <Cell title="时间选择" desc={desc6} onClick={() => setShow6(true)} />
+      <Cell title="时间选择" desc={desc7} onClick={() => setShow6(true)} />
       <DatePicker
           title="时间选择"
           type="datehour"


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [X] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#448 

### 💡 需求背景和解决方案
![image](https://user-images.githubusercontent.com/52622877/201304543-8f606bb5-9dde-497f-855f-37b23c7d3e8f.png)
链接 https://nutui.jd.com/react/#/zh-CN/component/datepicker 例子7 过滤选项,跳转至代码平台后，预览框无法渲染，看到控制台报错 `ReferenceError: desc6 is not defined`。修改desc6 为desc7 后正常运行
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
