### PR TITLE
fix: menu 组件被使用 transform 的组件嵌套后，遮罩层发生偏移

### DIFF
--- a/src/packages/menu/__test__/__snapshots__/menu.spec.tsx.snap
+++ b/src/packages/menu/__test__/__snapshots__/menu.spec.tsx.snap
@@ -39,60 +39,65 @@ exports[`should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="nut-overlay-first-render nut-overlay-hidden-render nut-menu__overlay nut-overlay"
-        style="z-index: 1000; animation-duration: 0.3s; top: 0px;"
-      />
-      <div
-        class="nut-menu-item__wrap"
-        style="display: none;"
+        class="nut-menu-item-container"
+        style="position: absolute; left: 0px; right: 0px;"
       >
         <div
-          class="nut-menu-item__content"
+          class="nut-overlay-first-render nut-overlay-hidden-render nut-menu__overlay nut-overlay"
+          style="z-index: 1000; animation-duration: 0.3s; position: absolute; height: 768px;"
+        />
+        <div
+          class="nut-menu-item__wrap"
+          style="display: none;"
         >
           <div
-            class="nut-menu-item__option active"
-            style="flex-basis: 100%;"
+            class="nut-menu-item__content"
           >
-            <i>
-              <svg
-                aria-labelledby="Check"
-                class="nut-icon nut-icon-Check"
-                color=""
-                role="presentation"
-                viewBox="0 0 1024 1024"
-                xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="nut-menu-item__option active"
+              style="flex-basis: 100%;"
+            >
+              <i>
+                <svg
+                  aria-labelledby="Check"
+                  class="nut-icon nut-icon-Check"
+                  color=""
+                  role="presentation"
+                  viewBox="0 0 1024 1024"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M998.4 245.029c-219.429 153.6-398.629 332.8-552.229 552.228-40.228 58.514-128 54.857-164.571-3.657-69.486-106.057-149.943-186.514-256-256-51.2-32.914-18.286-113.371 40.229-98.743C182.857 460.8 274.286 508.343 358.4 585.143c157.257-190.172 358.4-340.114 588.8-435.2 62.171-25.6 106.057 58.514 51.2 95.086"
+                    fill="currentColor"
+                    fill-opacity="0.9"
+                  />
+                </svg>
+              </i>
+              <div
+                class=""
               >
-                <path
-                  d="M998.4 245.029c-219.429 153.6-398.629 332.8-552.229 552.228-40.228 58.514-128 54.857-164.571-3.657-69.486-106.057-149.943-186.514-256-256-51.2-32.914-18.286-113.371 40.229-98.743C182.857 460.8 274.286 508.343 358.4 585.143c157.257-190.172 358.4-340.114 588.8-435.2 62.171-25.6 106.057 58.514 51.2 95.086"
-                  fill="currentColor"
-                  fill-opacity="0.9"
-                />
-              </svg>
-            </i>
-            <div
-              class=""
-            >
-              全部商品
+                全部商品
+              </div>
             </div>
-          </div>
-          <div
-            class="nut-menu-item__option "
-            style="flex-basis: 100%;"
-          >
             <div
-              class=""
+              class="nut-menu-item__option "
+              style="flex-basis: 100%;"
             >
-              新款商品
+              <div
+                class=""
+              >
+                新款商品
+              </div>
             </div>
-          </div>
-          <div
-            class="nut-menu-item__option "
-            style="flex-basis: 100%;"
-          >
             <div
-              class=""
+              class="nut-menu-item__option "
+              style="flex-basis: 100%;"
             >
-              活动商品
+              <div
+                class=""
+              >
+                活动商品
+              </div>
             </div>
           </div>
         </div>

--- a/src/packages/menu/demo.taro.tsx
+++ b/src/packages/menu/demo.taro.tsx
@@ -112,11 +112,12 @@ const MenuDemo = () => {
           <MenuItem
             options={options}
             value={0}
+            closeOnClickAway
             onChange={(val) => {
               console.log(val)
             }}
           />
-          <MenuItem options={options1} value="a" />
+          <MenuItem closeOnClickAway options={options1} value="a" />
         </Menu>
         <h2>{translated.customMenuContent}</h2>
         <Menu>
@@ -144,8 +145,18 @@ const MenuDemo = () => {
         </Menu>
         <h2>{translated.expandDirection}</h2>
         <Menu>
-          <MenuItem options={options} value={0} direction="up" />
-          <MenuItem options={options1} value="a" direction="up" />
+          <MenuItem
+            options={options}
+            value={0}
+            direction="up"
+            closeOnClickAway
+          />
+          <MenuItem
+            options={options1}
+            value="a"
+            direction="up"
+            closeOnClickAway
+          />
         </Menu>
         <h2>{translated.disableMenu}</h2>
         <Menu>

--- a/src/packages/menu/demo.tsx
+++ b/src/packages/menu/demo.tsx
@@ -111,11 +111,12 @@ const MenuDemo = () => {
           <MenuItem
             options={options}
             value={0}
+            closeOnClickAway
             onChange={(val) => {
               console.log(val)
             }}
           />
-          <MenuItem options={options1} value="a" />
+          <MenuItem options={options1} value="a" closeOnClickAway />
         </Menu>
         <h2>{translated.customMenuContent}</h2>
         <Menu>

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -69,6 +69,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
   }
   const hideMenuItem = (index: number) => {
     showMenuItem[index] = false
+    console.log([...showMenuItem])
     setShowMenuItem([...showMenuItem])
   }
   const updateTitle = (text: string, index: number) => {
@@ -79,6 +80,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
   const cloneChildren = () => {
     return React.Children.map(children, (child, index) => {
       return React.cloneElement(child as any, {
+        ...(child as any).props,
         show: showMenuItem[index],
         index,
         activeColor,
@@ -115,7 +117,8 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
             })}
             style={{ color: showMenuItem[index] ? activeColor : '' }}
             key={index}
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation()
               !disabled && toggleMenuItem(index)
             }}
           >

--- a/src/packages/menuitem/menuitem.scss
+++ b/src/packages/menuitem/menuitem.scss
@@ -58,7 +58,7 @@
 }
 
 .placeholder-element {
-  position: fixed;
+  position: absolute;
   top: -$menu-bar-line-height;
   left: 0;
   right: 0;

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -1,4 +1,5 @@
 import React, {
+  CSSProperties,
   forwardRef,
   useEffect,
   useImperativeHandle,
@@ -115,12 +116,14 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     return { display: 'none' }
   }
 
-  const getPosition = () => {
+  const getPosition = (): CSSProperties => {
     return direction === 'down'
-      ? { top: `${position.top + position.height}px` }
+      ? { position: 'absolute', height: `${window.innerHeight}px` }
       : {
-          bottom: `${getSystemInfoSync().windowHeight - position.top}px`,
+          position: 'absolute',
+          bottom: '100%',
           top: 'auto',
+          height: `${window.innerHeight}px`,
         }
   }
 
@@ -128,20 +131,24 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     if (direction === 'down') {
       return {
         height: `${position.top + position.height}px`,
-        top: 0,
+        top: 'auto',
+        bottom: '-100%',
         ...isShow(),
       }
     }
     return {
       height: `${getSystemInfoSync().windowHeight - position.top}px`,
-      bottom: `0px`,
-      top: 'auto',
+      bottom: `auto`,
+      top: '0',
       ...isShow(),
     }
   }
 
   return (
-    <>
+    <div
+      className="nut-menu-item-container"
+      style={{ position: 'absolute', left: 0, right: 0 }}
+    >
       {closeOnClickAway ? (
         <div
           className={`placeholder-element ${classNames({
@@ -218,7 +225,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
           </div>
         </CSSTransition>
       </div>
-    </>
+    </div>
   )
 })
 

--- a/src/packages/menuitem/menuitem.tsx
+++ b/src/packages/menuitem/menuitem.tsx
@@ -1,14 +1,16 @@
 import React, {
+  CSSProperties,
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
 } from 'react'
 import classNames from 'classnames'
 import { CSSTransition } from 'react-transition-group'
 import { Check } from '@nutui/icons-react'
 import { Overlay } from '../overlay/overlay'
-
+import useClickAway from '@/utils/use-click-away'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 
 export interface OptionItem {
@@ -36,7 +38,6 @@ const defaultProps = {
   columns: 1,
   direction: 'down',
   icon: null,
-  closeOnClickAway: false,
   activeTitleClass: '',
   inactiveTitleClass: '',
   onChange: (value: OptionItem) => undefined,
@@ -70,9 +71,6 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
   useEffect(() => {
     setShowPopup(show)
   }, [show])
-  useEffect(() => {
-    getParentOffset()
-  }, [_showPopup])
 
   useImperativeHandle<any, any>(ref, () => ({
     toggle: parent.toggleMenuItem,
@@ -95,59 +93,43 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     setValue(item.value)
     onChange && onChange(item)
   }
-  const [position, setPosition] = useState<{ top: number; height: number }>({
-    top: 0,
-    height: 0,
-  })
-  const getParentOffset = () => {
-    setTimeout(() => {
-      const p = parent.menuRef.current
-      const rect = p.getBoundingClientRect()
-      setPosition({
-        height: rect.height,
-        top: rect.top,
-      })
-    })
-  }
+
   const isShow = () => {
     if (_showPopup) return {}
     return { display: 'none' }
   }
 
-  const getPosition = () => {
+  const getPosition = (): CSSProperties => {
     return direction === 'down'
-      ? { top: `${position.top + position.height}px` }
-      : { bottom: `${window.innerHeight - position.top}px`, top: 'auto' }
+      ? { position: 'absolute', height: `${window.innerHeight}px` }
+      : {
+          position: 'absolute',
+          bottom: '100%',
+          top: 'auto',
+          height: `${window.innerHeight}px`,
+        }
   }
 
-  const placeholderStyle = () => {
-    if (direction === 'down') {
-      return {
-        height: `${position.top + position.height}px`,
-        top: 0,
-        ...isShow(),
-      }
-    }
-    return {
-      height: `${window.innerHeight - position.top}px`,
-      bottom: `0px`,
-      top: 'auto',
-      ...isShow(),
-    }
-  }
+  const micRef = useRef<HTMLDivElement>(null)
+  const targetSet = [micRef.current]
+  useClickAway(
+    () => {
+      parent.hideMenuItem(index)
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    targetSet,
+    'click',
+    _showPopup,
+    closeOnClickAway
+  )
 
   return (
-    <>
-      {closeOnClickAway ? (
-        <div
-          className={`placeholder-element ${classNames({
-            up: direction === 'up',
-          })}`}
-          style={placeholderStyle()}
-          onClick={() => parent.toggleMenuItem(index)}
-        />
-      ) : null}
-
+    <div
+      className="nut-menu-item-container"
+      ref={micRef}
+      style={{ position: 'absolute', left: 0, right: 0 }}
+    >
       <Overlay
         className="nut-menu__overlay"
         style={getPosition()}
@@ -174,7 +156,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
           classNames={direction === 'down' ? 'menu-item' : 'menu-item-up'}
         >
           <div className="nut-menu-item__content">
-            {options?.map((item: any, index: any) => {
+            {options?.map((item: any) => {
               return (
                 <div
                   className={`nut-menu-item__option ${classNames({
@@ -213,7 +195,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
           </div>
         </CSSTransition>
       </div>
-    </>
+    </div>
   )
 })
 

--- a/src/utils/use-click-away.ts
+++ b/src/utils/use-click-away.ts
@@ -42,9 +42,9 @@ export default function useClickAway(
 
   useEffect(() => {
     if (isListener) {
-      window.addEventListener(eventName, handler, true)
+      window.addEventListener(eventName, handler, false)
     } else {
-      window.removeEventListener(eventName, handler, true)
+      window.removeEventListener(eventName, handler, false)
     }
 
     return () => {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？


- [x] 日常 bug 修复

### 🔗 相关 Issue



### 💡 需求背景和解决方案

在被使用 transform 布局的组件中嵌套 Menu 组件，会导致 Menu 组件的遮罩层偏移。主要是因为遮罩层的 position 采用的是 fixed 。由于开发者并不一定在整个页面最外层使用 Menu，所以不可避免会出现上述嵌套情况的发生。

例如：
```tsx
const [options] = useState([
    { text: '全部商品', value: 0 },
    { text: '新款商品', value: 1 },
    { text: '活动商品', value: 2 },
  ])
  const [tab1value, setTab1value] = useState(0);


  return (
    <View>
      <View style={{ width: '100%', height: '500px' }}>
        <Tabs
          value={tab1value}
          onChange={({ paneKey }) => {
            setTab1value(paneKey)
          }}
        >
          <TabPane title="校园">
            <View style={{ height: '500px' }}>
              <Menu>
                <MenuItem options={options} value={0} />
              </Menu>
            </View>
          </TabPane>
          <TabPane title="班级">
            <View style={{ height: '500px' }}>
              <Menu>
                <MenuItem options={options} value={0} />
              </Menu>
            </View>
          </TabPane>
        </Tabs>
      </View>
    </View>
  );
```
![image](https://github.com/jdf2e/nutui-react/assets/12181600/800fcd84-1e9b-429e-a8d6-057914264ba4)
![image](https://github.com/jdf2e/nutui-react/assets/12181600/58c27f45-5c1b-42fa-82bd-b7cfc85d5c77)

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fock仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
