### PR TITLE
fix: #508 修改折叠面板组件修改后不刷新问题

### DIFF
--- a/src/packages/collapse/collapse.taro.tsx
+++ b/src/packages/collapse/collapse.taro.tsx
@@ -28,8 +28,9 @@ function areEqual(
   nextProps: Partial<CollapseProps>
 ) {
   return (
+    prevProps.children === nextProps.children &&
     JSON.stringify(prevProps.activeName) ===
-    JSON.stringify(nextProps.activeName)
+      JSON.stringify(nextProps.activeName)
   )
 }
 

--- a/src/packages/collapse/collapse.tsx
+++ b/src/packages/collapse/collapse.tsx
@@ -29,8 +29,9 @@ function areEqual(
   nextProps: Partial<CollapseProps>
 ) {
   return (
+    prevProps.children === nextProps.children &&
     JSON.stringify(prevProps.activeName) ===
-    JSON.stringify(nextProps.activeName)
+      JSON.stringify(nextProps.activeName)
   )
 }
 

--- a/src/packages/collapseitem/collapseitem.taro.tsx
+++ b/src/packages/collapseitem/collapseitem.taro.tsx
@@ -77,11 +77,6 @@ export const CollapseItem: FunctionComponent<
   })
   const colBem = bem('collapse-item')
 
-  useEffect(() => {
-    setCurrHeight('auto')
-    setUpdate(!update)
-  }, [children])
-
   const measuredRef = useCallback(
     (node: HTMLDivElement) => {
       if (node !== null) {
@@ -104,6 +99,15 @@ export const CollapseItem: FunctionComponent<
     }, 10)
   }, [isOpen, domHeight, rotate])
 
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrHeight('0px')
+    } else {
+      setCurrHeight('auto')
+    }
+
+    setUpdate(!update)
+  }, [children, isOpen])
   return (
     <div className={colBem()} {...rest}>
       <div

--- a/src/packages/collapseitem/collapseitem.tsx
+++ b/src/packages/collapseitem/collapseitem.tsx
@@ -80,11 +80,6 @@ export const CollapseItem: FunctionComponent<
   })
   const colBem = bem('collapse-item')
 
-  useEffect(() => {
-    setCurrHeight('auto')
-    setUpdate(!update)
-  }, [children])
-
   const measuredRef = useCallback(
     (node: HTMLDivElement) => {
       if (node !== null) {
@@ -106,6 +101,16 @@ export const CollapseItem: FunctionComponent<
       setIconStyle(newIconStyle)
     }, 10)
   }, [isOpen, domHeight, rotate])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrHeight('0px')
+    } else {
+      setCurrHeight('auto')
+    }
+
+    setUpdate(!update)
+  }, [children, isOpen])
 
   return (
     <div className={colBem()} {...rest}>


### PR DESCRIPTION
close #508
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/jdf2e/nutui-react/issues/508

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1、Collapse组件数据修改后组件不刷新 #508
2、监听组件children发生变化 渲染组件

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
