### PR TITLE
fix: 修复 trao/h5 版本中 swipe 内使用 Dialog 无法正常展示问题

### DIFF
--- a/src/packages/swipe/swipe.scss
+++ b/src/packages/swipe/swipe.scss
@@ -5,7 +5,8 @@
 
   &__wrapper {
     transition-timing-function: cubic-bezier(0.18, 0.89, 0.32, 1);
-    transition-property: transform;
+    transition-property: left;
+    position: relative;
     .nut-button {
       height: 100%;
     }

--- a/src/packages/swipe/swipe.taro.tsx
+++ b/src/packages/swipe/swipe.taro.tsx
@@ -120,8 +120,7 @@ export const Swipe = forwardRef<
     right: 0,
   })
   const wrapperStyle = {
-    transform: `translate3d(${state.offset}px, 0, 0)`,
-    transitionDuration: state.dragging ? '0s' : '.6s',
+    left: `${state.offset}px`,
   }
   const leftWidth = useMemo(
     () => (props.leftWidth ? props.leftWidth : actionWidth.left),

--- a/src/packages/swipe/swipe.tsx
+++ b/src/packages/swipe/swipe.tsx
@@ -105,8 +105,7 @@ export const Swipe = forwardRef<
     right: 0,
   })
   const wrapperStyle = {
-    transform: `translate3d(${state.offset}px, 0, 0)`,
-    transitionDuration: state.dragging ? '0s' : '.6s',
+    left: `${state.offset}px`,
   }
   const leftWidth = useMemo(
     () => (props.leftWidth ? props.leftWidth : actionWidth.left),


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/787

### 💡 需求背景和解决方案




1. 要解决的具体问题。
swipe内使用Dialog无法正常展示。
2. 解决方案
swipe中的transform改为position:relative，防止transform形成BFC后，position:fixed相对于transform进行定位。



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
