### PR TITLE
fix: textarea 禁用状态仍然可以输入

### DIFF
--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -106,8 +106,7 @@ export const TextArea: FunctionComponent<
           resize: `${autosize ? 'vertical' : 'none'}` as any,
           ...style,
         }}
-        disabled={disabled}
-        readOnly={readonly}
+        readOnly={disabled || readonly}
         value={inputValue}
         onInput={(e: any) => {
           textChange(e)


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/672
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Taro 提供的 plugin-html 插件中会对一些认为是特殊属性的属性进行处理，对于 textarea 的处理来说，disabled 和 readonly 都映射到一个上面，所以当 disabled设置为true，readonly 设置为 false，则 textarea 可以输入内容

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fock仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
