### PR TITLE
fix: picker 组件在小程序端触发滚动后，页面(有滚动条的情况下)也一起滚动

### DIFF
--- a/src/packages/picker/picker.taro.tsx
+++ b/src/packages/picker/picker.taro.tsx
@@ -5,6 +5,7 @@ import React, {
   RefObject,
   ForwardRefRenderFunction,
 } from 'react'
+import { View } from '@tarojs/components'
 import Popup from '@/packages/popup/index.taro'
 import PickerSlot from './pickerSlot.taro'
 import useRefs from '@/utils/useRefs'
@@ -287,7 +288,12 @@ const InternalPicker: ForwardRefRenderFunction<unknown, Partial<PickerProps>> =
           closeActionSheet()
         }}
       >
-        <div className={`${b()} ${className || ''}`} style={style} {...rest}>
+        <View
+          className={`${b()} ${className || ''}`}
+          style={style}
+          {...rest}
+          catchMove
+        >
           {renderToolbar()}
           <div className={b('panel')} ref={pickerRef}>
             {columnsList?.map((item, index) => {
@@ -308,7 +314,7 @@ const InternalPicker: ForwardRefRenderFunction<unknown, Partial<PickerProps>> =
               )
             })}
           </div>
-        </div>
+        </View>
       </Popup>
     )
   }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
<https://github.com/jdf2e/nutui-react/issues/828>
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
