### PR TITLE
chore: nutui taro 在 iOS 11 下和 taro 的 regenerator-runtime 冲突

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@use-gesture/react": "^10.2.9",
     "async-validator": "^4.2.5",
     "classnames": "^2.3.1",
-    "lodash": "^4.17.21",
+    "lodash.kebabcase": "^4.1.1",
     "react-transition-group": "^4.4.2"
   },
   "devDependencies": {
@@ -124,7 +124,7 @@
     "@testing-library/react": "^13.3.0",
     "@types/jest": "^27.4.1",
     "@types/loadable__component": "^5.13.3",
-    "@types/lodash": "^4.14.191",
+    "@types/lodash.kebabcase": "^4.1.6",
     "@types/node": "^15.3.1",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",

--- a/rollup.config.es.js
+++ b/rollup.config.es.js
@@ -27,12 +27,12 @@ export default {
   input: entries,
   external: (id, parent) =>
     /^react/.test(id) ||
-    /^react\-dom/.test(id) ||
+    /^react-dom/.test(id) ||
     /^classnames/.test(id) ||
-    /^\@use-gesture/.test(id) ||
-    /^\@react-spring/.test(id) ||
-    /^\@bem-react/.test(id) ||
-    (/^\@\/packages\/\w+$/.test(id) && !!parent),
+    /^@use-gesture/.test(id) ||
+    /^@react-spring/.test(id) ||
+    /^@bem-react/.test(id) ||
+    (/^@\/packages\/\w+$/.test(id) && !!parent),
   output: {
     format: 'esm',
     dir: './dist/esm',

--- a/rollup.config.taro.es.js
+++ b/rollup.config.taro.es.js
@@ -1,6 +1,5 @@
 import commonjs from '@rollup/plugin-commonjs'
 import typescript from '@rollup/plugin-typescript'
-import { getBabelOutputPlugin } from '@rollup/plugin-babel'
 
 const path = require('path')
 const config = require('./src/config.json')
@@ -30,12 +29,12 @@ export default {
   input: entries,
   external: (id, parent) => {
     ;/^react/.test(id) ||
-      /^react\-dom/.test(id) ||
+      /^react-dom/.test(id) ||
       /^classnames/.test(id) ||
-      /^\@use-gesture/.test(id) ||
-      /^\@react-spring/.test(id) ||
-      /^\@bem-react/.test(id) ||
-      (/^\@\/packages\/\w+$/.test(id) && !!parent)
+      /^@use-gesture/.test(id) ||
+      /^@react-spring/.test(id) ||
+      /^@bem-react/.test(id) ||
+      (/^@\/packages\/\w+$/.test(id) && !!parent)
   },
   output: {
     format: 'esm',
@@ -47,17 +46,5 @@ export default {
         : id
     },
   },
-  plugins: [
-    commonjs(),
-    typescript(),
-    getBabelOutputPlugin({
-      presets: ['@babel/preset-env'],
-      plugins: [
-        '@babel/plugin-transform-runtime',
-        '@babel/plugin-proposal-class-properties',
-        '@babel/plugin-proposal-object-rest-spread',
-        '@babel/plugin-syntax-dynamic-import',
-      ],
-    }),
-  ],
+  plugins: [commonjs(), typescript()],
 }

--- a/src/packages/configprovider/configprovider.taro.tsx
+++ b/src/packages/configprovider/configprovider.taro.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   CSSProperties,
 } from 'react'
-import _ from 'lodash'
+import kebabCase from 'lodash.kebabcase'
 import { BaseLang } from '@/locales/base'
 import zhCN from '@/locales/zh-CN'
 
@@ -46,7 +46,7 @@ export const useConfig = () => {
 function convertThemeVarsToCSSVars(themeVars: Record<string, string | number>) {
   const cssVars: Record<string, string | number> = {}
   Object.keys(themeVars).forEach((key) => {
-    cssVars[`--${_.kebabCase(key)}`] = themeVars[key]
+    cssVars[`--${kebabCase(key)}`] = themeVars[key]
   })
   return cssVars
 }

--- a/src/packages/configprovider/configprovider.tsx
+++ b/src/packages/configprovider/configprovider.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   CSSProperties,
 } from 'react'
-import _ from 'lodash'
+import kebabCase from 'lodash.kebabcase'
 import { BaseLang } from '@/locales/base'
 import zhCN from '@/locales/zh-CN'
 
@@ -46,7 +46,7 @@ export const useConfig = () => {
 function convertThemeVarsToCSSVars(themeVars: Record<string, string | number>) {
   const cssVars: Record<string, string | number> = {}
   Object.keys(themeVars).forEach((key) => {
-    cssVars[`--${_.kebabCase(key)}`] = themeVars[key]
+    cssVars[`--${kebabCase(key)}`] = themeVars[key]
   })
   return cssVars
 }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fock仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
