### PR TITLE
fix: 修复inputnumber-v2.0在taro H5样式失效的问题

### DIFF
--- a/src/packages/inputnumber/inputnumber.scss
+++ b/src/packages/inputnumber/inputnumber.scss
@@ -52,12 +52,14 @@
   }
 }
 
-.icon-minus {
+.nut-icon-Minus,
+.nut-icon-minus {
   --nut-icon-width: 20px;
   --nut-icon-height: 20px;
 }
 
-.icon-plus {
+.nut-icon-Plus,
+.nut-icon-plus {
   --nut-icon-width: 20px;
   --nut-icon-height: 20px;
 }

--- a/src/packages/inputnumber/inputnumber.taro.tsx
+++ b/src/packages/inputnumber/inputnumber.taro.tsx
@@ -266,6 +266,7 @@ export const InputNumber: FunctionComponent<
       <>
         {formatter ? (
           <input
+            className="nut-number-input"
             type="text"
             min={min}
             max={max}
@@ -278,6 +279,7 @@ export const InputNumber: FunctionComponent<
           />
         ) : (
           <input
+            className="nut-number-input"
             type="digit"
             min={min}
             max={max}


### PR DESCRIPTION
修复inputnumber-v2.0在taro H5样式失效的问题