### PR TITLE
fix: input 组件忽略 maxlength 和 password 属性

### DIFF
--- a/src/packages/input/doc.taro.md
+++ b/src/packages/input/doc.taro.md
@@ -277,7 +277,7 @@ export default App;
 | onClear | 点击清空按钮时触发 | `(value: string) => void` | `-` |
 | onClick | 点击 input 容器触发 | `(value: MouseEvent<HTMLDivElement>) => void` | `-` |
 
-此外还支持 taro 中的 [input 属性](https://docs.taro.zone/docs/components/forms/input/)
+此外还支持 Taro 中的 [Input 属性](https://docs.taro.zone/docs/components/forms/input/)
 
 ## 主题定制
 

--- a/src/packages/input/input.taro.tsx
+++ b/src/packages/input/input.taro.tsx
@@ -66,7 +66,12 @@ const defaultProps = {
 export const Input = forwardRef(
   (
     props: Partial<InputProps> &
-      Partial<Omit<TaroInputProps, 'type' | 'ref' | 'onBlur' | 'onFocus'>>,
+      Partial<
+        Omit<
+          TaroInputProps,
+          'type' | 'ref' | 'onBlur' | 'onFocus' | 'maxlength' | 'password'
+        >
+      >,
     ref
   ) => {
     const { locale } = useConfig()


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue



### 💡 需求背景和解决方案

NutUI-React Taro 版本的 Input 组件 extends 了 Taro Input 的 Props，但是在实现中，maxlength 和 password 并没有使用，而是映射到了 maxLength 和 type 上。在 IDE 中会提示出来这两个属性，导致开发这错用属性，从而开发者认为组件有 Bug

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fock仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
