### PR TITLE
feat(MenuItem): 增加MenuItem暴露的实例(status) 能够判断当前菜单是否展开或者关闭

### DIFF
--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -89,6 +89,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
           updateTitle,
           hideMenuItem,
           menuRef,
+          isExistExpandMenuItem: showMenuItem.includes(true),
         },
       })
     })

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -12,6 +12,8 @@ export interface MenuProps extends BasicComponent {
   lockScroll: boolean
   icon: React.ReactNode
   children: React.ReactNode
+  onOpen: () => void
+  onClose: () => void
 }
 
 const defaultProps = {
@@ -21,6 +23,8 @@ const defaultProps = {
   scrollFixed: false,
   lockScroll: true,
   icon: null,
+  onOpen: () => undefined,
+  onClose: () => undefined,
 } as MenuProps
 export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
   const {
@@ -31,6 +35,8 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
     closeOnOverlayClick,
     children,
     activeColor,
+    onOpen,
+    onClose,
     ...rest
   } = {
     ...defaultProps,
@@ -38,6 +44,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
   }
   const menuRef = useRef(null)
   const [isScrollFixed, setIsScrollFixed] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
 
   const getScrollTop = (el: Element | Window) => {
     return Math.max(0, 'scrollTop' in el ? el.scrollTop : el.pageYOffset)
@@ -67,6 +74,12 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
     )
     setShowMenuItem([...temp])
   }
+  const toggleMenuItemCallback = () => {
+    const status = showMenuItem.includes(true)
+    if (status !== isOpen) {
+      status ? (setIsOpen(true), onOpen()) : (setIsOpen(false), onClose())
+    }
+  }
   const hideMenuItem = (index: number) => {
     showMenuItem[index] = false
     setShowMenuItem([...showMenuItem])
@@ -89,7 +102,6 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
           updateTitle,
           hideMenuItem,
           menuRef,
-          isExistExpandMenuItem: showMenuItem.includes(true),
         },
       })
     })
@@ -118,7 +130,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
             style={{ color: showMenuItem[index] ? activeColor : '' }}
             key={index}
             onClick={() => {
-              !disabled && toggleMenuItem(index)
+              !disabled && (toggleMenuItem(index), toggleMenuItemCallback())
             }}
           >
             <div

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -102,6 +102,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
           updateTitle,
           hideMenuItem,
           menuRef,
+          toggleMenuItemCallback,
         },
       })
     })

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -78,7 +78,6 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
 
   useImperativeHandle<any, any>(ref, () => ({
     toggle: parent.toggleMenuItem,
-    status: parent.isExistExpandMenuItem,
   }))
 
   const getIconCName = (optionVal: string | number, value: string | number) => {

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -78,6 +78,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
 
   useImperativeHandle<any, any>(ref, () => ({
     toggle: parent.toggleMenuItem,
+    status: parent.isExistExpandMenuItem,
   }))
 
   const getIconCName = (optionVal: string | number, value: string | number) => {

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -166,7 +166,8 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
         visible={_showPopup}
         closeOnOverlayClick={parent.closeOnOverlayClick}
         onClick={() => {
-          parent.closeOnOverlayClick && parent.toggleMenuItem(index)
+          parent.closeOnOverlayClick &&
+            (parent.toggleMenuItem(index), parent.toggleMenuItemCallback())
         }}
       />
       <div


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [✔️] 新特性提交
- [✔️] 功能增强

### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/1115

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [✔️] fock仓库代码是否为最新避免文件冲突
- [✔️] Files changed 没有 package.json lock 等无关文件
