### PR TITLE
fix: tabs 组件paneKey为空字符串时返回索引问题

### DIFF
--- a/src/packages/tabs/tabs.taro.tsx
+++ b/src/packages/tabs/tabs.taro.tsx
@@ -108,7 +108,7 @@ export const Tabs: FunctionComponent<
       const childProps = child?.props
       if (childProps?.title || childProps?.paneKey) {
         title.title = childProps?.title
-        title.paneKey = childProps?.paneKey || idx
+        title.paneKey = getPaneKey(childProps?.paneKey, idx)
         title.disabled = childProps?.disabled
         title.index = idx
         if (title.paneKey === value) {
@@ -149,6 +149,10 @@ export const Tabs: FunctionComponent<
         ? `translate3d(-${index * 100}%, 0, 0)`
         : `translate3d( 0,-${index * 100}%, 0)`,
     transitionDuration: `${animatedTime}ms`,
+  }
+
+  const getPaneKey = (paneKey: string | number, index: number) => {
+    return typeof paneKey === 'string' ? paneKey : String(paneKey || index)
   }
 
   const tabChange = (item: Title, index: number) => {
@@ -231,7 +235,7 @@ export const Tabs: FunctionComponent<
             }
 
             if (
-              String(value) !== String(child.props?.paneKey || idx) &&
+              String(value) !== getPaneKey(child.props?.paneKey, idx) &&
               autoHeight
             ) {
               childProps = {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/869

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
