### PR TITLE
fix: 修复Range 区间选择器，更新modelValue时，界面显示不正确的问题 #908

### DIFF
--- a/src/packages/range/range.taro.tsx
+++ b/src/packages/range/range.taro.tsx
@@ -100,12 +100,18 @@ export const Range: FunctionComponent<
   }
 
   useEffect(() => {
-    if (typeof modelValue === 'number') {
-      if (!range && (modelValue < min || modelValue > max)) {
+    if (!range && typeof modelValue === 'number') {
+      if (modelValue < min || modelValue > max) {
         SetInitValue(0)
         toastShow(`${modelValue} ${locale.range.rangeText}`)
         return
       }
+      SetInitValue(modelValue)
+    } else if (
+      range &&
+      Array.isArray(modelValue) &&
+      [0, 1].every((i) => typeof modelValue[i] === 'number')
+    ) {
       SetInitValue(modelValue)
     }
   }, [modelValue])

--- a/src/packages/range/range.tsx
+++ b/src/packages/range/range.tsx
@@ -93,12 +93,18 @@ export const Range: FunctionComponent<
   const [marksList, SetMarksList] = useState([])
 
   useEffect(() => {
-    if (typeof modelValue === 'number') {
-      if (!range && (modelValue < min || modelValue > max)) {
+    if (!range && typeof modelValue === 'number') {
+      if (modelValue < min || modelValue > max) {
         SetInitValue(0)
         Toast.text(`${modelValue} ${locale.range.rangeText}`)
         return
       }
+      SetInitValue(modelValue)
+    } else if (
+      range &&
+      Array.isArray(modelValue) &&
+      [0, 1].every((i) => typeof modelValue[i] === 'number')
+    ) {
       SetInitValue(modelValue)
     }
   }, [modelValue])


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/908

### 💡 需求背景和解决方案

区间模式range=true 时，当拖拽节点initValue 有值后，更新modelValue 不再设置initValue，导致ui 不再更新，补充这部分赋值逻辑

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fock仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
