### PR TITLE
fix: 修复 taro 版本中 dialog 组件的 lockScroll 属性，重构 taro 版本的 dialog 类型，去掉函数调…

### DIFF
--- a/src/packages/dialog/Confirm.tsx
+++ b/src/packages/dialog/Confirm.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Dialog } from './dialog'
 import { destroyList, ConfirmProps } from './config'
+import { render as reactRender } from '@/utils/render'
 
 function ConfirmDialog(props: ConfirmProps) {
   return <Dialog {...props}>{props.content}</Dialog>
@@ -33,7 +34,7 @@ function confirm(
   document.body.appendChild(div)
 
   function render(props: ConfirmProps) {
-    ReactDOM.render(<ConfirmDialog {...props} onCancel={onCancel} />, div)
+    reactRender(<ConfirmDialog {...props} onCancel={onCancel} />, div)
   }
 
   const renderFunction = renderFunc || render

--- a/src/packages/dialog/DialogWrap.tsx
+++ b/src/packages/dialog/DialogWrap.tsx
@@ -15,7 +15,7 @@ interface DialogWrapProps {
 }
 
 export const DialogWrap: FunctionComponent<
-  Partial<DialogWrapProps> & HTMLAttributes<HTMLDivElement>
+  Partial<DialogWrapProps> & Omit<HTMLAttributes<HTMLDivElement>, 'title'>
 > = (props) => {
   const {
     className,

--- a/src/packages/dialog/DialogWrapper.taro.tsx
+++ b/src/packages/dialog/DialogWrapper.taro.tsx
@@ -1,0 +1,29 @@
+import React, { FunctionComponent, ReactNode, HTMLAttributes } from 'react'
+import { View } from '@tarojs/components'
+import { DialogWrap } from './DialogWrap'
+
+interface DialogWrapperProps {
+  visible?: boolean
+  title?: ReactNode
+  footer?: ReactNode
+  lockScroll?: boolean
+  onCancel?: () => void
+  onClosed?: () => void
+}
+
+export const DialogWrapper: FunctionComponent<
+  Partial<DialogWrapperProps> & Omit<HTMLAttributes<HTMLDivElement>, 'title'>
+> = (props) => {
+  const { visible, lockScroll } = props
+
+  return (
+    <View
+      style={{ display: visible ? 'block' : 'none' }}
+      catchMove={lockScroll}
+    >
+      <DialogWrap {...props} />
+    </View>
+  )
+}
+
+DialogWrapper.displayName = 'NutDialogWrapper'

--- a/src/packages/dialog/DialogWrapper.tsx
+++ b/src/packages/dialog/DialogWrapper.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, ReactNode, HTMLAttributes } from 'react'
+import React, {
+  FunctionComponent,
+  ReactNode,
+  HTMLAttributes,
+  useEffect,
+} from 'react'
 import { DialogWrap } from './DialogWrap'
 
 interface DialogWrapperProps {
@@ -14,13 +19,20 @@ export const DialogWrapper: FunctionComponent<
   Partial<DialogWrapperProps> & HTMLAttributes<HTMLDivElement>
 > = (props) => {
   const { visible, lockScroll } = props
-  if (
-    lockScroll &&
-    !visible &&
-    document.body.classList.value.includes('nut-overflow-hidden')
-  ) {
-    document.body.classList.remove('nut-overflow-hidden')
-  }
+  useEffect(() => {
+    if (lockScroll && visible) {
+      document.body.classList.add('nut-overflow-hidden')
+    } else {
+      document.body.classList.remove('nut-overflow-hidden')
+    }
+  }, [visible])
+  useEffect(() => {
+    return () => {
+      if (document.body.classList.value.includes('nut-overflow-hidden')) {
+        document.body.classList.remove('nut-overflow-hidden')
+      }
+    }
+  }, [])
 
   return (
     <div style={{ display: visible ? 'block' : 'none' }}>

--- a/src/packages/dialog/demo.taro.tsx
+++ b/src/packages/dialog/demo.taro.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
+import Taro from '@tarojs/taro'
 import { Dialog, Cell } from '@/packages/nutui.react.taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
 import Header from '@/sites/components/header'
-import Taro from '@tarojs/taro'
 
 interface T {
   basic: string
@@ -54,6 +54,7 @@ const DialogDemo = () => {
         <Cell title={translated.basic} onClick={() => setVisible1(true)} />
         <Dialog
           title={translated.title1}
+          lockScroll
           visible={visible1}
           okText={translated.okText}
           cancelText={translated.cancelText}
@@ -77,7 +78,7 @@ const DialogDemo = () => {
           title={translated.title1}
           visible={visible3}
           okText={translated.okText}
-          noCancelBtn={true}
+          noCancelBtn
           onOk={() => setVisible3(false)}
           onCancel={() => setVisible3(false)}
         >

--- a/src/packages/dialog/demo.tsx
+++ b/src/packages/dialog/demo.tsx
@@ -59,6 +59,7 @@ const DialogDemo = () => {
               content: translated.content,
               okText: translated.okText,
               cancelText: translated.cancelText,
+              lockScroll: true,
             })
           }}
         />

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -1,15 +1,10 @@
-import React, {
-  ForwardRefRenderFunction,
-  HTMLAttributes,
-  forwardRef,
-} from 'react'
+import React, { forwardRef } from 'react'
 import classNames from 'classnames'
 import Button from '@/packages/button/index.taro'
-import { DialogWrapper } from './DialogWrapper'
-import { BasicDialogProps, DialogComponent } from './config'
+import { DialogWrapper } from './DialogWrapper.taro'
+import { BasicDialogProps } from './config'
 import { useConfig } from '@/packages/configprovider/configprovider.taro'
 
-export type DialogProps = BasicDialogProps
 const defaultProps = {
   okText: '',
   cancelText: '',
@@ -23,97 +18,98 @@ const defaultProps = {
   textAlign: 'center',
   footerDirection: 'horizontal',
   lockScroll: false,
-} as DialogProps
+} as BasicDialogProps
 
-const BaseDialog: ForwardRefRenderFunction<
-  unknown,
-  Partial<DialogProps> & HTMLAttributes<HTMLDivElement>
-> = (props, ref) => {
-  const { locale } = useConfig()
-  const {
-    visible,
-    footer,
-    noOkBtn,
-    noCancelBtn,
-    lockScroll,
-    okBtnDisabled,
-    cancelAutoClose,
-    okText,
-    cancelText,
-    onClosed,
-    onCancel,
-    onOk,
-    ...restProps
-  } = props
+export const BaseDialog = forwardRef(
+  (
+    props: Partial<BasicDialogProps> &
+      Omit<React.HTMLAttributes<HTMLDivElement>, 'title'>,
+    ref
+  ) => {
+    const { locale } = useConfig()
+    const {
+      visible,
+      footer,
+      noOkBtn,
+      noCancelBtn,
+      lockScroll,
+      okBtnDisabled,
+      cancelAutoClose,
+      okText,
+      cancelText,
+      onClosed,
+      onCancel,
+      onOk,
+      ...restProps
+    } = props
 
-  const renderFooter = function () {
-    if (footer === null) return ''
+    const renderFooter = function () {
+      if (footer === null) return ''
 
-    const handleCancel = function (e: MouseEvent) {
-      e.stopPropagation()
-      if (!cancelAutoClose) return
+      const handleCancel = function (e: MouseEvent) {
+        e.stopPropagation()
+        if (!cancelAutoClose) return
 
-      onClosed?.()
-      onCancel?.()
-      if (lockScroll && visible) {
-        document.body.classList.remove('nut-overflow-hidden')
+        onClosed?.()
+        onCancel?.()
+        if (lockScroll && visible) {
+          document.body.classList.remove('nut-overflow-hidden')
+        }
       }
+
+      const handleOk = function (e: MouseEvent) {
+        e.stopPropagation()
+        onClosed?.()
+        onOk?.(e)
+        if (lockScroll && visible) {
+          document.body.classList.remove('nut-overflow-hidden')
+        }
+      }
+
+      const footerContent = footer || (
+        <>
+          {!noCancelBtn && (
+            <Button
+              size="small"
+              plain
+              type="primary"
+              className="nut-dialog__footer-cancel"
+              onClick={(e) => handleCancel(e)}
+            >
+              {cancelText || locale.cancel}
+            </Button>
+          )}
+          {!noOkBtn && (
+            <Button
+              size="small"
+              type="primary"
+              className={classNames('nut-dialog__footer-ok', {
+                disabled: okBtnDisabled,
+              })}
+              disabled={okBtnDisabled}
+              onClick={(e) => handleOk(e)}
+            >
+              {okText || locale.confirm}
+            </Button>
+          )}
+        </>
+      )
+
+      return footerContent
     }
 
-    const handleOk = function (e: MouseEvent) {
-      e.stopPropagation()
-      onClosed?.()
-      onOk?.(e)
-      if (lockScroll && visible) {
-        document.body.classList.remove('nut-overflow-hidden')
-      }
-    }
-
-    const footerContent = footer || (
-      <>
-        {!noCancelBtn && (
-          <Button
-            size="small"
-            plain
-            type="primary"
-            className="nut-dialog__footer-cancel"
-            onClick={(e) => handleCancel(e)}
-          >
-            {cancelText || locale.cancel}
-          </Button>
-        )}
-        {!noOkBtn && (
-          <Button
-            size="small"
-            type="primary"
-            className={classNames('nut-dialog__footer-ok', {
-              disabled: okBtnDisabled,
-            })}
-            disabled={okBtnDisabled}
-            onClick={(e) => handleOk(e)}
-          >
-            {okText || locale.confirm}
-          </Button>
-        )}
-      </>
+    return (
+      <DialogWrapper
+        {...restProps}
+        visible={visible}
+        lockScroll={lockScroll}
+        footer={renderFooter()}
+        onClosed={onClosed}
+        onCancel={onCancel}
+      />
     )
-
-    return footerContent
   }
+)
 
-  return (
-    <DialogWrapper
-      {...restProps}
-      visible={visible}
-      lockScroll={lockScroll}
-      footer={renderFooter()}
-      onClosed={onClosed}
-      onCancel={onCancel}
-    />
-  )
-}
-
-export const Dialog: DialogComponent = forwardRef(BaseDialog) as DialogComponent
-
-Dialog.defaultProps = defaultProps
-Dialog.displayName = 'NutDialog'
+BaseDialog.defaultProps = defaultProps
+BaseDialog.displayName = 'NutDialog'


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复


### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/694
https://github.com/jdf2e/nutui-react/issues/676

### 💡 需求背景和解决方案
taro 版本中使用 View 组件的 catchmove 属性，在 H5 版本中则向 body 追加 nut-overflow-hidden 类，组件退出的时候清理 nut-overflow-hidden。

taro 版本不支持函数调用，所以去掉了函数调用的几个 TS 类型，这样在 taro 环境下开发不会提示这些 API。

dialog 使用的 render 方法更换为兼容 react 17 和 18 的方法。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
