### PR TITLE
fix: input类名依赖

### DIFF
--- a/src/packages/input/input.tsx
+++ b/src/packages/input/input.tsx
@@ -210,7 +210,6 @@ export const Input: FunctionComponent<
     updateValue(getModelValue(), formatTrigger)
   })
   useEffect(() => {
-    setClasses(inputClass)
     SetInputValue(defaultValue)
   }, [defaultValue])
 
@@ -240,6 +239,10 @@ export const Input: FunctionComponent<
       .filter(Boolean)
       .join(' ')
   }, [disabled, required, error, border, hasRightMark, center])
+
+  useEffect(() => {
+    setClasses(inputClass)
+  }, [inputClass])
 
   const updateValue = (
     value: any,

--- a/src/packages/input/input.tsx
+++ b/src/packages/input/input.tsx
@@ -225,6 +225,7 @@ export const Input: FunctionComponent<
     return inputRef.current
   })
 
+  const hasRightMark = !!(slotButton || rightIcon)
   const inputClass = useCallback(() => {
     const prefixCls = 'nut-input'
     return [
@@ -234,11 +235,11 @@ export const Input: FunctionComponent<
       `${required ? `${prefixCls}-required` : ''}`,
       `${error ? `${prefixCls}-error` : ''}`,
       `${border ? `${prefixCls}-border` : ''}`,
-      `${slotButton || rightIcon ? `${prefixCls}-right-mark` : ''}`,
+      `${hasRightMark ? `${prefixCls}-right-mark` : ''}`,
     ]
       .filter(Boolean)
       .join(' ')
-  }, [disabled, required, error, border])
+  }, [disabled, required, error, border, hasRightMark, center])
 
   const updateValue = (
     value: any,


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

当Input组件的slotButton、rigthIcon或center属性发生变化时，组件的类名无法触发重新计算，导致样式展示错误。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
