### PR TITLE
fix: ellipsis 展开和关闭操作应该阻止事件冒泡

### DIFF
--- a/src/packages/ellipsis/demo.taro.tsx
+++ b/src/packages/ellipsis/demo.taro.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
+import Taro from '@tarojs/taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
 import { Ellipsis, Cell } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
-import Taro from '@tarojs/taro'
 
 interface T {
   basic: string
@@ -58,6 +58,8 @@ const EllipsisDemo = () => {
         <Cell>
           <Ellipsis
             content={content}
+            onClick={() => Taro.showToast({ title: 'Clicked!' })}
+            onChange={(type) => Taro.showToast({ title: type })}
             direction="start"
             expandText="展开"
             collapseText="收起"

--- a/src/packages/ellipsis/demo.tsx
+++ b/src/packages/ellipsis/demo.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Ellipsis } from './ellipsis'
 import Cell from '@/packages/cell'
 import { useTranslate } from '../../sites/assets/locale'
+import Toast from '@/packages/toast'
 
 interface T {
   basic: string
@@ -56,6 +57,10 @@ const EllipsisDemo = () => {
         <Cell>
           <Ellipsis
             content={content}
+            onClick={() => {
+              Toast.text('Clicked!')
+            }}
+            onChange={(type) => Toast.text(type)}
             direction="start"
             expandText="展开"
             collapseText="收起"

--- a/src/packages/ellipsis/ellipsis.taro.tsx
+++ b/src/packages/ellipsis/ellipsis.taro.tsx
@@ -52,7 +52,6 @@ export const Ellipsis: FunctionComponent<
     onClick,
     onChange,
   } = { ...defaultProps, ...props }
-  const container: any = null
   let maxHeight: any = 0 // 当行的最大高度
   const [exceeded, setExceeded] = useState(false)
   const [expanded, setExpanded] = useState(false)
@@ -274,7 +273,6 @@ export const Ellipsis: FunctionComponent<
     if (type === 1) {
       setExpanded(true)
       onChange && onChange('expand')
-      //   emit('change', 'expand')
     } else {
       setExpanded(false)
       onChange && onChange('collapse')
@@ -305,7 +303,8 @@ export const Ellipsis: FunctionComponent<
                 {expandText ? (
                   <span
                     className="nut-ellipsis-text"
-                    onClick={() => {
+                    onClick={(e) => {
+                      e.stopPropagation()
                       clickHandle(1)
                     }}
                   >
@@ -323,7 +322,8 @@ export const Ellipsis: FunctionComponent<
               {expandText ? (
                 <span
                   className="nut-ellipsis-text"
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation()
                     clickHandle(2)
                   }}
                 >

--- a/src/packages/ellipsis/ellipsis.tsx
+++ b/src/packages/ellipsis/ellipsis.tsx
@@ -228,7 +228,8 @@ export const Ellipsis: FunctionComponent<
             {expandText ? (
               <span
                 className="nut-ellipsis-text"
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation()
                   clickHandle(1)
                 }}
               >
@@ -244,7 +245,8 @@ export const Ellipsis: FunctionComponent<
             {expandText ? (
               <span
                 className="nut-ellipsis-text"
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation()
                   clickHandle(2)
                 }}
               >


### PR DESCRIPTION
### 🤔 这个变动的性质是？


- [x] 日常 bug 修复


### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/692

### 💡 需求背景和解决方案
ellipsis 组件的 onClick 加在最外层的 HTML 标签上，展开和关闭的 HTML 在内层，并且带有 onClick 事件，不过并没有加阻止冒泡的处理，导致展开和关闭点击的时候会触发父元素的 onClick

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档无须补充
- [x] 代码演示已提供或无须提供
