### PR TITLE
fix: 修复toast组件屏幕锁定不能滚动的问题

### DIFF
--- a/migrate-from-v1.md
+++ b/migrate-from-v1.md
@@ -412,6 +412,7 @@ plugins: [
 - 删除 `loadingRotate`，旋转状态通过 `iconFont`实现
 - 删除 `textAlignCenter`，通过css变量实现
 - 修改 `closeOnClickOverlay` 为 `closeOnOverlayClick` ，语义不变，是否在点击遮罩层后关闭提示
+- 新增 `lockScroll` ，用于背景是否锁定，默认值为 `false`
 
 ### 展示组件
 #### Animate

--- a/src/packages/toast/Notification.tsx
+++ b/src/packages/toast/Notification.tsx
@@ -14,6 +14,7 @@ export interface NotificationProps extends BasicComponent {
   title: string
   size: string | number
   closeOnOverlayClick: boolean
+  lockScroll: boolean
   contentClassName?: string
   contentStyle?: React.CSSProperties
   onClose: () => void
@@ -119,6 +120,7 @@ export default class Notification extends React.PureComponent<
       position,
       size,
       closeOnOverlayClick,
+      lockScroll,
       style,
       className,
       contentClassName,
@@ -141,6 +143,7 @@ export default class Notification extends React.PureComponent<
             this.clickCover()
           }}
           closeOnOverlayClick={closeOnOverlayClick}
+          lockScroll={lockScroll}
         >
           <div className={`${classPrefix} ${classes}`} id={`toast-${id}`}>
             <div

--- a/src/packages/toast/doc.en-US.md
+++ b/src/packages/toast/doc.en-US.md
@@ -344,6 +344,7 @@ export default App
 | contentClassName | Toast content class name | `string` | `-` |
 | contentStyle | Toast content style | `React.CSSProperties` | `-` |
 | closeOnOverlayClick | Whether to close when overlay is clicked | `boolean` | `false` |
+| lockScroll | Whether the background is locked | `boolean` | `false` |
 | onClose | Callback function after close | `() => void` | `null` |
 
 `Toast` only supports Imperative calls.

--- a/src/packages/toast/doc.en-US.md
+++ b/src/packages/toast/doc.en-US.md
@@ -356,7 +356,7 @@ You can also pass in a string directly, and `Toast.show` will automatically use 
 | Property | Description | Parameters |
 | --- | --- | --- |
 | clear | Turn off `Toast` in all displays. | `-`|
-| config | Methods for global configuration | `{ duration: number, position: 'top' \| 'center' \| 'bottom', closeOnOverlayClick: boolean }` |
+| config | Methods for global configuration | `{ duration: number, position: 'top' \| 'center' \| 'bottom', closeOnOverlayClick: boolean, lockScroll: boolean }` |
 
 ## Theming
 

--- a/src/packages/toast/doc.md
+++ b/src/packages/toast/doc.md
@@ -343,6 +343,7 @@ export default App
 | contentClassName | 自定义内容区类名 | `string` | `-` |
 | contentStyle | 自定义内容区样式 | `React.CSSProperties` | `-` |
 | closeOnOverlayClick | 是否在点击遮罩层后关闭提示 | `boolean` | `false` |
+| lockScroll | 背景是否锁定 | `boolean` | `false` |
 | onClose | 关闭时触发的事件 | `() => void` | `() => void` |
 
 `Toast`只支持指令式调用

--- a/src/packages/toast/doc.md
+++ b/src/packages/toast/doc.md
@@ -355,7 +355,7 @@ export default App
 | 方法名 | 说明 | 参数 |
 | --- | --- | --- |
 | clear | 关闭所有显示中的`Toast` | `-` |
-| config | `Toast`全局配置 | `{ duration: number, position: 'top' \| 'center' \| 'bottom', closeOnOverlayClick: boolean }` |
+| config | `Toast`全局配置 | `{ duration: number, position: 'top' \| 'center' \| 'bottom', closeOnOverlayClick: boolean, lockScroll: boolean }` |
 
 ## 主题定制
 

--- a/src/packages/toast/doc.taro.md
+++ b/src/packages/toast/doc.taro.md
@@ -163,6 +163,7 @@ export default App
 | icon | 自定义图标，对应icon组件，支持图片链接 | `string` | `-` |
 | size | 文案尺寸，三选一 | `small` \| `base` \| `large` | `base` |
 | closeOnOverlayClick | 是否在点击遮罩层后关闭提示 | `boolean` | `false` |
+| lockScroll | 背景是否锁定 | `boolean` | `false` |
 | type | 弹框类型 可选值（text、success、fail、warn、loading） | `string` | `-` |
 | visible | 弹窗是否显示开关 | `boolean` | `false` |
 | onClose | 关闭时触发的事件 | `Function` | `null` |

--- a/src/packages/toast/toast.taro.tsx
+++ b/src/packages/toast/toast.taro.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
 import classNames from 'classnames'
 import { Failure, Loading, Success, Tips } from '@nutui/icons-react-taro'
-import Overlay from '@/packages/overlay/index'
+import Overlay from '@/packages/overlay/index.taro'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 
 export type ToastPositionType = 'top' | 'bottom' | 'center'
@@ -19,6 +19,7 @@ export interface ToastProps extends BasicComponent {
   type: string
   title: string
   closeOnOverlayClick: boolean
+  lockScroll: boolean
   size: string | number
   visible: boolean
   onClose: () => void
@@ -35,6 +36,7 @@ const defaultProps = {
   type: 'text',
   title: '',
   closeOnOverlayClick: false,
+  lockScroll: false,
   contentClassName: '', // 内容自定义样式名
   size: 'base', // 设置字体大小，默认base,可选large\small\base
   visible: false,
@@ -59,6 +61,7 @@ export const Toast: FunctionComponent<
     type,
     title,
     closeOnOverlayClick,
+    lockScroll,
     contentClassName,
     size,
     visible,
@@ -135,6 +138,7 @@ export const Toast: FunctionComponent<
           style={style}
           className={`${classPrefix}__overlay-default ${className}`}
           closeOnOverlayClick={closeOnOverlayClick}
+          lockScroll={lockScroll}
           onClick={() => {
             clickCover()
           }}

--- a/src/packages/toast/toast.tsx
+++ b/src/packages/toast/toast.tsx
@@ -86,7 +86,10 @@ function show(option: ToastProps | string) {
 }
 
 function config(
-  config: Pick<ToastProps, 'duration' | 'position' | 'closeOnOverlayClick'>
+  config: Pick<
+    ToastProps,
+    'duration' | 'position' | 'closeOnOverlayClick' | 'lockScroll'
+  >
 ) {
   if (config.duration !== undefined) {
     options.duration = config.duration
@@ -96,6 +99,9 @@ function config(
   }
   if (config.closeOnOverlayClick !== undefined) {
     options.closeOnOverlayClick = config.closeOnOverlayClick
+  }
+  if (config.lockScroll !== undefined) {
+    options.lockScroll = config.lockScroll
   }
 }
 

--- a/src/packages/toast/toast.tsx
+++ b/src/packages/toast/toast.tsx
@@ -18,6 +18,7 @@ export interface ToastProps extends BasicComponent {
   position?: ToastPositionType
   title?: string
   closeOnOverlayClick?: boolean
+  lockScroll?: boolean
   size?: string | number
   icon?: ToastIconType
   content?: React.ReactNode
@@ -36,6 +37,7 @@ const options: ToastProps = {
   icon: null,
   onClose: () => {},
   closeOnOverlayClick: false, // 是否点击遮罩可关闭
+  lockScroll: false,
   contentClassName: '',
 }
 


### PR DESCRIPTION
问题现状：toast弹出，屏幕是不能滑动的，无法适配屏幕要滑动的场景
问题修复：新增lockScroll属性透传到overlay组件，实现屏幕可滑动功能
