### PR TITLE
fix: grid-item 组件设置 className 后丢失了原有的 nut-grid-item 样式类

### DIFF
--- a/src/packages/griditem/griditem.taro.tsx
+++ b/src/packages/griditem/griditem.taro.tsx
@@ -77,6 +77,7 @@ export const GridItem: FunctionComponent<
     direction,
     iconClassPrefix,
     iconFontClassName,
+    className,
     onClick,
     ...rest
   } = {
@@ -84,6 +85,7 @@ export const GridItem: FunctionComponent<
     ...props,
   }
   const b = bem('grid-item')
+  const classes = classNames(b(), className)
   const context = useContext(GridContext)
   const pxCheck = (value: string | number): string => {
     return Number.isNaN(Number(value)) ? String(value) : `${value}px`
@@ -148,7 +150,12 @@ export const GridItem: FunctionComponent<
   }
 
   return (
-    <div className={b()} style={rootStyle()} {...rest} onClick={handleClick}>
+    <div
+      className={classes}
+      style={rootStyle()}
+      {...rest}
+      onClick={handleClick}
+    >
       <div className={contentClass()}>
         {icon && isIconName() ? (
           <Icon


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/871

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
