### PR TITLE
fix: 修改 textarea 的 padding 为之前版本的值

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -475,7 +475,7 @@ $input-padding: var(--nutui-input-padding, 10px 25px) !default;
 
 $textarea-font: var(--nutui-textarea-font, $font-size-2) !default;
 $textarea-height: var(--nutui-textarea-height, 100px) !default;
-$textarea-padding: var(--nutui-textarea-padding, 16px 10px 16px 16px) !default;
+$textarea-padding: var(--nutui-textarea-padding, 10px 25px) !default;
 $textarea-limit-color: var(--nutui-textarea-limit-color, $text-color) !default;
 $textarea-text-color: var(--nutui-textarea-text-color, $title-color) !default;
 $textarea-text-curror-color: var(


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/777

在 https://github.com/jdf2e/nutui-react/pull/688 中修改了 textarea 的 padding。导致和 vue 版本的视觉不一致。


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
