### PR TITLE
feat(shortpassword): 支持自动聚焦

### DIFF
--- a/src/packages/shortpassword/demo.taro.tsx
+++ b/src/packages/shortpassword/demo.taro.tsx
@@ -8,6 +8,7 @@ const ShortPasswordDemo = () => {
   const [visible2, setVisible2] = useState(false)
   const [visible3, setVisible3] = useState(false)
   const [visible4, setVisible4] = useState(false)
+  const [visible5, setVisible5] = useState(false)
   const [value, setValue] = useState<string | number>('')
   const change = (value: number | string) => {
     setValue(value)
@@ -107,6 +108,23 @@ const ShortPasswordDemo = () => {
           onClose={() => {
             SetShow(false)
           }}
+        />
+        <h2>自动聚焦</h2>
+        <Cell
+          title="自动聚焦"
+          isLink
+          onClick={() => {
+            setVisible5(true)
+          }}
+        />
+        <ShortPassword
+          visible={visible5}
+          modelValue={value}
+          onClose={() => {
+            setVisible5(false)
+            setValue('')
+          }}
+          autoFocus
         />
       </div>
     </>

--- a/src/packages/shortpassword/demo.tsx
+++ b/src/packages/shortpassword/demo.tsx
@@ -8,6 +8,7 @@ const ShortPasswordDemo = () => {
   const [visible2, setVisible2] = useState(false)
   const [visible3, setVisible3] = useState(false)
   const [visible4, setVisible4] = useState(false)
+  const [visible5, setVisible5] = useState(false)
   const [value, setValue] = useState<string | number>('')
   const change = (value: number | string) => {
     console.log(value)
@@ -87,6 +88,23 @@ const ShortPasswordDemo = () => {
           setValue('')
         }}
         onTips={() => onTips()}
+      />
+      <h2>自动聚焦</h2>
+      <Cell
+        title="自动聚焦"
+        isLink
+        onClick={() => {
+          setVisible5(true)
+        }}
+      />
+      <ShortPassword
+        visible={visible5}
+        modelValue={value}
+        onClose={() => {
+          setVisible5(false)
+          setValue('')
+        }}
+        autoFocus
       />
     </div>
   )

--- a/src/packages/shortpassword/doc.en-US.md
+++ b/src/packages/shortpassword/doc.en-US.md
@@ -191,6 +191,7 @@ export default App;
 | noButton              | whether to hide the bottom button    | Boolean        | true                         |
 | length                 | ShortPassword lenght The value is 4~6 | String｜Number | 6                            |
 | errorMsg              | Error message         | String         | ''                           |
+| autoFocus              | Be focused when ShortPassword is displayed | Boolean         | false                           |
 
 ### Events
 

--- a/src/packages/shortpassword/doc.md
+++ b/src/packages/shortpassword/doc.md
@@ -189,6 +189,7 @@ export default App;
 | noButton              | 是否隐藏底部按钮    | Boolean        | true                         |
 | length                 | 密码长度，取值为4~6 | String｜Number | 6                            |
 | errorMsg              | 错误信息提示        | String         | ''                           |
+| autoFocus              | 自动聚焦        | Boolean         | false                           |
 
 ### Events
 

--- a/src/packages/shortpassword/doc.taro.md
+++ b/src/packages/shortpassword/doc.taro.md
@@ -188,6 +188,7 @@ export default App;
 | noButton              | 是否隐藏底部按钮    | Boolean        | true                         |
 | length                 | 密码长度，取值为4~6 | String｜Number | 6                            |
 | errorMsg              | 错误信息提示        | String         | ''                           |
+| autoFocus              | 自动聚焦        | Boolean         | false                           |
 
 ### Events
 

--- a/src/packages/shortpassword/doc.zh-TW.md
+++ b/src/packages/shortpassword/doc.zh-TW.md
@@ -189,6 +189,7 @@ export default App;
 | noButton              | 是否隱藏底部按鈕    | Boolean        | true                         |
 | length                 | 密碼長度，取值為4~6 | String｜Number | 6                            |
 | errorMsg              | 錯誤信息提示        | String         | ''                           |
+| autoFocus              | 自動聚焦        | Boolean         | false                           |
 
 ### Events
 

--- a/src/packages/shortpassword/shortpassword.taro.tsx
+++ b/src/packages/shortpassword/shortpassword.taro.tsx
@@ -24,6 +24,7 @@ export interface ShortPasswordProps extends BasicComponent {
   length: string | number
   className: string
   style?: CSSProperties
+  autoFocus?: boolean
   onChange: (value: string | number) => void
   onOk: (value: string | number) => void
   onCancel: () => void
@@ -44,6 +45,7 @@ const defaultProps = {
   closeOnClickOverlay: true,
   length: 6, // 1~6
   className: '',
+  autoFocus: false,
   onChange: (value: number | string) => {},
   onOk: (value: number | string) => {},
   onCancel: () => {},
@@ -76,6 +78,7 @@ export const ShortPassword: FunctionComponent<
     onComplete,
     iconClassPrefix,
     iconFontClassName,
+    autoFocus,
     ...reset
   } = props
   const b = bem('shortpassword')
@@ -163,6 +166,7 @@ export const ShortPassword: FunctionComponent<
               style={systemStyle()}
               maxLength={6}
               value={inputValue}
+              autoFocus={autoFocus}
               onChange={(e) => changeValue(e)}
             />
             <div className={b('input-site')} />

--- a/src/packages/shortpassword/shortpassword.tsx
+++ b/src/packages/shortpassword/shortpassword.tsx
@@ -24,6 +24,7 @@ export interface ShortPasswordProps extends BasicComponent {
   length: string | number
   className: string
   style?: CSSProperties
+  autoFocus?: boolean
   onChange: (value: string | number) => void
   onOk: (value: string | number) => void
   onCancel: () => void
@@ -44,6 +45,7 @@ const defaultProps = {
   closeOnClickOverlay: true,
   length: 6, // 1~6
   className: '',
+  autoFocus: false,
   onChange: (value: number | string) => {},
   onOk: (value: number | string) => {},
   onCancel: () => {},
@@ -76,6 +78,7 @@ export const ShortPassword: FunctionComponent<
     onComplete,
     iconClassPrefix,
     iconFontClassName,
+    autoFocus,
     ...reset
   } = props
   const b = bem('shortpassword')
@@ -163,6 +166,7 @@ export const ShortPassword: FunctionComponent<
               style={systemStyle()}
               maxLength={6}
               value={inputValue}
+              autoFocus={autoFocus}
               onChange={(e) => changeValue(e)}
             />
             <div className={b('input-site')} />


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

当前shortpassword组件不支持自动聚焦，每次弹出短密码输入框时，都需要用户手动点击一下才能输入密码，比较不方便，希望能增加`autoFocus`属性以支持自动聚焦，默认为false。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
