### PR TITLE
fix: textarea 优化中文输入

### DIFF
--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -63,6 +63,8 @@ export const TextArea: FunctionComponent<
   const textareaBem = bem('textarea')
   const [inputValue, SetInputValue] = useState('')
   const compositingRef = useRef(false)
+  const [, updateState] = React.useState()
+  const forceUpdate = React.useCallback(() => updateState({}), [])
 
   useEffect(() => {
     let initValue = defaultValue
@@ -76,7 +78,6 @@ export const TextArea: FunctionComponent<
     if (disabled) return
     if (readonly) return
     const text = event.detail ? (event.detail as any) : (event.target as any)
-    console.log('composing', compositingRef.current)
     if (
       maxlength &&
       [...text.value].length > Number(maxlength) &&
@@ -84,7 +85,11 @@ export const TextArea: FunctionComponent<
     ) {
       text.value = text.value.substring(0, Number(maxlength))
     }
-    SetInputValue(text.value)
+    if (text.value === inputValue) {
+      forceUpdate()
+    } else {
+      SetInputValue(text.value)
+    }
     onChange && onChange(text.value, event)
   }
 
@@ -124,9 +129,9 @@ export const TextArea: FunctionComponent<
         }}
         readOnly={disabled || readonly}
         value={inputValue}
-        // onInput={(e: any) => {
-        //   textChange(e)
-        // }}
+        onInput={(e: any) => {
+          textChange(e)
+        }}
         onChange={(e: any) => {
           textChange(e)
         }}
@@ -139,7 +144,7 @@ export const TextArea: FunctionComponent<
         onCompositionEnd={(e) => endComposing()}
         onCompositionStart={(e) => startComposing()}
         rows={rows}
-        maxLength={maxlength < 0 ? 0 : maxlength}
+        // maxLength={maxlength < 0 ? 0 : maxlength}
         placeholder={placeholder || locale.placeholder}
       />
       {limitshow ? (

--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useState,
   CSSProperties,
+  useRef,
 } from 'react'
 import { useConfig } from '@/packages/configprovider/configprovider.taro'
 import bem from '@/utils/bem'
@@ -61,6 +62,7 @@ export const TextArea: FunctionComponent<
 
   const textareaBem = bem('textarea')
   const [inputValue, SetInputValue] = useState('')
+  const compositingRef = useRef(false)
 
   useEffect(() => {
     let initValue = defaultValue
@@ -74,7 +76,12 @@ export const TextArea: FunctionComponent<
     if (disabled) return
     if (readonly) return
     const text = event.detail ? (event.detail as any) : (event.target as any)
-    if (maxlength && [...text.value].length > Number(maxlength)) {
+    console.log('composing', compositingRef.current)
+    if (
+      maxlength &&
+      [...text.value].length > Number(maxlength) &&
+      !compositingRef.current
+    ) {
       text.value = text.value.substring(0, Number(maxlength))
     }
     SetInputValue(text.value)
@@ -95,6 +102,13 @@ export const TextArea: FunctionComponent<
     onBlur && onBlur(event)
   }
 
+  const startComposing = () => {
+    compositingRef.current = true
+  }
+  const endComposing = () => {
+    compositingRef.current = false
+  }
+
   return (
     <div
       className={`${textareaBem()} ${disabled ? textareaBem('disabled') : ''} ${
@@ -110,9 +124,9 @@ export const TextArea: FunctionComponent<
         }}
         readOnly={disabled || readonly}
         value={inputValue}
-        onInput={(e: any) => {
-          textChange(e)
-        }}
+        // onInput={(e: any) => {
+        //   textChange(e)
+        // }}
         onChange={(e: any) => {
           textChange(e)
         }}
@@ -122,6 +136,8 @@ export const TextArea: FunctionComponent<
         onFocus={(e: any) => {
           textFocus(e)
         }}
+        onCompositionEnd={(e) => endComposing()}
+        onCompositionStart={(e) => startComposing()}
         rows={rows}
         maxLength={maxlength < 0 ? 0 : maxlength}
         placeholder={placeholder || locale.placeholder}

--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -63,7 +63,7 @@ export const TextArea: FunctionComponent<
   const textareaBem = bem('textarea')
   const [inputValue, SetInputValue] = useState('')
   const compositingRef = useRef(false)
-  const [, updateState] = React.useState()
+  const [, updateState] = React.useState({})
   const forceUpdate = React.useCallback(() => updateState({}), [])
 
   useEffect(() => {

--- a/src/packages/textarea/textarea.tsx
+++ b/src/packages/textarea/textarea.tsx
@@ -64,6 +64,8 @@ export const TextArea: FunctionComponent<
   const [inputValue, SetInputValue] = useState('')
   const textareaRef = useRef<any>(null)
 
+  const compositingRef = useRef(false)
+
   useEffect(() => {
     let initValue = defaultValue
     if (initValue && maxlength && [...initValue].length > Number(maxlength)) {
@@ -109,7 +111,11 @@ export const TextArea: FunctionComponent<
 
   const textChange = (event: Event) => {
     const text = event.target as any
-    if (maxlength && [...text.value].length > Number(maxlength)) {
+    if (
+      maxlength &&
+      [...text.value].length > Number(maxlength) &&
+      !compositingRef.current
+    ) {
       text.value = text.value.substring(0, Number(maxlength))
     }
     SetInputValue(text.value)
@@ -130,6 +136,13 @@ export const TextArea: FunctionComponent<
     onBlur && onBlur(event)
   }
 
+  const startComposing = () => {
+    compositingRef.current = true
+  }
+  const endComposing = () => {
+    compositingRef.current = false
+  }
+
   return (
     <div
       className={`${textareaBem()} ${disabled ? textareaBem('disabled') : ''} ${
@@ -146,9 +159,9 @@ export const TextArea: FunctionComponent<
         disabled={disabled}
         readOnly={readonly}
         value={inputValue}
-        onInput={(e: any) => {
-          textChange(e)
-        }}
+        // onInput={(e: any) => {
+        //   textChange(e)
+        // }}
         onChange={(e: any) => {
           textChange(e)
         }}
@@ -158,6 +171,8 @@ export const TextArea: FunctionComponent<
         onFocus={(e: any) => {
           textFocus(e)
         }}
+        onCompositionEnd={(e) => endComposing()}
+        onCompositionStart={(e) => startComposing()}
         rows={rows}
         maxLength={maxlength < 0 ? 0 : maxlength}
         placeholder={placeholder || locale.placeholder}


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
taro 版本中，给 textarea 设置 maxlength 后，通过中文输入法进行输入，拼音长度超过剩余可输入字符数的话，无法回填。

解决办法：
在 textarea 中去掉了 maxlength 属性的设置，通过 input 事件和 maxlength 做截断，如果截断后的数据一致，则强制更新。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
