### PR TITLE
chore: 中英文切换开发和本地移动端和pc端路径切换

### DIFF
--- a/src/sites/doc/components/demo-preview/demo-preview.tsx
+++ b/src/sites/doc/components/demo-preview/demo-preview.tsx
@@ -1,16 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import './demo-preview.scss'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 
 const DemoPreview = (props: any) => {
-  const history = useHistory()
   const location = useLocation()
-  const path = location.pathname.split('/')
-  const [URL, setURL] = useState(path[path.length - 1])
+  const [URL, setURL] = useState(location.pathname)
 
   useEffect(() => {
-    const path = location.pathname.split('/')
-    setURL(path[path.length - 1])
+    setURL(location.pathname)
   }, [location])
 
   return (

--- a/src/sites/mobile/App.tsx
+++ b/src/sites/mobile/App.tsx
@@ -67,7 +67,7 @@ const WithNavRouter = (C: LoadableComponent<any>) => {
       } else {
         href = location.href.replace('en-US', 'zh-CN')
       }
-      location.href = href
+      location.replace(href)
     }
     const getComponentName = () => {
       const s = window.location.hash.split('/')

--- a/src/sites/mobile/App.tsx
+++ b/src/sites/mobile/App.tsx
@@ -19,7 +19,7 @@ import enUS from '@/locales/en-US'
 import { BaseLang } from '@/locales/base'
 // import Icon from '@/packages/Icon'
 import { nav } from '@/config.json'
-import TaroDemo from '@/sites/mobile/TaroDemo'
+// import TaroDemo from '@/sites/mobile/TaroDemo'
 
 interface Languages {
   [key: string]: BaseLang
@@ -168,9 +168,9 @@ const AppSwitch = () => {
             />
           )
         })}
-        <Route path="*-taro">
+        {/* <Route path="*-taro">
           <TaroDemo />
-        </Route>
+        </Route> */}
         <Route path="*">
           <Redirect
             to={{

--- a/src/sites/mobile/Links.scss
+++ b/src/sites/mobile/Links.scss
@@ -28,6 +28,7 @@
         line-height: 18px;
         font-size: 13px;
         color: rgba(154, 155, 157, 1);
+        white-space: nowrap;
       }
     }
   }

--- a/src/sites/mobile/Links.scss
+++ b/src/sites/mobile/Links.scss
@@ -20,13 +20,13 @@
       h1 {
         height: 48px;
         line-height: 48px;
-        font-size: 34px;
+        font-size: 26px;
         color: rgba(51, 51, 51, 1);
       }
       p {
         height: 18px;
         line-height: 18px;
-        font-size: 12px;
+        font-size: 13px;
         color: rgba(154, 155, 157, 1);
       }
     }

--- a/src/sites/mobile/Links.tsx
+++ b/src/sites/mobile/Links.tsx
@@ -3,10 +3,12 @@ import './Links.scss'
 import { Link } from 'react-router-dom'
 import { Right } from '@nutui/icons-react'
 import pkg from '../../config.json'
+import useLocale from '@/sites/assets/locale/uselocale'
 
 const navs = pkg.nav
 
 const Links = () => {
+  const [lang] = useLocale()
   return (
     <>
       {navs.map((nav) => (
@@ -16,7 +18,7 @@ const Links = () => {
             {nav.packages.map((com) =>
               com.show ? (
                 <li key={com.name}>
-                  <Link key={com.name} to={`${com.name}`}>
+                  <Link key={com.name} to={`${lang}/component/${com.name}`}>
                     {com.name}&nbsp;&nbsp;{com.cName}
                   </Link>
                   <Right color="#979797" name="right"></Right>

--- a/src/sites/mobile/Links.tsx
+++ b/src/sites/mobile/Links.tsx
@@ -3,12 +3,10 @@ import './Links.scss'
 import { Link } from 'react-router-dom'
 import { Right } from '@nutui/icons-react'
 import pkg from '../../config.json'
-import useLocale from '@/sites/assets/locale/uselocale'
 
 const navs = pkg.nav
 
 const Links = () => {
-  const [lang] = useLocale()
   return (
     <>
       {navs.map((nav) => (

--- a/src/sites/mobile/main.tsx
+++ b/src/sites/mobile/main.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom/client'
 import App from './App'
 import '../assets/util/touch-emulator' // 适配 h5 示例桌面端预览
 import '@/sites/assets/styles/reset.scss'
+import { isMobile } from '@/sites/assets/util'
 // import '@/styles/font/iconfont.css'
 
 const projectID = import.meta.env.VITE_APP_PROJECT_ID
@@ -18,6 +19,14 @@ if (projectID) {
 import('../../packages/nutui.react.scss')
 
 const rootElement = document.querySelector('#app')
+
+const { pathname } = window.parent.location
+let href = ''
+
+if (!isMobile && pathname.includes('demo')) {
+  href = location.href.replace('demo.html', '')
+  window.location.href = href
+}
 
 if (rootElement != null) {
   const root = ReactDOM.createRoot(rootElement)

--- a/src/sites/mobile/router.ts
+++ b/src/sites/mobile/router.ts
@@ -4,7 +4,17 @@ const routes: any[] = []
 for (const path in modulesPage) {
   let name = (/packages\/(.*)\/demo.tsx/.exec(path) as any[])[1]
   routes.push({
-    path: '/' + name.toLowerCase(),
+    path: '/zh-CN/component/' + name.toLowerCase(),
+    component: modulesPage[path],
+    name,
+  })
+}
+
+const modulesENPage = import.meta.glob('/src/packages/**/demo.tsx')
+for (const path in modulesENPage) {
+  let name = (/packages\/(.*)\/demo.tsx/.exec(path) as any[])[1]
+  routes.push({
+    path: '/en-US/component/' + name.toLowerCase(),
     component: modulesPage[path],
     name,
   })

--- a/src/sites/mobile/router.ts
+++ b/src/sites/mobile/router.ts
@@ -8,11 +8,7 @@ for (const path in modulesPage) {
     component: modulesPage[path],
     name,
   })
-}
 
-const modulesENPage = import.meta.glob('/src/packages/**/demo.tsx')
-for (const path in modulesENPage) {
-  let name = (/packages\/(.*)\/demo.tsx/.exec(path) as any[])[1]
   routes.push({
     path: '/en-US/component/' + name.toLowerCase(),
     component: modulesPage[path],


### PR DESCRIPTION
1.修改本地开发移动端切换成PC端可以路径自动切换
2.移动端点击中英文切换按钮实现demo语言的切换
3.PC端点击中英文切换按钮实现移动端和pc端联动