### PR TITLE
fix(tag): 修复 plain 与 type 同时使用时的样式错误

### DIFF
--- a/src/packages/tag/__test__/__snapshots__/tag.spec.tsx.snap
+++ b/src/packages/tag/__test__/__snapshots__/tag.spec.tsx.snap
@@ -2,22 +2,14 @@
 
 exports[`type test 1`] = `
 <div>
-  <div>
-    <div
-      class="nut-tag
-    nut-tag--primary
-    
-    
-    
-    "
+  <div
+    class="nut-tag nut-tag--primary"
+  >
+    <span
+      class="nut-tag-text"
     >
-      <span
-        class="text"
-      >
-        TEST
-      </span>
-    </div>
+      TEST
+    </span>
   </div>
 </div>
 `;
-

--- a/src/packages/tag/__test__/tag.spec.tsx
+++ b/src/packages/tag/__test__/tag.spec.tsx
@@ -9,10 +9,10 @@ test('color test', () => {
   const state = {
     color: 'rgb(250, 104, 93)',
   }
-  const { getByTestId, container } = render(<Tag color={state.color}>TEST</Tag>)
+  const { container } = render(<Tag color={state.color}>TEST</Tag>)
   expect(container.querySelector('.nut-tag--default')).toHaveAttribute(
     'style',
-    'color: rgb(255, 255, 255); background: rgb(250, 104, 93);'
+    'background: rgb(250, 104, 93);'
   )
 })
 test('type test', () => {
@@ -34,6 +34,21 @@ test('plain test', () => {
   const { container } = render(<Tag plain={state.plain}>TEST</Tag>)
   const el = container.querySelectorAll('.nut-tag--plain').length
   expect(el > 0).toBe(true)
+})
+
+test('color & plain test', () => {
+  const state = {
+    color: 'rgb(250, 104, 93)',
+  }
+  const { container } = render(
+    <Tag color={state.color} plain>
+      TEST
+    </Tag>
+  )
+  expect(container.querySelector('.nut-tag--plain')).toHaveAttribute(
+    'style',
+    'color: rgb(250, 104, 93); background: rgb(255, 255, 255); border-color: rgb(250, 104, 93);'
+  )
 })
 
 test('round test', () => {

--- a/src/packages/tag/doc.en-US.md
+++ b/src/packages/tag/doc.en-US.md
@@ -226,6 +226,4 @@ The component provides the following CSS variables, which can be used to customi
 | --nutui-tag-warning-background-color | `  #f3812e` |
 | --nutui-tag-default-color | ` #ffffff` |
 | --nutui-tag-border-width | ` 1px` |
-| --nutui-tag-plain-background-color | `  #fff` |
-| --nutui-tag-plain-color | ` rgb(250, 36, 0)` |
 | --nutui-tag-height | ` auto` |

--- a/src/packages/tag/doc.md
+++ b/src/packages/tag/doc.md
@@ -227,6 +227,4 @@ export default App;
 | --nutui-tag-warning-background-color | `  #f3812e` |
 | --nutui-tag-default-color | ` #ffffff` |
 | --nutui-tag-border-width | ` 1px` |
-| --nutui-tag-plain-background-color | `  #fff` |
-| --nutui-tag-plain-color | ` rgb(250, 36, 0)` |
 | --nutui-tag-height | ` auto` |

--- a/src/packages/tag/doc.taro.md
+++ b/src/packages/tag/doc.taro.md
@@ -226,6 +226,4 @@ export default App;
 | --nutui-tag-warning-background-color | `  #f3812e` |
 | --nutui-tag-default-color | ` #ffffff` |
 | --nutui-tag-border-width | ` 1px` |
-| --nutui-tag-plain-background-color | `  #fff` |
-| --nutui-tag-plain-color | ` rgb(250, 36, 0)` |
 | --nutui-tag-height | ` auto` |

--- a/src/packages/tag/doc.zh-TW.md
+++ b/src/packages/tag/doc.zh-TW.md
@@ -225,6 +225,4 @@ export default App;
 | --nutui-tag-warning-background-color | `  #f3812e` |
 | --nutui-tag-default-color | ` #ffffff` |
 | --nutui-tag-border-width | ` 1px` |
-| --nutui-tag-plain-background-color | `  #fff` |
-| --nutui-tag-plain-color | ` rgb(250, 36, 0)` |
 | --nutui-tag-height | ` auto` |

--- a/src/packages/tag/tag.scss
+++ b/src/packages/tag/tag.scss
@@ -6,39 +6,47 @@
     vertical-align: middle;
     margin-left: 4px;
   }
+
+  @mixin plain {
+    &.nut-tag--plain {
+      color: $tag-default-background-color;
+      border: $tag-border-width solid $tag-default-background-color;
+    }
+  }
+
   &--default {
     color: $tag-default-color;
     background: $tag-default-background-color;
     border: $tag-border-width solid transparent;
+    @include plain;
   }
 
   &--primary {
     color: $tag-default-color;
     background: $tag-primary-background-color;
     border: $tag-border-width solid transparent;
+    @include plain;
   }
 
   &--success {
     color: $tag-default-color;
     background: $tag-success-background-color;
     border: $tag-border-width solid transparent;
+    @include plain;
   }
 
   &--danger {
     color: $tag-default-color;
     background: $tag-danger-background-color;
     border: $tag-border-width solid transparent;
+    @include plain;
   }
 
   &--warning {
     color: $tag-default-color;
     background: $tag-warning-background-color;
     border: $tag-border-width solid transparent;
-  }
-  &--plain {
-    color: $tag-plain-color;
-    background: $tag-plain-background-color;
-    border: $tag-border-width solid $tag-plain-color;
+    @include plain;
   }
   &--round {
     border-radius: 8px;

--- a/src/packages/tag/tag.taro.tsx
+++ b/src/packages/tag/tag.taro.tsx
@@ -7,6 +7,7 @@ import React, {
 import Icon from '@/packages/icon/index.taro'
 
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+import classNames from 'classnames'
 
 export interface TagProps extends BasicComponent {
   type: TagType
@@ -76,29 +77,35 @@ export const Tag: FunctionComponent<Partial<TagProps>> = (props) => {
   ])
   const classes = () => {
     const prefixCls = 'nut-tag'
-    return `${prefixCls}
-    ${type ? `${prefixCls}--${type}` : ''}
-    ${plain ? `${prefixCls}--plain` : ''}
-    ${round ? `${prefixCls}--round` : ''}
-    ${mark ? `${prefixCls}--mark` : ''}
-    ${closeable ? `${prefixCls}--close` : ''}`
+    return classNames({
+      [prefixCls]: true,
+      [`${prefixCls}--${type}`]: type,
+      [`${prefixCls}--plain`]: plain,
+      [`${prefixCls}--round`]: round,
+      [`${prefixCls}--mark`]: mark,
+      [`${prefixCls}--close`]: closeable,
+      [`${className}`]: className,
+    })
   }
   const handleClick = (e: any) => {
     if (props.onClick) {
       props.onClick(e)
     }
   }
-  const getStyle = () => {
+  // 综合考虑 textColor、color、plain 组合使用时的效果
+  const getStyle = (): CSSProperties => {
     const style: CSSProperties = {}
+    // 标签内字体颜色
     if (textColor) {
       style.color = textColor
-      if (plain) {
-        style.background = '#fff'
-      } else if (color) {
-        style.background = color
-      }
+    } else if (color && plain) {
+      style.color = color
+    }
+    // 标签背景与边框颜色
+    if (plain) {
+      style.background = '#fff'
+      style.borderColor = color
     } else if (color) {
-      style.color = '#fff'
       style.background = color
     }
     return style
@@ -108,7 +115,7 @@ export const Tag: FunctionComponent<Partial<TagProps>> = (props) => {
       {closeable ? (
         isTagShow && (
           <div
-            className={`${btnName} ${className}`}
+            className={btnName}
             style={{ ...style, ...getStyle() }}
             onClick={(e) => handleClick(e)}
           >
@@ -130,7 +137,7 @@ export const Tag: FunctionComponent<Partial<TagProps>> = (props) => {
         )
       ) : (
         <div
-          className={`${btnName} ${className}`}
+          className={btnName}
           style={{ ...style, ...getStyle() }}
           onClick={(e) => handleClick(e)}
         >

--- a/src/packages/tag/tag.tsx
+++ b/src/packages/tag/tag.tsx
@@ -7,6 +7,7 @@ import React, {
 import Icon from '@/packages/icon'
 
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+import classNames from 'classnames'
 
 export interface TagProps extends BasicComponent {
   type: TagType
@@ -76,29 +77,35 @@ export const Tag: FunctionComponent<Partial<TagProps>> = (props) => {
   ])
   const classes = () => {
     const prefixCls = 'nut-tag'
-    return `${prefixCls}
-    ${type ? `${prefixCls}--${type}` : ''}
-    ${plain ? `${prefixCls}--plain` : ''}
-    ${round ? `${prefixCls}--round` : ''}
-    ${mark ? `${prefixCls}--mark` : ''}
-    ${closeable ? `${prefixCls}--close` : ''}`
+    return classNames({
+      [prefixCls]: true,
+      [`${prefixCls}--${type}`]: type,
+      [`${prefixCls}--plain`]: plain,
+      [`${prefixCls}--round`]: round,
+      [`${prefixCls}--mark`]: mark,
+      [`${prefixCls}--close`]: closeable,
+      [`${className}`]: className,
+    })
   }
   const handleClick = (e: any) => {
     if (props.onClick) {
       props.onClick(e)
     }
   }
-  const getStyle = () => {
+  // 综合考虑 textColor、color、plain 组合使用时的效果
+  const getStyle = (): CSSProperties => {
     const style: CSSProperties = {}
+    // 标签内字体颜色
     if (textColor) {
       style.color = textColor
-      if (plain) {
-        style.background = '#fff'
-      } else if (color) {
-        style.background = color
-      }
+    } else if (color && plain) {
+      style.color = color
+    }
+    // 标签背景与边框颜色
+    if (plain) {
+      style.background = '#fff'
+      style.borderColor = color
     } else if (color) {
-      style.color = '#fff'
       style.background = color
     }
     return style
@@ -108,7 +115,7 @@ export const Tag: FunctionComponent<Partial<TagProps>> = (props) => {
       {closeable ? (
         isTagShow && (
           <div
-            className={`${btnName} ${className}`}
+            className={btnName}
             style={{ ...style, ...getStyle() }}
             onClick={(e) => handleClick(e)}
           >
@@ -130,7 +137,7 @@ export const Tag: FunctionComponent<Partial<TagProps>> = (props) => {
         )
       ) : (
         <div
-          className={`${btnName} ${className}`}
+          className={btnName}
           style={{ ...style, ...getStyle() }}
           onClick={(e) => handleClick(e)}
         >

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1248,11 +1248,6 @@ $tag-warning-background-color: var(
 ) !default;
 $tag-default-color: var(--nutui-tag-default-color, #ffffff) !default;
 $tag-border-width: var(--nutui-tag-border-width, 1px) !default;
-$tag-plain-background-color: var(
-  --nutui-tag-plain-background-color,
-  #fff
-) !default;
-$tag-plain-color: var(--nutui-tag-plain-color, rgb(250, 36, 0)) !default;
 $tag-height: var(--nutui-tag-height, auto) !default;
 
 //badge（✅）


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复
- [x] 站点、文档改进
- [x] 组件样式/交互改进
- [x] 测试用例
- [x] 其他改动

### 💡 需求背景和解决方案

存在问题：
同时使用 type、color、plain 时，生成样式的逻辑错误。

本次提交包含以下内容：
1、修改样式生成逻辑，与 NutUI-Vue 保持一致
2、移除多余的样式变量及其文档说明
3、更新了单元测试
4、优化了 Tag 类名生成逻辑

效果图：
![image](https://user-images.githubusercontent.com/44915689/215655998-809042ef-211e-4cf7-9bf6-e524ea9431a1.png)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
