### PR TITLE
fix: nutui-react-trao 移除 formitem 对 react-router-dom 的依赖

### DIFF
--- a/src/packages/formitem/formitem.taro.tsx
+++ b/src/packages/formitem/formitem.taro.tsx
@@ -1,0 +1,163 @@
+import React from 'react'
+import { BaseFormField } from './types'
+import { FormItemContext } from './formitemcontext'
+import Cell from '@/packages/cell/index.taro'
+import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+
+type TextAlign =
+  | 'start'
+  | 'end'
+  | 'left'
+  | 'right'
+  | 'center'
+  | 'justify'
+  | 'match-parent'
+export interface FormItemProps extends BasicComponent, BaseFormField {
+  labelWidth: string | number
+  errorMessageAlign: TextAlign
+  showErrorLine: boolean
+  showErrorMessage: boolean
+}
+
+const defaultProps = {
+  ...ComponentDefaults,
+  name: '',
+  label: '',
+  className: '',
+  rules: [{ required: false, message: '' }],
+  disabled: false,
+  labelWidth: 90,
+  errorMessageAlign: 'left',
+  showErrorLine: true,
+  showErrorMessage: true,
+} as FormItemProps
+
+export type FieldProps = typeof defaultProps & Partial<BaseFormField>
+
+export class FormItem extends React.Component<FieldProps> {
+  static defaultProps = defaultProps
+
+  static contextType: any = FormItemContext
+
+  declare context: React.ContextType<typeof FormItemContext>
+
+  private cancelRegister: any
+
+  componentDidMount() {
+    // 注册组件实例到FormStore
+    this.cancelRegister = this.context.registerField(this)
+  }
+
+  componentWillUnmount() {
+    if (this.cancelRegister) {
+      this.cancelRegister()
+    }
+  }
+
+  // children添加value属性和onChange事件
+  getControlled = (children: React.ReactElement) => {
+    const { getFieldValue, setFieldsValue } = this.context
+    const { name } = this.props
+    const type = (children as any).type.NAME
+
+    return {
+      value: getFieldValue(name),
+      onChange: (
+        event: React.ChangeEvent<HTMLInputElement> | number | string | string[]
+      ) => {
+        let newValue = event
+        switch (type) {
+          case 'checkbox':
+            newValue = (event as React.ChangeEvent<HTMLInputElement>).target
+              .value
+            break
+          default:
+        }
+        setFieldsValue({ [name]: newValue })
+      },
+    }
+  }
+
+  onStoreChange = () => {
+    this.forceUpdate()
+  }
+
+  renderLayout = (childNode: React.ReactNode) => {
+    const {
+      label,
+      name,
+      rules = [{ required: false, message: '' }],
+      className,
+      labelWidth,
+      errorMessageAlign,
+      showErrorLine,
+      showErrorMessage,
+    } = {
+      ...defaultProps,
+      ...this.props,
+    }
+
+    const item =
+      this.context.errList?.length > 0 &&
+      this.context.errList?.filter((item: any) => {
+        return item.field === name
+      })
+
+    const { starPositon } = this.context
+    const renderStar = rules.length > 0 && rules[0].required && (
+      <i className="required" />
+    )
+    const renderLabel =
+      starPositon === 'Right' ? (
+        <>
+          {label}
+          {renderStar}
+        </>
+      ) : (
+        <>
+          {renderStar}
+          {label}
+        </>
+      )
+
+    return (
+      <Cell className={`nut-form-item ${className}`}>
+        {label ? (
+          <div
+            className="nut-cell__title nut-form-item__label"
+            style={{
+              width: this.pxCheck(labelWidth),
+            }}
+          >
+            {renderLabel}
+          </div>
+        ) : null}
+        <div className="nut-cell__value nut-form-item__body">
+          <div className="nut-form-item__body__slots">{childNode}</div>
+          {item.length > 0 && (
+            <div
+              className="nut-form-item__body__tips"
+              style={{ textAlign: errorMessageAlign }}
+            >
+              {item[0].message}
+            </div>
+          )}
+        </div>
+      </Cell>
+    )
+  }
+
+  pxCheck = (value: string | number): string => {
+    return Number.isNaN(Number(value)) ? String(value) : `${value}px`
+  }
+
+  render() {
+    const { children } = this.props
+    const c = Array.isArray(children) ? children[0] : children
+    const returnChildNode = React.cloneElement(
+      c as React.ReactElement,
+      this.getControlled(c as React.ReactElement)
+    )
+    return this.renderLayout(returnChildNode)
+  }
+}

--- a/src/packages/formitem/index.taro.ts
+++ b/src/packages/formitem/index.taro.ts
@@ -1,3 +1,3 @@
-import { FormItem } from './formitem'
+import { FormItem } from './formitem.taro'
 
 export default FormItem


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fock仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
