### PR TITLE
fix: cascader 没有传递 ref 参数

### DIFF
--- a/src/packages/cascader/cascader.taro.tsx
+++ b/src/packages/cascader/cascader.taro.tsx
@@ -72,7 +72,7 @@ const defaultProps = {
 const InternalCascader: ForwardRefRenderFunction<
   unknown,
   PropsWithChildren<Partial<CascaderProps>>
-> = (props) => {
+> = (props, ref) => {
   const {
     className,
     style,

--- a/src/packages/cascader/cascader.tsx
+++ b/src/packages/cascader/cascader.tsx
@@ -71,7 +71,7 @@ const defaultProps = {
 const InternalCascader: ForwardRefRenderFunction<
   unknown,
   PropsWithChildren<Partial<CascaderProps>>
-> = (props) => {
+> = (props, ref) => {
   const {
     className,
     style,
@@ -96,7 +96,7 @@ const InternalCascader: ForwardRefRenderFunction<
   } = { ...defaultProps, ...props }
 
   const [tabvalue, setTabvalue] = useState('c1')
-  const [optiosData, setOptiosData] = useState<CascaderPane[]>([])
+  const [optionsData, setOptionsData] = useState<CascaderPane[]>([])
 
   const isLazy = () => state.configs.lazy && Boolean(state.configs.lazyLoad)
 
@@ -182,7 +182,7 @@ const InternalCascader: ForwardRefRenderFunction<
     ]
     syncValue()
 
-    setOptiosData(state.panes)
+    setOptionsData(state.panes)
   }
   // 处理有默认值时的数据
   const syncValue = async () => {
@@ -193,7 +193,6 @@ const InternalCascader: ForwardRefRenderFunction<
 
     if (currentValue.length === 0) {
       state.tabsCursor = 0
-      // state.panes = [{ nodes: state.tree.nodes, selectedNode: null }];
       return
     }
 
@@ -310,12 +309,11 @@ const InternalCascader: ForwardRefRenderFunction<
         onChange(optionParams, pathNodes)
         onPathChange(optionParams, pathNodes)
       }
-      setOptiosData(state.panes)
+      setOptionsData(state.panes)
       close()
       return
     }
     // 如果有子节点，滑到下一个
-    // if (node.children && node.children.length > 0) {
     if (state.tree.hasChildren(node, isLazy())) {
       const level = (node.level as number) + 1
 
@@ -328,7 +326,7 @@ const InternalCascader: ForwardRefRenderFunction<
         paneKey: `c${state.tabsCursor + 1}`,
       })
       setTabvalue(`c${state.tabsCursor + 1}`)
-      setOptiosData(state.panes)
+      setOptionsData(state.panes)
 
       if (!type) {
         const pathNodes = state.panes.map((item) => item.selectedNode)
@@ -349,7 +347,7 @@ const InternalCascader: ForwardRefRenderFunction<
       state.panes[state.tabsCursor].selectedNode = node
       chooseItem(node, type)
     }
-    setOptiosData(state.panes)
+    setOptionsData(state.panes)
   }
 
   const renderItem = () => {
@@ -359,7 +357,7 @@ const InternalCascader: ForwardRefRenderFunction<
         <Tabs
           value={tabvalue}
           titleNode={() => {
-            return optiosData.map((pane, index) => (
+            return optionsData.map((pane, index) => (
               <div
                 onClick={() => {
                   setTabvalue(pane.paneKey)
@@ -371,11 +369,6 @@ const InternalCascader: ForwardRefRenderFunction<
                 key={pane.paneKey}
               >
                 <span className="nut-tabs__titles-item__text">
-                  {/* {!state.initLoading && state.panes.length
-                    ? pane?.selectedNode?.text
-                      ? pane.selectedNode.text
-                      : '请选择'
-                    : 'Loading...'} */}
                   {!state.initLoading &&
                     state.panes.length &&
                     pane?.selectedNode?.text}
@@ -394,7 +387,7 @@ const InternalCascader: ForwardRefRenderFunction<
           }}
         >
           {!state.initLoading && state.panes.length ? (
-            optiosData.map((pane) => (
+            optionsData.map((pane) => (
               <TabPane key={pane.paneKey} paneKey={pane.paneKey}>
                 <div className={classesPane}>
                   {pane.nodes &&

--- a/src/packages/cascader/cascaderItem.taro.tsx
+++ b/src/packages/cascader/cascaderItem.taro.tsx
@@ -47,7 +47,7 @@ const defaultProps = {
 const InternalCascaderItem: ForwardRefRenderFunction<
   unknown,
   PropsWithChildren<Partial<CascaderItemProps>>
-> = (props) => {
+> = (props, ref) => {
   const { data, checked, chooseItem, activeColor } = {
     ...defaultProps,
     ...props,

--- a/src/packages/cascader/cascaderItem.tsx
+++ b/src/packages/cascader/cascaderItem.tsx
@@ -1,8 +1,4 @@
-import React, {
-  ForwardRefRenderFunction,
-  PropsWithChildren,
-  useEffect,
-} from 'react'
+import React, { ForwardRefRenderFunction, PropsWithChildren } from 'react'
 import classNames from 'classnames'
 import { Icon } from '@/packages/icon/icon'
 import bem from '@/utils/bem'
@@ -47,7 +43,7 @@ const defaultProps = {
 const InternalCascaderItem: ForwardRefRenderFunction<
   unknown,
   PropsWithChildren<Partial<CascaderItemProps>>
-> = (props) => {
+> = (props, ref) => {
   const { data, checked, chooseItem, activeColor } = {
     ...defaultProps,
     ...props,
@@ -66,14 +62,6 @@ const InternalCascaderItem: ForwardRefRenderFunction<
   const classesTitle = classNames({
     [`${b('')}__title`]: true,
   })
-
-  useEffect(() => {
-    initData()
-  }, [data])
-
-  const initData = () => {
-    // console.log('------data', data)
-  }
 
   return (
     <div


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/695

### 💡 需求背景和解决方案

Cascader 组件使用了 forwardRef ，但是缺少了 ref 参数，导致出现 waring 信息


