### PR TITLE
fix(animatingnumbers): 修复delaySpeed不生效

### DIFF
--- a/src/packages/animatingnumbers/__tests__/animatingnumbers.spec.tsx
+++ b/src/packages/animatingnumbers/__tests__/animatingnumbers.spec.tsx
@@ -2,11 +2,18 @@ import React from 'react'
 import { render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { AnimatingNumbers } from '../animatingnumbers'
+import { CountUp } from '@/packages/animatingnumbers/countup'
 
+jest.useFakeTimers()
 test('test endNumber props', () => {
   const { container } = render(<AnimatingNumbers.CountUp endNumber="678.94" />)
 
   const listNumbers = container.querySelectorAll('.nut-countup__number')
+  expect(listNumbers[0]).toHaveAttribute(
+    'style',
+    'transition: transform 1s ease-in-out;'
+  )
+  jest.advanceTimersByTime(CountUp.defaultProps?.delaySpeed ?? 0)
   expect(listNumbers[0]).toHaveAttribute(
     'style',
     'transition: transform 1s ease-in-out; transform: translate(0, -30%); webkit-transform: translate(0, -30%);'
@@ -26,6 +33,7 @@ test('test aysnc endNumber and  easeSpeed props', async () => {
   )
   const listNumbers = container.querySelectorAll('.nut-countup__number')
   expect(listNumbers.length).toBe(8)
+  jest.advanceTimersByTime(CountUp.defaultProps?.delaySpeed ?? 0)
   expect(listNumbers[0]).toHaveAttribute(
     'style',
     'transition: transform 1.2s ease-in-out; transform: translate(0, -50%); webkit-transform: translate(0, -50%);'

--- a/src/packages/animatingnumbers/countup.tsx
+++ b/src/packages/animatingnumbers/countup.tsx
@@ -2,6 +2,7 @@ import React, {
   CSSProperties,
   FunctionComponent,
   useEffect,
+  useMemo,
   useRef,
 } from 'react'
 
@@ -54,7 +55,7 @@ export const CountUp: FunctionComponent<Partial<CountUpProps>> = (props) => {
     return currNumber.split('')
   }
 
-  const numerArr = getShowNumber()
+  const numerArr = useMemo(getShowNumber, [endNumber, maxLen, thousands])
 
   const setNumberTransform = () => {
     if (countupRef.current) {
@@ -88,10 +89,6 @@ export const CountUp: FunctionComponent<Partial<CountUpProps>> = (props) => {
     return () => {
       window.clearTimeout(timerRef.current)
     }
-  }, [])
-
-  useEffect(() => {
-    setNumberTransform()
   }, [numerArr])
 
   return (


### PR DESCRIPTION

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

问题：`AnimatingNumbers.CountUp` 组件设置`delaySpeed`属性不生效。

原因：`CountUp`组件里有两个`useEffect`调用了`setNumberTransform`，导致第一个useEffect（使用了delaySpeed那个）是无效的。

修改点：

1.  把两个`useEffect`合并成一个
2. `numerArr`使用了`useMemo`，可以避免重新渲染时不必要的`setNumberTransform`调用


<!--
1. 要解决的具体问题。
4. 列出最终的 API 实现和用法。
5. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
