### PR TITLE
fix(ellipsis): ellipsis内存泄露

### DIFF
--- a/src/packages/ellipsis/__test__/ellipsis.spec.tsx
+++ b/src/packages/ellipsis/__test__/ellipsis.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { useEffect, useState } from 'react'
 import Ellipsis from '@/packages/ellipsis'
 
 const content =
@@ -23,4 +24,25 @@ test('Ellipsis Props Rows', () => {
     <Ellipsis content={content} direction="start" rows="3" />
   )
   expect(container).toMatchSnapshot()
+})
+
+jest.useFakeTimers()
+test('Ellipsis Memory Leak', () => {
+  const App = () => {
+    const [count, setCount] = useState(0)
+    useEffect(() => {
+      const timer = setInterval(() => {
+        act(() => {
+          setCount(count + 1)
+        })
+      }, 1000)
+      return () => clearInterval(timer)
+    })
+    return <Ellipsis content={`${count}`} direction="end" />
+  }
+  const { baseElement } = render(<App />)
+  const elementCount = baseElement.children.length
+  jest.advanceTimersByTime(2000)
+  const newElementCount = baseElement.children.length
+  expect(newElementCount).toBe(elementCount)
 })

--- a/src/packages/ellipsis/ellipsis.tsx
+++ b/src/packages/ellipsis/ellipsis.tsx
@@ -63,9 +63,6 @@ export const Ellipsis: FunctionComponent<
 
   useEffect(() => {
     if (content) {
-      if (container) {
-        document.body.appendChild(container)
-      }
       createContainer()
     }
   }, [content])
@@ -105,6 +102,7 @@ export const Ellipsis: FunctionComponent<
     container.innerText = content
     document.body.appendChild(container)
     calcEllipse()
+    document.body.removeChild(container)
   }
 
   // 计算省略号的位置
@@ -123,8 +121,6 @@ export const Ellipsis: FunctionComponent<
           : tailor(0, end)
 
       ellipsis.current = ellipsised
-
-      document.body.removeChild(container)
     }
   }
   // 计算 start/end 省略


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题描述：Ellipsis组件在content较少（不足以触发展示省略号逻辑时），多次修改content会触发内存泄露（创建的dom一直保留在body内，没有删除）

复现代码：

```
const [count, setCount] = useState(0)
  useEffect(() => {
    const timer = setInterval(() => {
      setCount(count + 1)
    }, 1000)
    return () => clearInterval(timer)
  })
<Ellipsis content={`${count}`} direction="end" />
```

改动点：

1. calcEllipse执行完后，直接把container移除（因为后面已经没有地方再需要使用container了）
2. useEffect里把`document.body.appendChild(container)`移除，这行代码似乎是多余的？
3. 增加内存泄露测试用例

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
