### PR TITLE
fix: menu 组件被使用 transform 的组件嵌套后，遮罩层发生偏移

### DIFF
--- a/src/packages/menuitem/menuitem.scss
+++ b/src/packages/menuitem/menuitem.scss
@@ -67,7 +67,7 @@
 }
 
 .placeholder-element {
-  position: fixed;
+  position: absolute;
   top: -$menu-bar-line-height;
   left: 0;
   right: 0;

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -1,4 +1,5 @@
 import React, {
+  CSSProperties,
   forwardRef,
   useEffect,
   useImperativeHandle,
@@ -6,7 +7,7 @@ import React, {
 } from 'react'
 import classNames from 'classnames'
 import { CSSTransition } from 'react-transition-group'
-import { useConfig } from '@/packages/configprovider/configprovider.taro'
+import { getSystemInfoSync } from '@tarojs/taro'
 import Icon from '@/packages/icon/index.taro'
 import { Overlay } from '../overlay/overlay.taro'
 
@@ -49,7 +50,6 @@ const defaultProps = {
   onChange: (value: OptionItem) => undefined,
 } as MenuItemProps
 export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
-  const { locale } = useConfig()
   const mergedProps = { ...defaultProps, ...props }
   const {
     style,
@@ -120,30 +120,39 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     return { display: 'none' }
   }
 
-  const getPosition = () => {
+  const getPosition = (): CSSProperties => {
     return direction === 'down'
-      ? { top: `${position.top + position.height}px` }
-      : { bottom: `${window.innerHeight - position.top}px`, top: 'auto' }
+      ? { position: 'absolute', height: `${window.innerHeight}px` }
+      : {
+          position: 'absolute',
+          bottom: '100%',
+          top: 'auto',
+          height: `${window.innerHeight}px`,
+        }
   }
 
   const placeholderStyle = () => {
     if (direction === 'down') {
       return {
         height: `${position.top + position.height}px`,
+        top: 'auto',
+        bottom: '-100%',
         ...isShow(),
-        ...style,
       }
     }
     return {
-      height: `${window.innerHeight - position.top}px`,
-      top: 'auto',
+      height: `${getSystemInfoSync().windowHeight - position.top}px`,
+      bottom: `auto`,
+      top: '0',
       ...isShow(),
-      ...style,
     }
   }
 
   return (
-    <>
+    <div
+      className="nut-menu-item-container"
+      style={{ position: 'absolute', left: 0, right: 0 }}
+    >
       <div
         className={`placeholder-element ${classNames({
           up: direction === 'up',
@@ -216,7 +225,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
           </div>
         </CSSTransition>
       </div>
-    </>
+    </div>
   )
 })
 

--- a/src/packages/menuitem/menuitem.tsx
+++ b/src/packages/menuitem/menuitem.tsx
@@ -1,4 +1,5 @@
 import React, {
+  CSSProperties,
   forwardRef,
   useEffect,
   useImperativeHandle,
@@ -118,30 +119,41 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     return { display: 'none' }
   }
 
-  const getPosition = () => {
+  const getPosition = (): CSSProperties => {
     return direction === 'down'
-      ? { top: `${position.top + position.height}px` }
-      : { bottom: `${window.innerHeight - position.top}px`, top: 'auto' }
+      ? { position: 'absolute', height: `${window.innerHeight}px` }
+      : {
+          position: 'absolute',
+          bottom: '100%',
+          top: 'auto',
+          height: `${window.innerHeight}px`,
+        }
   }
 
   const placeholderStyle = () => {
     if (direction === 'down') {
       return {
         height: `${position.top + position.height}px`,
+        top: 'auto',
+        bottom: '-100%',
         ...isShow(),
         ...style,
       }
     }
     return {
       height: `${window.innerHeight - position.top}px`,
-      top: 'auto',
+      bottom: `auto`,
+      top: '0',
       ...isShow(),
       ...style,
     }
   }
 
   return (
-    <>
+    <div
+      className="nut-menu-item-container"
+      style={{ position: 'absolute', left: 0, right: 0 }}
+    >
       <div
         className={`placeholder-element ${classNames({
           up: direction === 'up',
@@ -214,7 +226,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
           </div>
         </CSSTransition>
       </div>
-    </>
+    </div>
   )
 })
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1786,7 +1786,7 @@ $menu-bar-border-bottom-color: var(
   --nutui-menu-bar-border-bottom-color,
   #eaf0fb
 ) !default;
-$menu-bar-opened-z-index: var(--nutui-menu-bar-opened-z-index, 2001) !default;
+$menu-bar-opened-z-index: var(--nutui-menu-bar-opened-z-index, 2054) !default;
 $menu-item-disabled-color: var(
   --nutui-menu-item-disabled-color,
   #969799


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？


- [x] 日常 bug 修复

### 🔗 相关 Issue



### 💡 需求背景和解决方案

在被使用 transform 布局的组件中嵌套 Menu 组件，会导致 Menu 组件的遮罩层偏移。主要是因为遮罩层的 position 采用的是 fixed 。由于开发者并不一定在整个页面最外层使用 Menu，所以不可避免会出现上述嵌套情况的发生。

例如：
```tsx
const [options] = useState([
    { text: '全部商品', value: 0 },
    { text: '新款商品', value: 1 },
    { text: '活动商品', value: 2 },
  ])
  const [tab1value, setTab1value] = useState(0);


  return (
    <View>
      <View style={{ width: '100%', height: '500px' }}>
        <Tabs
          value={tab1value}
          onChange={({ paneKey }) => {
            setTab1value(paneKey)
          }}
        >
          <TabPane title="校园">
            <View style={{ height: '500px' }}>
              <Menu>
                <MenuItem options={options} value={0} />
              </Menu>
            </View>
          </TabPane>
          <TabPane title="班级">
            <View style={{ height: '500px' }}>
              <Menu>
                <MenuItem options={options} value={0} />
              </Menu>
            </View>
          </TabPane>
        </Tabs>
      </View>
    </View>
  );
```
![image](https://github.com/jdf2e/nutui-react/assets/12181600/800fcd84-1e9b-429e-a8d6-057914264ba4)
![image](https://github.com/jdf2e/nutui-react/assets/12181600/58c27f45-5c1b-42fa-82bd-b7cfc85d5c77)

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fock仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
