### PR TITLE
fix: ellipsis 在深层嵌套中无法获取元素信息

### DIFF
--- a/src/packages/ellipsis/ellipsis.taro.tsx
+++ b/src/packages/ellipsis/ellipsis.taro.tsx
@@ -1,10 +1,5 @@
-import React, {
-  FunctionComponent,
-  useState,
-  useRef,
-  useLayoutEffect,
-} from 'react'
-import { createSelectorQuery } from '@tarojs/taro'
+import React, { FunctionComponent, useState, useRef } from 'react'
+import { useReady, nextTick, createSelectorQuery } from '@tarojs/taro'
 import { useConfig } from '@/packages/configprovider/configprovider.taro'
 import { getRectByTaro } from '@/utils/useClientRect'
 
@@ -26,6 +21,7 @@ export interface EllipsisProps {
   onClick: () => void
   onChange: (type: string) => void
 }
+
 const defaultProps = {
   content: '',
   direction: 'end',
@@ -74,12 +70,12 @@ export const Ellipsis: FunctionComponent<
   const letterUpperReg = /^[A-Z]+$/ // 字母
   const letterLowerReg = /^[a-z]+$/ // 字母
 
-  useLayoutEffect(() => {
-    setTimeout(() => {
+  useReady(() => {
+    nextTick(() => {
       getSymbolInfo()
       getReference()
-    }, 100)
-  }, [])
+    })
+  })
 
   // 获取省略号宽度
   const getSymbolInfo = async () => {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/786

### 💡 需求背景和解决方案
在 taro 版本中 useLayoutEffect 替换为 useReady

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档无须补充
- [x] 代码演示无须提供
- [x] TypeScript 定义无须补充

