### PR TITLE
fix: radiogroup 中使用 button 类型的 radio 样式不对

### DIFF
--- a/src/packages/radiogroup/radiogroup.scss
+++ b/src/packages/radiogroup/radiogroup.scss
@@ -66,6 +66,7 @@
 
       &__button--active {
         border-color: $radio-label-button-border-color;
+        background-color: $radio-label-button-background;
       }
     }
   }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/768

### 💡 需求背景和解决方案
针对 radiogroup 的 button 增加激活状态的样式

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
