### PR TITLE
refactor: 调整 MenuItem CellGroup SwiperItem 使用方式为 Menu.Item Cell.Group…

### DIFF
--- a/src/packages/avatar/avatar.taro.tsx
+++ b/src/packages/avatar/avatar.taro.tsx
@@ -10,8 +10,8 @@ import classNames from 'classnames'
 import { My } from '@nutui/icons-react-taro'
 import Image from '@/packages/image/index.taro'
 import { AvatarContext } from '@/packages/avatargroup/context'
-
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+import AvatarGroup from '@/packages/avatargroup/index.taro'
 
 export interface AvatarProps extends BasicComponent {
   size: string
@@ -43,7 +43,7 @@ const defaultProps = {
 const classPrefix = `nut-avatar`
 export const Avatar: FunctionComponent<
   Partial<AvatarProps> & Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>
-> = (props) => {
+> & { Group: typeof AvatarGroup } = (props) => {
   const {
     children,
     size,
@@ -189,3 +189,4 @@ export const Avatar: FunctionComponent<
 
 Avatar.defaultProps = defaultProps
 Avatar.displayName = 'NutAvatar'
+Avatar.Group = AvatarGroup

--- a/src/packages/avatar/avatar.tsx
+++ b/src/packages/avatar/avatar.tsx
@@ -10,8 +10,8 @@ import classNames from 'classnames'
 import { My } from '@nutui/icons-react'
 import { AvatarContext } from '@/packages/avatargroup/context'
 import Image from '@/packages/image'
-
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+import AvatarGroup from '@/packages/avatargroup'
 
 export interface AvatarProps extends BasicComponent {
   size: string
@@ -43,7 +43,7 @@ const defaultProps = {
 const classPrefix = `nut-avatar`
 export const Avatar: FunctionComponent<
   Partial<AvatarProps> & Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>
-> = (props) => {
+> & { Group: typeof AvatarGroup } = (props) => {
   const {
     children,
     size,
@@ -188,3 +188,4 @@ export const Avatar: FunctionComponent<
 
 Avatar.defaultProps = defaultProps
 Avatar.displayName = 'NutAvatar'
+Avatar.Group = AvatarGroup

--- a/src/packages/avatar/demo.taro.tsx
+++ b/src/packages/avatar/demo.taro.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Taro from '@tarojs/taro'
 import { My } from '@nutui/icons-react-taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import { Cell, Badge, Avatar, AvatarGroup } from '@/packages/nutui.react.taro'
+import { Cell, Badge, Avatar } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 import '@/packages/avatar/demo.scss'
 
@@ -118,35 +118,35 @@ const AvatarDemo = () => {
         </Cell>
         <h2>{translated.e981579e}</h2>
         <Cell>
-          <AvatarGroup gap="-4">
+          <Avatar.Group gap="-4">
             <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
             <Avatar icon={<My />} />
             <Avatar color="rgb(245, 106, 0)" bg-color="rgb(253, 227, 207)">
               U
             </Avatar>
-          </AvatarGroup>
+          </Avatar.Group>
         </Cell>
 
         <Cell>
-          <AvatarGroup max="3" maxColor="#fff" maxBackground="#498ff2">
+          <Avatar.Group max="3" maxColor="#fff" maxBackground="#498ff2">
             <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
             <Avatar icon={<My />} />
             <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
               U
             </Avatar>
             <Avatar icon={<My />} />
-          </AvatarGroup>
+          </Avatar.Group>
         </Cell>
         <h2>{translated.f645fc65}</h2>
         <Cell>
-          <AvatarGroup max="3" level="right" maxContent="...">
+          <Avatar.Group max="3" level="right" maxContent="...">
             <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
             <Avatar icon={<My />} />
             <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
               U
             </Avatar>
             <Avatar icon={<My />} />
-          </AvatarGroup>
+          </Avatar.Group>
         </Cell>
         <h2>{translated['43f00872']}</h2>
         <Cell>

--- a/src/packages/avatar/demo.tsx
+++ b/src/packages/avatar/demo.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from '../../sites/assets/locale'
 import { Avatar } from './avatar'
 import Cell from '@/packages/cell'
 import Badge from '@/packages/badge'
-import AvatarGroup from '@/packages/avatargroup'
 import Toast from '@/packages/toast'
 import './demo.scss'
 
@@ -115,35 +114,35 @@ const AvatarDemo = () => {
         </Cell>
         <h2>{translated.e981579e}</h2>
         <Cell>
-          <AvatarGroup gap="-4">
+          <Avatar.Group gap="-4">
             <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
             <Avatar icon={<My />} />
             <Avatar color="rgb(245, 106, 0)" bg-color="rgb(253, 227, 207)">
               U
             </Avatar>
-          </AvatarGroup>
+          </Avatar.Group>
         </Cell>
 
         <Cell>
-          <AvatarGroup max="3" maxColor="#fff" maxBackground="#498ff2">
+          <Avatar.Group max="3" maxColor="#fff" maxBackground="#498ff2">
             <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
             <Avatar icon={<My />} />
             <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
               U
             </Avatar>
             <Avatar icon={<My />} />
-          </AvatarGroup>
+          </Avatar.Group>
         </Cell>
         <h2>{translated.f645fc65}</h2>
         <Cell>
-          <AvatarGroup max="3" level="right" maxContent="...">
+          <Avatar.Group max="3" level="right" maxContent="...">
             <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
             <Avatar icon={<My />} />
             <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
               U
             </Avatar>
             <Avatar icon={<My />} />
-          </AvatarGroup>
+          </Avatar.Group>
         </Cell>
         <h2>{translated['43f00872']}</h2>
         <Cell>

--- a/src/packages/avatar/doc.en-US.md
+++ b/src/packages/avatar/doc.en-US.md
@@ -155,28 +155,28 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react';
+import { Avatar } from '@nutui/nutui-react';
 import { My } from '@nutui/icons-react';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup gap="-4">
+      <Avatar.Group gap="-4">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
-      </AvatarGroup>
+      </Avatar.Group>
 
-      <AvatarGroup max="3" maxColor="#fff" maxBackground="#498ff2">
+      <Avatar.Group max="3" maxColor="#fff" maxBackground="#498ff2">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -191,20 +191,20 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react';
+import { Avatar } from '@nutui/nutui-react';
 import { My } from '@nutui/icons-react';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup max="3" level="right" maxContent="...">
+      <Avatar.Group max="3" level="right" maxContent="...">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -254,7 +254,7 @@ export default App;
 | onClick | Emitted when cell is clicked | `(e: MouseEvent) => void` | `-` |
 | onError | Handler when img load error | `() => void` | `-` |
 
-## AvatarGroup
+## Avatar.Group
 
 ### Props
 

--- a/src/packages/avatar/doc.md
+++ b/src/packages/avatar/doc.md
@@ -158,28 +158,28 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react';
+import { Avatar } from '@nutui/nutui-react';
 import { My } from '@nutui/icons-react';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup gap="-4">
+      <Avatar.Group gap="-4">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" bg-color="rgb(253, 227, 207)">
           U
         </Avatar>
-      </AvatarGroup>
+      </Avatar.Group>
 
-      <AvatarGroup max="3" maxColor="#fff" maxBackground="#498ff2">
+      <Avatar.Group max="3" maxColor="#fff" maxBackground="#498ff2">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -194,20 +194,20 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react';
+import { Avatar } from '@nutui/nutui-react';
 import { My } from '@nutui/icons-react';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup max="3" level="right" maxContent="...">
+      <Avatar.Group max="3" level="right" maxContent="...">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -257,7 +257,7 @@ export default App;
 | onClick | 点击头像触发事件 | `(e: MouseEvent) => void` | `-` |
 | onError | 图片加载失败的事件 | `() => void` | `-` |
 
-## AvatarGroup
+## Avatar.Group
 
 ### Props
 

--- a/src/packages/avatar/doc.taro.md
+++ b/src/packages/avatar/doc.taro.md
@@ -155,28 +155,28 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react-taro';
+import { Avatar } from '@nutui/nutui-react-taro';
 import { My } from '@nutui/icons-react-taro';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup gap="-4">
+      <Avatar.Group gap="-4">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" bg-color="rgb(253, 227, 207)">
           U
         </Avatar>
-      </AvatarGroup>
+      </Avatar.Group>
 
-      <AvatarGroup max="3" maxColor="#fff" maxBackground="#498ff2">
+      <Avatar.Group max="3" maxColor="#fff" maxBackground="#498ff2">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -191,20 +191,20 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react-taro';
+import { Avatar } from '@nutui/nutui-react-taro';
 import { My } from '@nutui/icons-react-taro';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup max="3" level="right" maxContent="...">
+      <Avatar.Group max="3" level="right" maxContent="...">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -254,7 +254,7 @@ export default App;
 | onClick | 点击头像触发事件 | `(e: MouseEvent) => void` | `-` |
 | onError | 图片加载失败的事件 | `() => void` | `-` |
 
-## AvatarGroup
+## Avatar.Group
 
 ### Props
 

--- a/src/packages/avatar/doc.zh-TW.md
+++ b/src/packages/avatar/doc.zh-TW.md
@@ -158,28 +158,28 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react';
+import { Avatar } from '@nutui/nutui-react';
 import { My } from '@nutui/icons-react';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup gap="-4">
+      <Avatar.Group gap="-4">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" bg-color="rgb(253, 227, 207)">
           U
         </Avatar>
-      </AvatarGroup>
+      </Avatar.Group>
 
-      <AvatarGroup max="3" maxColor="#fff" maxBackground="#498ff2">
+      <Avatar.Group max="3" maxColor="#fff" maxBackground="#498ff2">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -194,20 +194,20 @@ export default App;
 
 ```tsx
 import React from "react";
-import { Avatar, AvatarGroup } from '@nutui/nutui-react';
+import { Avatar } from '@nutui/nutui-react';
 import { My } from '@nutui/icons-react';
 
 const App = () => {
   return (
     <>
-      <AvatarGroup max="3" level="right" maxContent="...">
+      <Avatar.Group max="3" level="right" maxContent="...">
         <Avatar src="https://img12.360buyimg.com/imagetools/jfs/t1/196430/38/8105/14329/60c806a4Ed506298a/e6de9fb7b8490f38.png" />
         <Avatar icon={<My />} />
         <Avatar color="rgb(245, 106, 0)" background="rgb(253, 227, 207)">
           U
         </Avatar>
         <Avatar icon={<My />} />
-      </AvatarGroup>
+      </Avatar.Group>
     </>
   )
 }
@@ -257,7 +257,7 @@ export default App;
 | onClick | 點擊頭像觸發事件 | `(e: MouseEvent) => void` | `-` |
 | onError | 圖片加載失敗的事件 | `() => void` | `-` |
 
-## AvatarGroup
+## Avatar.Group
 
 ### Props
 

--- a/src/packages/badge/demo.taro.tsx
+++ b/src/packages/badge/demo.taro.tsx
@@ -11,7 +11,6 @@ import {
   Avatar,
   Badge,
   Cell,
-  CellGroup,
   ConfigProvider,
 } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
@@ -69,7 +68,7 @@ const BadgeDemo = () => {
       <Header />
       <div className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
         <h2>{translated['8ab98966']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge style={{ marginRight: '40px' }} value={8}>
               <Avatar icon={<My />} shape="square" />
@@ -84,10 +83,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['1e7a2282']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge style={{ marginRight: '40px' }} value={200} max={9}>
               <Avatar icon={<My />} shape="square" />
@@ -99,10 +98,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['781b07fd']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge
               style={{ marginRight: '40px' }}
@@ -133,10 +132,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['1c730245']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge
               style={{ marginRight: '40px' }}
@@ -157,10 +156,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['1c730248']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <ConfigProvider theme={customTheme}>
               <Badge style={{ marginRight: '40px' }} value="NEW">
@@ -174,10 +173,10 @@ const BadgeDemo = () => {
               </Badge>
             </ConfigProvider>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['915d7b01']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge style={{ marginRight: '40px' }} value={8} top="5" right="5">
               <Avatar icon={<My />} shape="square" />
@@ -194,16 +193,16 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated.f1089312}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell style={{ height: '80px' }}>
             <Badge style={{ marginRight: '40px' }} value={8} />
             <Badge style={{ marginRight: '40px' }} value={76} />
             <Badge style={{ marginRight: '40px' }} value="NEW" />
           </Cell>
-        </CellGroup>
+        </Cell.Group>
       </div>
     </>
   )

--- a/src/packages/badge/demo.tsx
+++ b/src/packages/badge/demo.tsx
@@ -3,7 +3,6 @@ import { Checklist, Link as LinkIcon, Download, My } from '@nutui/icons-react'
 import { useTranslate } from '../../sites/assets/locale'
 import { Badge } from './badge'
 import Cell from '@/packages/cell'
-import CellGroup from '@/packages/cellgroup'
 import Avatar from '@/packages/avatar'
 import ConfigProvider from '@/packages/configprovider'
 
@@ -61,7 +60,7 @@ const BadgeDemo = () => {
     <>
       <div className="demo">
         <h2>{translated['8ab98966']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge style={{ marginRight: '40px' }} value={8}>
               <Avatar icon={<My />} shape="square" />
@@ -76,10 +75,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['1e7a2282']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge style={{ marginRight: '40px' }} value={200} max={9}>
               <Avatar icon={<My />} shape="square" />
@@ -91,10 +90,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['781b07fd']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge
               style={{ marginRight: '40px' }}
@@ -125,10 +124,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['1c730245']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge
               style={{ marginRight: '40px' }}
@@ -149,10 +148,10 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['1c730248']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <ConfigProvider theme={customTheme}>
               <Badge style={{ marginRight: '40px' }} value="NEW">
@@ -166,10 +165,10 @@ const BadgeDemo = () => {
               </Badge>
             </ConfigProvider>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated['915d7b01']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Badge style={{ marginRight: '40px' }} value={8} top="5" right="5">
               <Avatar icon={<My />} shape="square" />
@@ -186,16 +185,16 @@ const BadgeDemo = () => {
               <Avatar icon={<My />} shape="square" />
             </Badge>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated.f1089312}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell style={{ height: '80px' }}>
             <Badge style={{ marginRight: '40px' }} value={8} />
             <Badge style={{ marginRight: '40px' }} value={76} />
             <Badge style={{ marginRight: '40px' }} value="NEW" />
           </Cell>
-        </CellGroup>
+        </Cell.Group>
       </div>
     </>
   )

--- a/src/packages/cell/cell.scss
+++ b/src/packages/cell/cell.scss
@@ -1,3 +1,5 @@
+@import '../cellgroup/cellgroup.scss';
+
 .nut-cell {
   position: relative;
   display: flex;
@@ -11,6 +13,7 @@
   color: $cell-title-color;
   margin: 10px 0;
   box-sizing: border-box;
+
   &__left {
     display: flex;
     flex-direction: column;

--- a/src/packages/cell/cell.taro.tsx
+++ b/src/packages/cell/cell.taro.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, ReactNode } from 'react'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+import { CellGroup } from '@/packages/cellgroup/cellgroup.taro'
 
 export interface CellProps extends BasicComponent {
   title: ReactNode
@@ -25,7 +26,7 @@ const classPrefix = 'nut-cell'
 
 export const Cell: FunctionComponent<
   Partial<CellProps> & Omit<React.HTMLAttributes<HTMLDivElement>, 'title'>
-> = (props) => {
+> & { Group: typeof CellGroup } = (props) => {
   const {
     children,
     onClick,
@@ -96,3 +97,4 @@ export const Cell: FunctionComponent<
 
 Cell.defaultProps = defaultProps
 Cell.displayName = 'NutCell'
+Cell.Group = CellGroup

--- a/src/packages/cell/cell.tsx
+++ b/src/packages/cell/cell.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, ReactNode } from 'react'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+import CellGroup from '@/packages/cellgroup'
 
 export interface CellProps extends BasicComponent {
   title: ReactNode
@@ -25,7 +26,7 @@ const classPrefix = 'nut-cell'
 
 export const Cell: FunctionComponent<
   Partial<CellProps> & Omit<React.HTMLAttributes<HTMLDivElement>, 'title'>
-> = (props) => {
+> & { Group: typeof CellGroup } = (props) => {
   const {
     children,
     onClick,
@@ -96,3 +97,4 @@ export const Cell: FunctionComponent<
 
 Cell.defaultProps = defaultProps
 Cell.displayName = 'NutCell'
+Cell.Group = CellGroup

--- a/src/packages/cell/demo.taro.tsx
+++ b/src/packages/cell/demo.taro.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { My, Right } from '@nutui/icons-react-taro'
 import Taro, { redirectTo, navigateTo } from '@tarojs/taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import { Switch, Cell, CellGroup } from '@/packages/nutui.react.taro'
+import { Switch, Cell } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 import '@/packages/cell/demo.scss'
 
@@ -74,7 +74,7 @@ const CellDemo = () => {
       title1: 'Description',
       title2: 'Click Test',
       title3: 'Round Radius 0',
-      title4: 'Link | CellGroup Usage',
+      title4: 'Link | Cell.Group Usage',
       title5: 'Vertical Center',
       title6: 'Customize the title area',
       title7: 'Grouping usage',
@@ -141,9 +141,9 @@ const CellDemo = () => {
           }
           extra={translated.extra}
         />
-        <CellGroup title={translated.customRight}>
+        <Cell.Group title={translated.customRight}>
           <Cell title="Switch" extra={<Switch defaultChecked />} />
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.title5}</h2>
         <Cell
           align="center"
@@ -151,7 +151,7 @@ const CellDemo = () => {
           description={translated.title1}
           extra={translated.extra}
         />
-        <CellGroup
+        <Cell.Group
           title={translated.title4}
           description={translated.description}
         >
@@ -175,15 +175,15 @@ const CellDemo = () => {
               event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
             ) => onJumpclick(event, '/pages/index/index')}
           />
-        </CellGroup>
-        <CellGroup
+        </Cell.Group>
+        <Cell.Group
           divider={false}
           title={translated.title7}
           description={translated.description1}
         >
           <Cell title={translated.title} extra={translated.extra} />
           <Cell title={translated.title} extra={translated.extra} />
-        </CellGroup>
+        </Cell.Group>
       </div>
     </>
   )

--- a/src/packages/cell/demo.tsx
+++ b/src/packages/cell/demo.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { My, Right } from '@nutui/icons-react'
 import { useTranslate } from '../../sites/assets/locale'
-import { Cell } from './cell'
-import { CellGroup } from '../cellgroup/cellgroup'
+import Cell from './index'
 import { Switch } from '../switch/switch'
 import Toast from '../toast'
 import './demo.scss'
@@ -75,7 +74,7 @@ const CellDemo = () => {
       title1: 'Description',
       title2: 'Click Test',
       title3: 'Round Radius 0',
-      title4: 'Link | CellGroup Usage',
+      title4: 'Link | Cell.Group Usage',
       title5: 'Vertical Center',
       title6: 'Customize the title area',
       title7: 'Grouping usage',
@@ -141,17 +140,16 @@ const CellDemo = () => {
           }
           extra={translated.extra}
         />
-        <CellGroup title={translated.customRight}>
+        <Cell.Group title={translated.customRight}>
           <Cell title="Switch" extra={<Switch defaultChecked />} />
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.title5}</h2>
         <Cell
-          align="center"
           title={translated.title}
           description={translated.title1}
           extra={translated.extra}
         />
-        <CellGroup
+        <Cell.Group
           title={translated.title4}
           description={translated.description}
         >
@@ -171,19 +169,16 @@ const CellDemo = () => {
               </>
             }
             align="center"
-            onClick={(
-              event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
-            ) => onJumpclick(event, 'https://jd.com')}
           />
-        </CellGroup>
-        <CellGroup
+        </Cell.Group>
+        <Cell.Group
           divider={false}
           title={translated.title7}
           description={translated.description1}
         >
           <Cell title={translated.title} extra={translated.extra} />
           <Cell title={translated.title} extra={translated.extra} />
-        </CellGroup>
+        </Cell.Group>
       </div>
     </>
   )

--- a/src/packages/cell/doc.en-US.md
+++ b/src/packages/cell/doc.en-US.md
@@ -7,7 +7,7 @@ The cell is a single display item in the list.
 ## Install
 
 ```tsx
-import { Cell, CellGroup } from '@nutui/nutui-react'
+import { Cell } from '@nutui/nutui-react'
 ```
 
 ## Demo
@@ -101,13 +101,13 @@ export default App
 
 ```tsx
 import React from 'react'
-import { CellGroup, Cell, Switch } from '@nutui/nutui-react'
+import { Cell, Switch } from '@nutui/nutui-react'
 
 const App = () => {
   return (
-    <CellGroup title="Customize the right arrow area">
+    <Cell.Group title="Customize the right arrow area">
       <Cell title="Switch" extra={<Switch defaultChecked />} />
-    </CellGroup>
+    </Cell.Group>
   )
 }
 export default App
@@ -135,13 +135,13 @@ export default App
 
 :::
 
-### Link | CellGroup Usage
+### Link | Cell.Group Usage
 
 :::demo
 
 ```tsx
 import React from 'react'
-import { CellGroup, Cell } from '@nutui/nutui-react'
+import { Cell } from '@nutui/nutui-react'
 import { Right } from '@nutui/icons-react'
 
 const App = () => {
@@ -155,8 +155,8 @@ const App = () => {
     }
   }
   return (
-      <CellGroup
-        title="Link | CellGroup Usage"
+      <Cell.Group
+        title="Link | Cell.Group Usage"
         extra="Usage nut-cell-group support title extra"
       >
         <Cell 
@@ -179,7 +179,7 @@ const App = () => {
             event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
         ) => onJumpclick(event, 'https://jd.com')}
         />
-      </CellGroup>
+      </Cell.Group>
   )
 }
 export default App
@@ -195,18 +195,18 @@ The 'divider' property allows you to keep the lower edge from being displayed be
 
 ```tsx
 import  React from "react"
-import { CellGroup, Cell } from '@nutui/nutui-react'
+import { Cell } from '@nutui/nutui-react'
 
 const App = () => {
   return (
-     <CellGroup
+     <Cell.Group
         divider={false}
         title="Grouping usage"
         description="The bottom edge is not displayed between cells"
     >
         <Cell title="Title" extra="extra" />
         <Cell title="Title" extra="extra" />
-    </CellGroup>
+    </Cell.Group>
   );
 };
 export default App;
@@ -214,7 +214,7 @@ export default App;
 
 :::
 
-## CellGroup
+## Cell.Group
 
 ### Props
 

--- a/src/packages/cell/doc.md
+++ b/src/packages/cell/doc.md
@@ -7,7 +7,7 @@
 ## 安装
 
 ```tsx
-import { Cell, CellGroup } from '@nutui/nutui-react'
+import { Cell } from '@nutui/nutui-react'
 ```
 
 ## 代码演示
@@ -99,14 +99,14 @@ export default App;
 
 ```tsx
 import  React from "react";
-import { CellGroup,Cell,Switch } from '@nutui/nutui-react';
+import { Cell,Switch } from '@nutui/nutui-react';
 
 
 const App = () => {
   return (
-    <CellGroup title="自定义右侧箭头区域">
+    <Cell.Group title="自定义右侧箭头区域">
       <Cell title="Switch" extra={<Switch defaultChecked />} />
-    </CellGroup>
+    </Cell.Group>
   );
 };
 export default App;
@@ -140,7 +140,7 @@ export default App;
 
 ```tsx
 import  React from "react";
-import { CellGroup,Cell } from '@nutui/nutui-react';
+import { Cell } from '@nutui/nutui-react';
 import { Right } from '@nutui/icons-react'
 
 const App = () => {
@@ -154,7 +154,7 @@ const App = () => {
     }
   }
   return (
-    <CellGroup
+    <Cell.Group
         title="链接 | 分组用法"
         description="使用 nut-cell-group 支持 title extra"
     >
@@ -178,7 +178,7 @@ const App = () => {
             event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
         ) => onJumpclick(event, 'https://jd.com')}
         />
-    </CellGroup>
+    </Cell.Group>
   );
 };
 export default App;
@@ -194,18 +194,18 @@ export default App;
 
 ```tsx
 import  React from "react";
-import { CellGroup, Cell } from '@nutui/nutui-react';
+import { Cell } from '@nutui/nutui-react';
 
 const App = () => {
   return (
-     <CellGroup
+     <Cell.Group
         divider={false}
         title="分组用法"
         description="单元格之间不显示下边线"
     >
         <Cell title="我是标题" extra="描述文字" />
         <Cell title="我是标题" extra="描述文字" />
-    </CellGroup>
+    </Cell.Group>
   );
 };
 export default App;
@@ -213,7 +213,7 @@ export default App;
 
 :::
 
-## CellGroup
+## Cell.Group
 
 ### Props
 

--- a/src/packages/cell/doc.taro.md
+++ b/src/packages/cell/doc.taro.md
@@ -7,7 +7,7 @@
 ## 安装
 
 ```tsx
-import { Cell, CellGroup } from '@nutui/nutui-react-taro'
+import { Cell } from '@nutui/nutui-react-taro'
 ```
 
 ## 代码演示
@@ -98,18 +98,18 @@ export default App;
 :::demo
 
 ```tsx
-import  React from "react";
-import { CellGroup,Cell,Switch  } from '@nutui/nutui-react-taro';
+import React from 'react'
+import { Cell, Switch } from '@nutui/nutui-react-taro'
 
 
 const App = () => {
   return (
-    <CellGroup title="自定义右侧箭头区域">
-      <Cell title="Switch" extra={<Switch defaultChecked />} />
-    </CellGroup>
-  );
-};
-export default App;
+    <Cell.Group title='自定义右侧箭头区域'>
+      <Cell title='Switch' extra={<Switch defaultChecked />} />
+    </Cell.Group>
+  )
+}
+export default App
 ```
 
 :::
@@ -139,14 +139,14 @@ export default App;
 :::demo
 
 ```tsx
-import  React from "react";
-import { CellGroup, Cell } from '@nutui/nutui-react-taro';
+import React from 'react'
+import { Cell } from '@nutui/nutui-react-taro'
 import { Right } from '@nutui/icons-react-taro'
 
 const App = () => {
   const onJumpclick = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    link: string
+    link: string,
   ) => {
     const replace = false
     if (link) {
@@ -154,34 +154,34 @@ const App = () => {
     }
   }
   return (
-    <CellGroup
-        title="链接 | 分组用法"
-        description="使用 nut-cell-group 支持 title extra"
+    <Cell.Group
+      title='链接 | 分组用法'
+      description='使用 nut-cell-group 支持 title extra'
     >
-        <Cell
-        className="nutui-cell--clickable"
-        title="链接"
-        align="center"
+      <Cell
+        className='nutui-cell--clickable'
+        title='链接'
+        align='center'
         extra={<Right />}
-        />
-        <Cell
-        className="nutui-cell--clickable"
-        title="URL 跳转"
+      />
+      <Cell
+        className='nutui-cell--clickable'
+        title='URL 跳转'
         extra={
-            <>
+          <>
             <span style={{ marginRight: '5px' }}>/pages/index/index</span>
             <Right />
-            </>
+          </>
         }
-        align="center"
+        align='center'
         onClick={(
-            event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
+          event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
         ) => onJumpclick(event, '/pages/index/index')}
-        />
-    </CellGroup>
-  );
-};
-export default App;
+      />
+    </Cell.Group>
+  )
+}
+export default App
 ```
 
 :::
@@ -193,27 +193,27 @@ export default App;
 :::demo
 
 ```tsx
-import  React from "react";
-import { CellGroup, Cell } from '@nutui/nutui-react-taro';
+import React from 'react'
+import { Cell } from '@nutui/nutui-react-taro'
 
 const App = () => {
   return (
-     <CellGroup
-        divider={false}
-        title="分组用法"
-        description="单元格之间不显示下边线"
+    <Cell.Group
+      divider={false}
+      title='分组用法'
+      description='单元格之间不显示下边线'
     >
-        <Cell title="我是标题" extra="描述文字" />
-        <Cell title="我是标题" extra="描述文字" />
-    </CellGroup>
-  );
-};
-export default App;
+      <Cell title='我是标题' extra='描述文字' />
+      <Cell title='我是标题' extra='描述文字' />
+    </Cell.Group>
+  )
+}
+export default App
 ```
 
 :::
 
-## CellGroup
+## Cell.Group
 
 ### Props
 

--- a/src/packages/cell/doc.zh-TW.md
+++ b/src/packages/cell/doc.zh-TW.md
@@ -7,7 +7,7 @@
 ## 安裝
 
 ```tsx
-import { Cell, CellGroup } from '@nutui/nutui-react'
+import { Cell } from '@nutui/nutui-react'
 ```
 
 ## 代碼演示
@@ -98,18 +98,18 @@ export default App;
 :::demo
 
 ```tsx
-import  React from "react";
-import { CellGroup,Cell,Switch } from '@nutui/nutui-react';
+import React from 'react'
+import { Cell, Switch } from '@nutui/nutui-react'
 
 
 const App = () => {
   return (
-    <CellGroup title="自定義右側箭頭區域">
-      <Cell title="Switch" extra={<Switch defaultChecked />} />
-    </CellGroup>
-  );
-};
-export default App;
+    <Cell.Group title='自定義右側箭頭區域'>
+      <Cell title='Switch' extra={<Switch defaultChecked />} />
+    </Cell.Group>
+  )
+}
+export default App
 ```
 
 :::
@@ -119,14 +119,14 @@ export default App;
 :::demo
 
 ```tsx
-import  React from "react";
-import { CellGroup,Cell } from '@nutui/nutui-react';
+import React from 'react'
+import { Cell } from '@nutui/nutui-react'
 import { Right } from '@nutui/icons-react'
 
 const App = () => {
   const onJumpclick = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    url: string
+    url: string,
   ) => {
     const replace = false
     if (url) {
@@ -134,34 +134,34 @@ const App = () => {
     }
   }
   return (
-    <CellGroup
-        title="鏈接 | 分組用法"
-        description="使用 nut-cell-group 支持 title extra"
+    <Cell.Group
+      title='鏈接 | 分組用法'
+      description='使用 nut-cell-group 支持 title extra'
     >
-        <Cell
-        className="nutui-cell--clickable"
-        title="鏈接"
-        align="center"
+      <Cell
+        className='nutui-cell--clickable'
+        title='鏈接'
+        align='center'
         extra={<Right />}
-        />
-        <Cell
-        className="nutui-cell--clickable"
-        title="URL 跳轉"
+      />
+      <Cell
+        className='nutui-cell--clickable'
+        title='URL 跳轉'
         extra={
-            <>
+          <>
             <span style={{ marginRight: '5px' }}>https://jd.com</span>
             <Right />
-            </>
+          </>
         }
-        align="center"
+        align='center'
         onClick={(
-            event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
+          event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
         ) => onJumpclick(event, 'https://jd.com')}
-        />
-    </CellGroup>
-  );
-};
-export default App;
+      />
+    </Cell.Group>
+  )
+}
+export default App
 ```
 
 :::
@@ -186,7 +186,7 @@ export default App;
 
 :::
 
-## CellGroup
+## Cell.Group
 
 ### Props
 

--- a/src/packages/configprovider/demo.taro.tsx
+++ b/src/packages/configprovider/demo.taro.tsx
@@ -3,7 +3,6 @@ import {
   ConfigProvider,
   TextArea,
   Button,
-  CellGroup,
   Cell,
   Rate,
 } from '@/packages/nutui.react.taro'
@@ -55,7 +54,7 @@ const ConfigProviderDemo = () => {
         </ConfigProvider>
         <h2>{translated.defaultTheme}</h2>
         <ConfigProvider>
-          <CellGroup>
+          <Cell.Group>
             <Cell>
               <Rate defaultValue={3} />
             </Cell>
@@ -64,11 +63,11 @@ const ConfigProviderDemo = () => {
                 {translated.submit}
               </Button>
             </Cell>
-          </CellGroup>
+          </Cell.Group>
         </ConfigProvider>
         <h2>{translated.customTheme}</h2>
         <ConfigProvider theme={darkTheme}>
-          <CellGroup>
+          <Cell.Group>
             <Cell>
               <Rate defaultValue={3} />
             </Cell>
@@ -77,7 +76,7 @@ const ConfigProviderDemo = () => {
                 {translated.submit}
               </Button>
             </Cell>
-          </CellGroup>
+          </Cell.Group>
         </ConfigProvider>
       </div>
     </>

--- a/src/packages/configprovider/demo.tsx
+++ b/src/packages/configprovider/demo.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { ConfigProvider } from './configprovider'
 import TextArea from '../textarea'
 import Button from '../button'
-import CellGroup from '../cellgroup'
 import Cell from '../cell'
 import Rate from '../rate'
 import enUS from '../../locales/en-US'
@@ -50,7 +49,7 @@ const ConfigProviderDemo = () => {
         </ConfigProvider>
         <h2>{translated.defaultTheme}</h2>
         <ConfigProvider>
-          <CellGroup>
+          <Cell.Group>
             <Cell>
               <Rate defaultValue={3} />
             </Cell>
@@ -59,11 +58,11 @@ const ConfigProviderDemo = () => {
                 {translated.submit}
               </Button>
             </Cell>
-          </CellGroup>
+          </Cell.Group>
         </ConfigProvider>
         <h2>{translated.customTheme}</h2>
         <ConfigProvider theme={darkTheme}>
-          <CellGroup>
+          <Cell.Group>
             <Cell>
               <Rate defaultValue={3} />
             </Cell>
@@ -72,7 +71,7 @@ const ConfigProviderDemo = () => {
                 {translated.submit}
               </Button>
             </Cell>
-          </CellGroup>
+          </Cell.Group>
         </ConfigProvider>
       </div>
     </>

--- a/src/packages/configprovider/doc.en-US.md
+++ b/src/packages/configprovider/doc.en-US.md
@@ -43,7 +43,6 @@ The ConfigProvider component provides the ability to override CSS variables, and
 import React from 'react';
 import {
   ConfigProvider,
-  CellGroup,
   Cell,
   Button,
   Rate
@@ -57,7 +56,7 @@ const darkTheme = {
 const App = () => {
   return (
     <ConfigProvider theme={darkTheme}>
-      <CellGroup>
+      <Cell.Group>
         <Cell>
           <Rate defaultValue={3} />
         </Cell>
@@ -66,7 +65,7 @@ const App = () => {
             Submit
           </Button>
         </Cell>
-      </CellGroup>
+      </Cell.Group>
     </ConfigProvider>
   )
 }

--- a/src/packages/configprovider/doc.md
+++ b/src/packages/configprovider/doc.md
@@ -43,7 +43,6 @@ ConfigProvider 组件提供了覆盖 CSS 变量的能力，你需要在根节点
 import React from 'react';
 import {
   ConfigProvider,
-  CellGroup,
   Cell,
   Button,
   Rate
@@ -57,7 +56,7 @@ const darkTheme = {
 const App = () => {
   return (
     <ConfigProvider theme={darkTheme}>
-      <CellGroup>
+      <Cell.Group>
         <Cell>
           <Rate defaultValue={3} />
         </Cell>
@@ -66,7 +65,7 @@ const App = () => {
             提交
           </Button>
         </Cell>
-      </CellGroup>
+      </Cell.Group>
     </ConfigProvider>
   )
 }

--- a/src/packages/configprovider/doc.taro.md
+++ b/src/packages/configprovider/doc.taro.md
@@ -43,7 +43,6 @@ ConfigProvider 组件提供了覆盖 CSS 变量的能力，你需要在根节点
 import React from 'react';
 import {
   ConfigProvider,
-  CellGroup,
   Cell,
   Button,
   Rate
@@ -57,7 +56,7 @@ const darkTheme = {
 const App = () => {
   return (
     <ConfigProvider theme={darkTheme}>
-      <CellGroup>
+      <Cell.Group>
         <Cell>
           <Rate defaultValue={3} />
         </Cell>
@@ -66,7 +65,7 @@ const App = () => {
             提交
           </Button>
         </Cell>
-      </CellGroup>
+      </Cell.Group>
     </ConfigProvider>
   )
 }

--- a/src/packages/configprovider/doc.zh-TW.md
+++ b/src/packages/configprovider/doc.zh-TW.md
@@ -43,7 +43,6 @@ ConfigProvider 元件提供了覆蓋 CSS 變數的能力，你需要在根節點
 import React from 'react';
 import {
   ConfigProvider,
-  CellGroup,
   Cell,
   Button,
   Rate
@@ -57,7 +56,7 @@ const darkTheme = {
 const App = () => {
   return (
     <ConfigProvider theme={darkTheme}>
-      <CellGroup>
+      <Cell.Group>
         <Cell>
           <Rate defaultValue={3} />
         </Cell>
@@ -66,7 +65,7 @@ const App = () => {
             提交
           </Button>
         </Cell>
-      </CellGroup>
+      </Cell.Group>
     </ConfigProvider>
   )
 }

--- a/src/packages/form/form.taro.tsx
+++ b/src/packages/form/form.taro.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, ReactNode } from 'react'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import Cell from '@/packages/cell/index.taro'
-import CellGroup from '../cellgroup/index.taro'
 import { Context } from './context'
 import { useForm } from './useform.taro'
 import { FormItem } from '../formitem/formitem.taro'
@@ -92,10 +91,10 @@ export const Form: FunctionComponent<
         resetFields()
       }}
     >
-      <CellGroup>
+      <Cell.Group>
         <Context.Provider value={formInstance}>{children}</Context.Provider>
         {footer ? <Cell>{footer}</Cell> : null}
-      </CellGroup>
+      </Cell.Group>
     </form>
   )
 }

--- a/src/packages/form/form.tsx
+++ b/src/packages/form/form.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, ReactNode } from 'react'
 import classNames from 'classnames'
-import CellGroup from '../cellgroup'
 import { Context } from './context'
 import { useForm } from './useform'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
@@ -92,10 +91,10 @@ export const Form: FunctionComponent<
         resetFields()
       }}
     >
-      <CellGroup>
+      <Cell.Group>
         <Context.Provider value={formInstance}>{children}</Context.Provider>
         {footer ? <Cell>{footer}</Cell> : null}
-      </CellGroup>
+      </Cell.Group>
     </form>
   )
 }

--- a/src/packages/icon/demo.taro.tsx
+++ b/src/packages/icon/demo.taro.tsx
@@ -3,7 +3,7 @@ import Taro from '@tarojs/taro'
 import '@nutui/icons-react-taro/dist/style_iconfont.css'
 import { Add, IconFontConfig, IconFont } from '@nutui/icons-react-taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import { Cell, CellGroup, Toast } from '@/packages/nutui.react.taro'
+import { Cell, Toast } from '@/packages/nutui.react.taro'
 import '@/packages/icon/demo.scss'
 import Header from '@/sites/components/header'
 import { camelCase } from '@/utils/camel-case'
@@ -154,7 +154,7 @@ const IconDemo = () => {
         </Cell>
         {(IconFontConfig as any).data.map((item: any) => {
           return (
-            <CellGroup key={item.name} title={item.name}>
+            <Cell.Group key={item.name} title={item.name}>
               <Cell>
                 <ul>
                   {item.icons.map((icon: any) => {
@@ -177,12 +177,12 @@ const IconDemo = () => {
                   })}
                 </ul>
               </Cell>
-            </CellGroup>
+            </Cell.Group>
           )
         })}
         {(IconFontConfig as any).style.map((item: any) => {
           return (
-            <CellGroup key={item.name} title={item.name}>
+            <Cell.Group key={item.name} title={item.name}>
               <Cell>
                 <ul>
                   {item.icons.map((icon: any) => {
@@ -208,7 +208,7 @@ const IconDemo = () => {
                   })}
                 </ul>
               </Cell>
-            </CellGroup>
+            </Cell.Group>
           )
         })}
       </div>

--- a/src/packages/icon/demo.tsx
+++ b/src/packages/icon/demo.tsx
@@ -3,7 +3,6 @@ import '@nutui/icons-react/dist/style_iconfont.css'
 import { Add, IconFontConfig, IconFont } from '@nutui/icons-react'
 import { useTranslate } from '../../sites/assets/locale'
 import Cell from '../cell'
-import CellGroup from '../cellgroup'
 import Toast from '../toast'
 import { camelCase } from '@/utils/camel-case'
 
@@ -126,7 +125,7 @@ const IconDemo = () => {
         </Cell>
         {(IconFontConfig as any).data.map((item: any) => {
           return (
-            <CellGroup key={item.name} title={item.name}>
+            <Cell.Group key={item.name} title={item.name}>
               <Cell>
                 <ul>
                   {item.icons.map((icon: any) => {
@@ -142,12 +141,12 @@ const IconDemo = () => {
                   })}
                 </ul>
               </Cell>
-            </CellGroup>
+            </Cell.Group>
           )
         })}
         {(IconFontConfig as any).style.map((item: any) => {
           return (
-            <CellGroup key={item.name} title={item.name}>
+            <Cell.Group key={item.name} title={item.name}>
               <Cell>
                 <ul>
                   {item.icons.map((icon: any) => {
@@ -166,7 +165,7 @@ const IconDemo = () => {
                   })}
                 </ul>
               </Cell>
-            </CellGroup>
+            </Cell.Group>
           )
         })}
       </div>

--- a/src/packages/menu/demo.taro.tsx
+++ b/src/packages/menu/demo.taro.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
-
 import { TriangleDown, Success } from '@nutui/icons-react-taro'
 import Taro from '@tarojs/taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import { Menu, MenuItem, Button } from '@/packages/nutui.react.taro'
+import { Menu, Button } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 
 const MenuDemo = () => {
@@ -109,7 +108,7 @@ const MenuDemo = () => {
       <div className={`demo demo-full ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
         <h2>{translated.basic}</h2>
         <Menu closeOnOverlayClick lockScroll={false}>
-          <MenuItem
+          <Menu.Item
             options={options}
             value={0}
             closeOnClickAway
@@ -117,41 +116,41 @@ const MenuDemo = () => {
               console.log(val)
             }}
           />
-          <MenuItem closeOnClickAway options={options1} value="a" />
+          <Menu.Item closeOnClickAway options={options1} value="a" />
         </Menu>
         <h2>{translated.customMenuContent}</h2>
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem title={translated.screen} ref={itemRef}>
+          <Menu.Item options={options} value={0} />
+          <Menu.Item title={translated.screen} ref={itemRef}>
             <div>{translated.customContent}</div>
             <Button onClick={() => (itemRef.current as any).toggle(false)}>
               {translated.confirm}
             </Button>
-          </MenuItem>
+          </Menu.Item>
         </Menu>
         <h2>{translated.twoColsInOneLine}</h2>
         <Menu>
-          <MenuItem options={options} value={0} columns={2} />
+          <Menu.Item options={options} value={0} columns={2} />
         </Menu>
         <h2>{translated.customActiveColor}</h2>
         <Menu activeColor="green">
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
         <h2>{translated.customIcons}</h2>
         <Menu icon={<TriangleDown />}>
-          <MenuItem options={options} value={0} icon={<Success />} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} icon={<Success />} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
         <h2>{translated.expandDirection}</h2>
         <Menu>
-          <MenuItem
+          <Menu.Item
             options={options}
             value={0}
             direction="up"
             closeOnClickAway
           />
-          <MenuItem
+          <Menu.Item
             options={options1}
             value="a"
             direction="up"
@@ -160,8 +159,8 @@ const MenuDemo = () => {
         </Menu>
         <h2>{translated.disableMenu}</h2>
         <Menu>
-          <MenuItem options={options} value={0} disabled />
-          <MenuItem options={options1} value="a" disabled />
+          <Menu.Item options={options} value={0} disabled />
+          <Menu.Item options={options1} value="a" disabled />
         </Menu>
       </div>
     </>

--- a/src/packages/menu/demo.tsx
+++ b/src/packages/menu/demo.tsx
@@ -3,7 +3,6 @@ import './demo.scss'
 import { TriangleDown, Success } from '@nutui/icons-react'
 import Button from '../button'
 import { Menu } from './menu'
-import MenuItem from '../menuitem'
 import { useTranslate } from '../../sites/assets/locale'
 
 const MenuDemo = () => {
@@ -108,7 +107,7 @@ const MenuDemo = () => {
       <div className="demo full">
         <h2>{translated.basic}</h2>
         <Menu closeOnOverlayClick lockScroll={false}>
-          <MenuItem
+          <Menu.Item
             options={options}
             value={0}
             closeOnClickAway
@@ -116,12 +115,12 @@ const MenuDemo = () => {
               console.log(val)
             }}
           />
-          <MenuItem options={options1} value="a" closeOnClickAway />
+          <Menu.Item options={options1} value="a" closeOnClickAway />
         </Menu>
         <h2>{translated.customMenuContent}</h2>
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem title={translated.screen} ref={itemRef}>
+          <Menu.Item options={options} value={0} />
+          <Menu.Item title={translated.screen} ref={itemRef}>
             <div>{translated.customContent}</div>
             <Button
               onClick={() => {
@@ -130,31 +129,31 @@ const MenuDemo = () => {
             >
               {translated.confirm}
             </Button>
-          </MenuItem>
+          </Menu.Item>
         </Menu>
         <h2>{translated.twoColsInOneLine}</h2>
         <Menu>
-          <MenuItem options={options} value={0} columns={2} />
+          <Menu.Item options={options} value={0} columns={2} />
         </Menu>
         <h2>{translated.customActiveColor}</h2>
         <Menu activeColor="green">
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
         <h2>{translated.customIcons}</h2>
         <Menu icon={<TriangleDown />}>
-          <MenuItem options={options} value={0} icon={<Success />} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} icon={<Success />} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
         <h2>{translated.expandDirection}</h2>
         <Menu>
-          <MenuItem options={options} value={0} direction="up" />
-          <MenuItem options={options1} value="a" direction="up" />
+          <Menu.Item options={options} value={0} direction="up" />
+          <Menu.Item options={options1} value="a" direction="up" />
         </Menu>
         <h2>{translated.disableMenu}</h2>
         <Menu>
-          <MenuItem options={options} value={0} disabled />
-          <MenuItem options={options1} value="a" disabled />
+          <Menu.Item options={options} value={0} disabled />
+          <Menu.Item options={options1} value="a" disabled />
         </Menu>
       </div>
     </>

--- a/src/packages/menu/doc.en-US.md
+++ b/src/packages/menu/doc.en-US.md
@@ -7,7 +7,7 @@ The menu list that pops down downwards.
 ## Install
 
 ```tsx
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react'
 ```
 
 ## Demo
@@ -18,7 +18,7 @@ import { Menu, MenuItem } from '@nutui/nutui-react';
 
 ```tsx
 import React, {useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -35,8 +35,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -56,7 +56,7 @@ Popup can be closed with toggle method in menu instance.
 
 ```tsx
 import React, { useRef, useState } from 'react'
-import { Menu, MenuItem, Button } from '@nutui/nutui-react';
+import { Menu, Button } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -70,11 +70,11 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem title="Filter" ref={itemRef}>
+          <Menu.Item options={options} value={0} />
+          <Menu.Item title="Filter" ref={itemRef}>
             <div>Custom content</div>
             <Button onClick={() => itemRef.current.toggle(false)}>Confirm</Button>
-          </MenuItem>
+          </Menu.Item>
         </Menu>
       </div>
     </>
@@ -92,7 +92,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -120,7 +120,7 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} columns={2} />
+          <Menu.Item options={options} value={0} columns={2} />
         </Menu>
       </div>
     </>
@@ -138,7 +138,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -155,8 +155,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu activeColor="green">
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -174,7 +174,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 import { TriangleDown, Success } from '@nutui/icons-react'
 
 const App = () => {
@@ -192,8 +192,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu icon={<TriangleDown />}>
-          <MenuItem options={options} value={0} icon={<Success />} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} icon={<Success />} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -211,7 +211,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -228,8 +228,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} direction="up" />
-          <MenuItem options={options1} value="a" direction="up" />
+          <Menu.Item options={options} value={0} direction="up" />
+          <Menu.Item options={options1} value="a" direction="up" />
         </Menu>
       </div>
     </>
@@ -247,7 +247,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -264,8 +264,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} disabled />
-          <MenuItem options={options1} value="a" disabled />
+          <Menu.Item options={options} value={0} disabled />
+          <Menu.Item options={options1} value="a" disabled />
         </Menu>
       </div>
     </>
@@ -289,7 +289,7 @@ export default App
 | scrollFixed | Whether to fixed when window is scrolled, fixed position can be set | `boolean` \| `string` \| `number` | `true` |
 | icon | Custome title icon | `React.ReactNode` | `-` |
 
-## MenuItem
+## Menu.Item
 
 ### Props
 

--- a/src/packages/menu/doc.md
+++ b/src/packages/menu/doc.md
@@ -7,7 +7,7 @@
 ## 安装
 
 ```tsx
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 ```
 
 ## 代码演示
@@ -18,7 +18,7 @@ import { Menu, MenuItem } from '@nutui/nutui-react';
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -35,8 +35,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -56,7 +56,7 @@ export default App
 
 ```tsx
 import React, { useRef, useState } from 'react'
-import { Menu, MenuItem, Button } from '@nutui/nutui-react';
+import { Menu, Button } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -74,11 +74,11 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem title="筛选" ref={itemRef}>
+          <Menu.Item options={options} value={0} />
+          <Menu.Item title="筛选" ref={itemRef}>
             <div>自定义内容</div>
             <Button onClick={() => itemRef.current.toggle(false)}>确认</Button>
-          </MenuItem>
+          </Menu.Item>
         </Menu>
       </div>
     </>
@@ -96,7 +96,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -109,7 +109,7 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} columns={2} />
+          <Menu.Item options={options} value={0} columns={2} />
         </Menu>
       </div>
     </>
@@ -127,7 +127,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -144,8 +144,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu activeColor="green">
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -163,7 +163,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 import { TriangleDown, Success } from '@nutui/icons-react'
 
 const App = () => {
@@ -181,8 +181,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu icon={<TriangleDown />}>
-          <MenuItem options={options} value={0} icon={<Success />} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} icon={<Success />} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -200,7 +200,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -217,8 +217,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} direction="up" />
-          <MenuItem options={options1} value="a" direction="up" />
+          <Menu.Item options={options} value={0} direction="up" />
+          <Menu.Item options={options1} value="a" direction="up" />
         </Menu>
       </div>
     </>
@@ -236,7 +236,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -253,8 +253,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} disabled />
-          <MenuItem options={options1} value="a" disabled />
+          <Menu.Item options={options} value={0} disabled />
+          <Menu.Item options={options1} value="a" disabled />
         </Menu>
       </div>
     </>
@@ -278,7 +278,7 @@ export default App
 | scrollFixed | 滚动后是否固定，可设置固定位置 | `boolean` \| `string` \| `number` | `true` |
 | icon | 自定义标题图标 | `React.ReactNode` | `-` |
 
-## MenuItem
+## Menu.Item
 
 ### Props
 

--- a/src/packages/menu/doc.taro.md
+++ b/src/packages/menu/doc.taro.md
@@ -7,7 +7,7 @@
 ## 安装
 
 ```tsx
-import { Menu, MenuItem } from '@nutui/nutui-react-taro';
+import { Menu } from '@nutui/nutui-react-taro';
 ```
 
 ## 代码演示
@@ -18,7 +18,7 @@ import { Menu, MenuItem } from '@nutui/nutui-react-taro';
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react-taro';
+import { Menu } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [options] = useState([
@@ -35,8 +35,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -56,7 +56,7 @@ export default App
 
 ```tsx
 import React, { useRef, useState } from 'react'
-import { Menu, MenuItem, Button } from '@nutui/nutui-react-taro';
+import { Menu, Button } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [options] = useState([
@@ -74,11 +74,11 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem title="筛选" ref={itemRef}>
+          <Menu.Item options={options} value={0} />
+          <Menu.Item title="筛选" ref={itemRef}>
             <div>自定义内容</div>
             <Button onClick={() => itemRef.current.toggle(false)}>确认</Button>
-          </MenuItem>
+          </Menu.Item>
         </Menu>
       </div>
     </>
@@ -96,7 +96,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react-taro';
+import { Menu } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [options] = useState([
@@ -109,7 +109,7 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} columns={2} />
+          <Menu.Item options={options} value={0} columns={2} />
         </Menu>
       </div>
     </>
@@ -127,7 +127,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react-taro';
+import { Menu } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [options] = useState([
@@ -144,8 +144,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu activeColor="green">
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -163,7 +163,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react-taro';
+import { Menu } from '@nutui/nutui-react-taro';
 import { TriangleDown, Success } from '@nutui/icons-react'
 
 const App = () => {
@@ -181,8 +181,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu icon={<TriangleDown />}>
-          <MenuItem options={options} value={0} icon={<Success />} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} icon={<Success />} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -200,7 +200,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react-taro';
+import { Menu } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [options] = useState([
@@ -217,8 +217,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} direction="up" />
-          <MenuItem options={options1} value="a" direction="up" />
+          <Menu.Item options={options} value={0} direction="up" />
+          <Menu.Item options={options1} value="a" direction="up" />
         </Menu>
       </div>
     </>
@@ -236,7 +236,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react-taro';
+import { Menu } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [options] = useState([
@@ -253,8 +253,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} disabled />
-          <MenuItem options={options1} value="a" disabled />
+          <Menu.Item options={options} value={0} disabled />
+          <Menu.Item options={options1} value="a" disabled />
         </Menu>
       </div>
     </>
@@ -278,7 +278,7 @@ export default App
 | scrollFixed | 滚动后是否固定，可设置固定位置 | `boolean` \| `string` \| `number` | `true` |
 | icon | 自定义标题图标 | `React.ReactNode` | `-` |
 
-## MenuItem
+## Menu.Item
 
 ### Props
 

--- a/src/packages/menu/doc.zh-TW.md
+++ b/src/packages/menu/doc.zh-TW.md
@@ -7,7 +7,7 @@
 ## 安裝
 
 ```tsx
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 ```
 
 ## 代碼演示
@@ -18,7 +18,7 @@ import { Menu, MenuItem } from '@nutui/nutui-react';
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -35,8 +35,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -56,7 +56,7 @@ export default App
 
 ```tsx
 import React, { useRef, useState } from 'react'
-import { Menu, MenuItem, Button } from '@nutui/nutui-react';
+import { Menu, Button } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -74,11 +74,11 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} />
-          <MenuItem title="篩選" ref={itemRef}>
+          <Menu.Item options={options} value={0} />
+          <Menu.Item title="篩選" ref={itemRef}>
             <div>自定義內容</div>
             <Button onClick={() => itemRef.current.toggle(false)}>確認</Button>
-          </MenuItem>
+          </Menu.Item>
         </Menu>
       </div>
     </>
@@ -96,7 +96,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -109,7 +109,7 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} columns={2} />
+          <Menu.Item options={options} value={0} columns={2} />
         </Menu>
       </div>
     </>
@@ -127,7 +127,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -144,8 +144,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu activeColor="green">
-          <MenuItem options={options} value={0} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -163,7 +163,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 import { TriangleDown, Success } from '@nutui/icons-react'
 
 const App = () => {
@@ -181,8 +181,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu icon={<TriangleDown />}>
-          <MenuItem options={options} value={0} icon={<Success />} />
-          <MenuItem options={options1} value="a" />
+          <Menu.Item options={options} value={0} icon={<Success />} />
+          <Menu.Item options={options1} value="a" />
         </Menu>
       </div>
     </>
@@ -200,7 +200,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -217,8 +217,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} direction="up" />
-          <MenuItem options={options1} value="a" direction="up" />
+          <Menu.Item options={options} value={0} direction="up" />
+          <Menu.Item options={options1} value="a" direction="up" />
         </Menu>
       </div>
     </>
@@ -236,7 +236,7 @@ export default App
 
 ```tsx
 import React, { useState } from 'react'
-import { Menu, MenuItem } from '@nutui/nutui-react';
+import { Menu } from '@nutui/nutui-react';
 
 const App = () => {
   const [options] = useState([
@@ -253,8 +253,8 @@ const App = () => {
     <>
       <div className="demo full">
         <Menu>
-          <MenuItem options={options} value={0} disabled />
-          <MenuItem options={options1} value="a" disabled />
+          <Menu.Item options={options} value={0} disabled />
+          <Menu.Item options={options1} value="a" disabled />
         </Menu>
       </div>
     </>
@@ -278,7 +278,7 @@ export default App
 | scrollFixed | 滾動後是否固定，可設置固定位置 | `boolean` \| `string` \| `number` | `true` |
 | icon | 自定義標題圖標 | `React.ReactNode` | `-` |
 
-## MenuItem
+## Menu.Item
 
 ### Props
 

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -1,8 +1,7 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { ArrowDown2, ArrowUp2 } from '@nutui/icons-react-taro'
-import { OptionItem } from '@/packages/menuitem/menuitem.taro'
-
+import { OptionItem, MenuItem } from '@/packages/menuitem/menuitem.taro'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 
 export interface MenuProps extends BasicComponent {
@@ -22,7 +21,9 @@ const defaultProps = {
   lockScroll: true,
   icon: null,
 } as MenuProps
-export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
+export const Menu: FunctionComponent<Partial<MenuProps>> & {
+  Item: typeof MenuItem
+} = (props) => {
   const {
     className,
     icon,
@@ -164,3 +165,4 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
 
 Menu.defaultProps = defaultProps
 Menu.displayName = 'NutMenu'
+Menu.Item = MenuItem

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -1,8 +1,7 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { ArrowDown2, ArrowUp2 } from '@nutui/icons-react'
-import { OptionItem } from '@/packages/menuitem/menuitem'
-
+import { OptionItem, MenuItem } from '@/packages/menuitem/menuitem'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 
 export interface MenuProps extends BasicComponent {
@@ -22,7 +21,9 @@ const defaultProps = {
   lockScroll: true,
   icon: null,
 } as MenuProps
-export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
+export const Menu: FunctionComponent<Partial<MenuProps>> & {
+  Item: typeof MenuItem
+} = (props) => {
   const {
     className,
     icon,
@@ -165,3 +166,4 @@ export const Menu: FunctionComponent<Partial<MenuProps>> = (props) => {
 
 Menu.defaultProps = defaultProps
 Menu.displayName = 'NutMenu'
+Menu.Item = MenuItem

--- a/src/packages/notify/demo.taro.tsx
+++ b/src/packages/notify/demo.taro.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import Taro from '@tarojs/taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import { Notify, Cell, CellGroup } from '@/packages/nutui.react.taro'
+import { Notify, Cell } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 
 interface T {
@@ -95,7 +95,7 @@ const NotifyDemo = () => {
           }}
         />
         <h2>{translated.t1}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title={translated.primaryNotify}
             onClick={(event: React.MouseEvent) => {
@@ -124,7 +124,7 @@ const NotifyDemo = () => {
               SetShowNotify(true)
             }}
           />
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.t2}</h2>
         <Notify
           className="customer"

--- a/src/packages/notify/demo.tsx
+++ b/src/packages/notify/demo.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Notify from './notify'
 import Cell from '@/packages/cell'
-import CellGroup from '@/packages/cellgroup'
 import { useTranslate } from '../../sites/assets/locale'
 
 interface T {
@@ -90,7 +89,7 @@ const NotifyDemo = () => {
           }}
         />
         <h2>{translated.t1}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title={translated.primaryNotify}
             onClick={(event: React.MouseEvent) => {
@@ -115,7 +114,7 @@ const NotifyDemo = () => {
               warningNotify(translated.warningNotify)
             }}
           />
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.t2}</h2>
         <Cell
           title={translated.cusBgNotify}

--- a/src/packages/price/demo.taro.tsx
+++ b/src/packages/price/demo.taro.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import Taro from '@tarojs/taro'
-import { Cell, Price, CellGroup } from '@/packages/nutui.react.taro'
+import { Cell, Price } from '@/packages/nutui.react.taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
 import Header from '@/sites/components/header'
 
@@ -63,7 +63,7 @@ const PriceDemo = () => {
     <>
       <Header />
       <div className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
-        <CellGroup title={translated.title1}>
+        <Cell.Group title={translated.title1}>
           <Cell>
             <Price price={0} size="small" thousands />
           </Cell>
@@ -73,7 +73,7 @@ const PriceDemo = () => {
           <Cell>
             <Price price={0} size="large" thousands />
           </Cell>
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.title2}</h2>
         <Cell>
           <Price price={8888} digits={0} size="normal" thousands />

--- a/src/packages/price/demo.tsx
+++ b/src/packages/price/demo.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Price } from './price'
 import { Cell } from '../cell/cell'
-import { CellGroup } from '../cellgroup/cellgroup'
 import { useTranslate } from '@/sites/assets/locale'
 
 interface T {
@@ -61,7 +60,7 @@ const PriceDemo = () => {
   }, [])
   return (
     <div className="demo">
-      <CellGroup title={translated.title1}>
+      <Cell.Group title={translated.title1}>
         <Cell>
           <Price price={0} size="small" thousands />
         </Cell>
@@ -71,7 +70,7 @@ const PriceDemo = () => {
         <Cell>
           <Price price={0} size="large" thousands />
         </Cell>
-      </CellGroup>
+      </Cell.Group>
       <h2>{translated.title2}</h2>
       <Cell>
         <Price price={8888} digits={0} size="normal" thousands />

--- a/src/packages/radio/demo.taro.tsx
+++ b/src/packages/radio/demo.taro.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import Taro from '@tarojs/taro'
 import { Checklist } from '@nutui/icons-react-taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import { Radio, Cell, CellGroup } from '@/packages/nutui.react.taro'
+import { Radio, Cell } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 
 interface T {
@@ -82,7 +82,7 @@ const RadioDemo = () => {
       <Header />
       <div className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
         <h2>{translated['74fc5d8a']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Radio defaultChecked>{translated.bb7486f4}1</Radio>
           </Cell>
@@ -91,7 +91,7 @@ const RadioDemo = () => {
               {translated.bb7486f4}1
             </Radio>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.disableOne}</h2>
         <Cell>
           <Radio.Group defaultValue="1">
@@ -195,7 +195,7 @@ const RadioDemo = () => {
           </Radio>
         </Cell>
         <h2>{translated['0f261484']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Radio.Group
               defaultValue={checkedValue}
@@ -210,7 +210,7 @@ const RadioDemo = () => {
               <Radio value={2}>{translated['0f261484']}</Radio>
             </Radio.Group>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.options}</h2>
         <Cell>
           <Radio.Group

--- a/src/packages/radio/demo.tsx
+++ b/src/packages/radio/demo.tsx
@@ -3,7 +3,6 @@ import { Checklist } from '@nutui/icons-react'
 import { useTranslate } from '../../sites/assets/locale'
 import Radio from '@/packages/radio'
 import Cell from '@/packages/cell'
-import CellGroup from '@/packages/cellgroup'
 import Toast from '@/packages/toast'
 
 interface T {
@@ -82,7 +81,7 @@ const RadioDemo = () => {
     <>
       <div className="demo">
         <h2>{translated['74fc5d8a']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Radio defaultChecked>{translated.bb7486f4}1</Radio>
           </Cell>
@@ -91,7 +90,7 @@ const RadioDemo = () => {
               {translated.bb7486f4}1
             </Radio>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.disableOne}</h2>
         <Cell>
           <Radio.Group defaultValue="1">
@@ -195,7 +194,7 @@ const RadioDemo = () => {
           </Radio>
         </Cell>
         <h2>{translated['0f261484']}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Radio.Group
               defaultValue={checkedValue}
@@ -205,7 +204,7 @@ const RadioDemo = () => {
               <Radio value={2}>{translated['0f261484']}</Radio>
             </Radio.Group>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
         <h2>{translated.options}</h2>
         <Cell>
           <Radio.Group

--- a/src/packages/swiper/__tests__/swiper.spec.tsx
+++ b/src/packages/swiper/__tests__/swiper.spec.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { act } from 'react-dom/test-utils'
-import { Swiper } from '../swiper'
-import { SwiperItem } from '../../swiperitem/swiperitem'
+import Swiper from '../index'
 import { triggerDrag } from '@/utils/test/event'
 
 function sleep(delay = 0): Promise<void> {
@@ -38,9 +37,9 @@ test('should render width and height', () => {
     >
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>
@@ -80,9 +79,9 @@ test('should render initpage', () => {
     >
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>
@@ -120,9 +119,9 @@ test('should render direction', () => {
     >
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>
@@ -161,9 +160,9 @@ test('should render indicator', () => {
     >
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>
@@ -202,9 +201,9 @@ test('should render loop and auto-play', async () => {
     >
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>
@@ -242,9 +241,9 @@ test('should not allow to drag when touchable is false', () => {
     >
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>
@@ -282,9 +281,9 @@ test('should not allow to drag when loop is false', async () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>

--- a/src/packages/swiper/demo.taro.tsx
+++ b/src/packages/swiper/demo.taro.tsx
@@ -3,7 +3,7 @@ import '@/packages/swiper/demo.scss'
 import Taro from '@tarojs/taro'
 import { Left, Right } from '@nutui/icons-react-taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import { SwiperItem, Swiper } from '@/packages/nutui.react.taro'
+import { Swiper } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 
 interface T {
@@ -69,17 +69,17 @@ const SwiperDemo = () => {
         <h2>{translated.basic}</h2>
         <Swiper defaultValue={1} autoPlay indicator>
           {list.map((item) => (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img width="100%" height="100%" src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           ))}
         </Swiper>
         <h2>{translated.asyc}</h2>
         <Swiper defaultValue={0} indicator>
           {asyncList.map((item) => (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img width="100%" height="100%" src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           ))}
         </Swiper>
 
@@ -91,9 +91,9 @@ const SwiperDemo = () => {
           defaultValue={0}
         >
           {list.map((item) => (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img width="100%" height="100%" src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           ))}
         </Swiper>
 
@@ -121,9 +121,9 @@ const SwiperDemo = () => {
           }
         >
           {list.map((item) => (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img width="100%" height="100%" src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           ))}
         </Swiper>
 
@@ -143,9 +143,9 @@ const SwiperDemo = () => {
           >
             {list.map((item) => {
               return (
-                <SwiperItem key={item}>
+                <Swiper.Item key={item}>
                   <img src={item} alt="" />
-                </SwiperItem>
+                </Swiper.Item>
               )
             })}
           </Swiper>
@@ -167,17 +167,17 @@ const SwiperDemo = () => {
         <h2>{translated.vertical}</h2>
         <Swiper defaultValue={0} direction="vertical">
           {list.map((item) => (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img width="100%" height="100%" src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           ))}
         </Swiper>
         <h2>{translated.horizontalCenter}</h2>
         <Swiper defaultValue={0} loop previousMargin="20px" nextMargin="20px">
           {list.map((item) => (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img width="100%" height="100%" src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           ))}
         </Swiper>
         <h2>{translated.verticalCenter}</h2>
@@ -189,9 +189,9 @@ const SwiperDemo = () => {
           nextMargin="20px"
         >
           {list.map((item) => (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img width="100%" height="100%" src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           ))}
         </Swiper>
       </div>

--- a/src/packages/swiper/demo.tsx
+++ b/src/packages/swiper/demo.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Left, Right } from '@nutui/icons-react'
-import SwiperItem from '@/packages/swiperitem'
+// import Swiper.Item from '@/packages/swiperitem'
 import Swiper from '@/packages/swiper'
 import '@/packages/swiper/demo.scss'
 import { useTranslate } from '../../sites/assets/locale'
@@ -103,9 +103,9 @@ const SwiperDemo = () => {
         >
           {list.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -125,9 +125,9 @@ const SwiperDemo = () => {
         >
           {list1.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -147,9 +147,9 @@ const SwiperDemo = () => {
         >
           {list2.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -160,9 +160,9 @@ const SwiperDemo = () => {
         <Swiper defaultValue={initPage4} width="300" height={height}>
           {list.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -178,9 +178,9 @@ const SwiperDemo = () => {
         >
           {list.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -197,9 +197,9 @@ const SwiperDemo = () => {
         >
           {list.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -224,9 +224,9 @@ const SwiperDemo = () => {
         >
           {list.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -243,9 +243,9 @@ const SwiperDemo = () => {
         >
           {list.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>
@@ -263,9 +263,9 @@ const SwiperDemo = () => {
         >
           {list.map((item) => {
             return (
-              <SwiperItem key={item}>
+              <Swiper.Item key={item}>
                 <img src={item} alt="" />
-              </SwiperItem>
+              </Swiper.Item>
             )
           })}
         </Swiper>

--- a/src/packages/swiper/doc.en-US.md
+++ b/src/packages/swiper/doc.en-US.md
@@ -7,7 +7,7 @@ Often used in a group of pictures or card rotation.
 ## Install
 
 ```tsx
-import { Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 ```
 
 ## Demo
@@ -18,7 +18,7 @@ import { Swiper, SwiperItem } from '@nutui/nutui-react';
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -35,18 +35,18 @@ const App = () => {
         defaultValue={defaultValue1}
         indicator
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -62,7 +62,7 @@ export default App;
 
 ```tsx
 import React, { useState, useEffect } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -92,9 +92,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -114,7 +114,7 @@ Support dynamic addition / deletion of pictures
 
 ```tsx
 import React, { useState, useEffect } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -145,9 +145,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -167,7 +167,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue2, setdefaultValue2] = useState(0)
@@ -178,18 +178,18 @@ const App = () => {
         height={150}
         defaultValue={defaultValue2}
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -207,7 +207,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue3, setdefaultValue3] = useState(0)
@@ -224,18 +224,18 @@ const App = () => {
         onChange={onChange3}
         indicator={<div className="page"> {current}/4 </div>}
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -253,7 +253,7 @@ You can manually switch through `ref` (`prev`, `next`)
 
 ```tsx
 import React, { useState, useRef } from 'react'
-import { Swiper, SwiperItem, Icon } from '@nutui/nutui-react';
+import { Swiper, Icon } from '@nutui/nutui-react';
 
 const App = () => {
   const swiperRef = React.useRef<any>(null)
@@ -317,9 +317,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -347,7 +347,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue4, setdefaultValue4] = useState(0)
@@ -365,18 +365,18 @@ const App = () => {
         height="150"
         indicator
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -394,7 +394,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue8, setdefaultValue8] = useState(0)
@@ -416,9 +416,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -438,7 +438,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue9, setdefaultValue9] = useState(0)
@@ -461,9 +461,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>

--- a/src/packages/swiper/doc.md
+++ b/src/packages/swiper/doc.md
@@ -7,7 +7,7 @@
 ## 安装
 
 ```tsx
-import { Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 ```
 
 ## 代码演示
@@ -18,7 +18,7 @@ import { Swiper, SwiperItem } from '@nutui/nutui-react';
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -35,18 +35,18 @@ const App = () => {
         defaultValue={defaultValue1}
         indicator
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -62,7 +62,7 @@ export default App;
 
 ```tsx
 import React, { useState, useEffect } from 'react'
-import { Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -92,9 +92,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -114,7 +114,7 @@ export default App;
 
 ```tsx
 import React, { useState, useEffect } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -145,9 +145,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -167,7 +167,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue2, setdefaultValue2] = useState(0)
@@ -178,18 +178,18 @@ const App = () => {
         height={150}
         defaultValue={defaultValue2}
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -207,7 +207,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue3, setdefaultValue3] = useState(0)
@@ -224,18 +224,18 @@ const App = () => {
         onChange={onChange3}
         indicator={<div className="page"> {current}/4 </div>}
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -253,7 +253,7 @@ export default App;
 
 ```tsx
 import React, { useState, useRef } from 'react'
-import { Swiper, SwiperItem, Icon } from '@nutui/nutui-react';
+import { Swiper, Icon } from '@nutui/nutui-react';
 
 const App = () => {
   const swiperRef = React.useRef<any>(null)
@@ -317,9 +317,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -347,7 +347,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue4, setdefaultValue4] = useState(0)
@@ -365,18 +365,18 @@ const App = () => {
         height="150"
         indicator
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -394,7 +394,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue8, setdefaultValue8] = useState(0)
@@ -416,9 +416,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -438,7 +438,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue9, setdefaultValue9] = useState(0)
@@ -461,9 +461,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>

--- a/src/packages/swiper/doc.taro.md
+++ b/src/packages/swiper/doc.taro.md
@@ -7,7 +7,7 @@
 ## 安装
 
 ```tsx
-import { Swiper, SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 ```
 
 ## 代码演示
@@ -18,7 +18,7 @@ import { Swiper, SwiperItem } from '@nutui/nutui-react-taro';
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   return (
@@ -26,18 +26,18 @@ const App = () => {
       defaultValue={0}
       indicator
     >
-      <SwiperItem >
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-      </SwiperItem>
-      <SwiperItem >
+      </Swiper.Item>
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-      </SwiperItem>
-      <SwiperItem >
+      </Swiper.Item>
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-      </SwiperItem>
-      <SwiperItem >
+      </Swiper.Item>
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-      </SwiperItem>
+      </Swiper.Item>
     </Swiper>
   )
 }
@@ -52,7 +52,7 @@ export default App;
 
 ```tsx
 import React, { useState, useEffect } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [initPage1, setInitPage1] = useState(0)
@@ -76,9 +76,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -98,23 +98,23 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   return (
     <Swiper width={300} height={150} defaultValue={0}>
-      <SwiperItem >
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-      </SwiperItem>
-      <SwiperItem >
+      </Swiper.Item>
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-      </SwiperItem>
-      <SwiperItem >
+      </Swiper.Item>
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-      </SwiperItem>
-      <SwiperItem >
+      </Swiper.Item>
+      <Swiper.Item >
         <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-      </SwiperItem>
+      </Swiper.Item>
     </Swiper>
   )
 }
@@ -131,7 +131,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [current, setCurrent] = useState(0)
@@ -144,18 +144,18 @@ const App = () => {
         onChange={onChange3}
         pageContent={<div className="page"> {current + 1}/4 </div>}
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
   )
 }
@@ -172,7 +172,7 @@ export default App;
 
 ```tsx
 import React, { useState, useRef } from 'react'
-import { Swiper, SwiperItem, Icon } from '@nutui/nutui-react-taro';
+import { Swiper, Icon } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const swiperRef = React.useRef<any>(null)
@@ -233,9 +233,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -263,7 +263,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   return (
@@ -272,18 +272,18 @@ const App = () => {
         defaultValue={0}
         direction="vertical"
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -301,7 +301,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [initPage8, setInitPage8] = useState(0)
@@ -315,9 +315,9 @@ const App = () => {
     <Swiper defaultValue={0} loop previousMargin="20px" nextMargin="20px">
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>
@@ -334,7 +334,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react-taro';
+import { Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const list = [
@@ -353,9 +353,9 @@ const App = () => {
       >
       {list.map((item) => {
         return (
-          <SwiperItem key={item}>
+          <Swiper.Item key={item}>
             <img src={item} alt="" />
-          </SwiperItem>
+          </Swiper.Item>
         )
       })}
     </Swiper>

--- a/src/packages/swiper/doc.zh-TW.md
+++ b/src/packages/swiper/doc.zh-TW.md
@@ -7,7 +7,7 @@
 ## 安裝
 
 ```tsx
-import { Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 ```
 
 ## 代碼演示
@@ -18,7 +18,7 @@ import { Swiper, SwiperItem } from '@nutui/nutui-react';
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -35,18 +35,18 @@ const App = () => {
         defaultValue={defaultValue1}
         indicator
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -62,7 +62,7 @@ export default App;
 
 ```tsx
 import React, { useState, useEffect } from 'react'
-import { Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -92,9 +92,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -114,7 +114,7 @@ export default App;
 
 ```tsx
 import React, { useState, useEffect } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue1, setdefaultValue1] = useState(0)
@@ -145,9 +145,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -167,7 +167,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue2, setdefaultValue2] = useState(0)
@@ -178,18 +178,18 @@ const App = () => {
         height={150}
         defaultValue={defaultValue2}
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -207,7 +207,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue3, setdefaultValue3] = useState(0)
@@ -224,18 +224,18 @@ const App = () => {
         onChange={onChange3}
         indicator={<div className="page"> {current}/4 </div>}
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -253,7 +253,7 @@ export default App;
 
 ```tsx
 import React, { useState, useRef } from 'react'
-import { Swiper, SwiperItem, Icon } from '@nutui/nutui-react';
+import { Swiper, Icon } from '@nutui/nutui-react';
 
 const App = () => {
   const swiperRef = React.useRef<any>(null)
@@ -317,9 +317,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -347,7 +347,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue4, setdefaultValue4] = useState(0)
@@ -365,18 +365,18 @@ const App = () => {
         height="150"
         indicator
       >
-        <SwiperItem >
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/welcomenutui.jpg" alt="" />
-        </SwiperItem>
-        <SwiperItem >
+        </Swiper.Item>
+        <Swiper.Item >
           <img src="https://storage.360buyimg.com/jdc-article/fristfabu.jpg" alt="" />
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </div>
   )
@@ -394,7 +394,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue8, setdefaultValue8] = useState(0)
@@ -416,9 +416,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>
@@ -438,7 +438,7 @@ export default App;
 
 ```tsx
 import React, { useState } from 'react'
-import { Swiper,SwiperItem } from '@nutui/nutui-react';
+import { Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [defaultValue9, setdefaultValue9] = useState(0)
@@ -461,9 +461,9 @@ const App = () => {
       >
         {list.map((item) => {
           return (
-            <SwiperItem key={item}>
+            <Swiper.Item key={item}>
               <img src={item} alt="" />
-            </SwiperItem>
+            </Swiper.Item>
           )
         })}
       </Swiper>

--- a/src/packages/swiper/index.taro.ts
+++ b/src/packages/swiper/index.taro.ts
@@ -1,4 +1,15 @@
-import { Swiper } from './swiper.taro'
+import React from 'react'
+import { Swiper, SwiperProps } from './swiper.taro'
+import SwiperItem from '@/packages/swiperitem/index.taro'
 
 export type { SwiperProps } from './swiper.taro'
-export default Swiper
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  Partial<SwiperProps> &
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> &
+    React.RefAttributes<any>
+> & {
+  Item: typeof SwiperItem
+}
+const InnerSwiper = Swiper as CompoundedComponent
+InnerSwiper.Item = SwiperItem
+export default InnerSwiper

--- a/src/packages/swiper/index.ts
+++ b/src/packages/swiper/index.ts
@@ -1,4 +1,15 @@
-import { Swiper } from './swiper'
+import React from 'react'
+import { Swiper, SwiperProps, SwiperRef } from './swiper'
+import SwiperItem from '@/packages/swiperitem'
 
 export type { SwiperProps, SwiperRef } from './swiper'
-export default Swiper
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  Partial<SwiperProps> &
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> &
+    React.RefAttributes<SwiperRef>
+> & {
+  Item: typeof SwiperItem
+}
+const InnerSwiper = Swiper as CompoundedComponent
+InnerSwiper.Item = SwiperItem
+export default InnerSwiper

--- a/src/packages/tabs/demo.taro.tsx
+++ b/src/packages/tabs/demo.taro.tsx
@@ -5,7 +5,6 @@ import { Tabs } from '@/packages/nutui.react.taro'
 import Swiper from '@/packages/swiper/index.taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
 import Header from '@/sites/components/header'
-import SwiperItem from '@/packages/swiperitem/index.taro'
 
 interface T {
   basic: string
@@ -190,21 +189,21 @@ const TabsDemo = () => {
             setTabIndex(page.detail.current)
           }}
         >
-          <SwiperItem>
+          <Swiper.Item>
             <div style={{ backgroundColor: '#fff', padding: '10px' }}>
               Tab 1
             </div>
-          </SwiperItem>
-          <SwiperItem>
+          </Swiper.Item>
+          <Swiper.Item>
             <div style={{ backgroundColor: '#fff', padding: '10px' }}>
               Tab 2
             </div>
-          </SwiperItem>
-          <SwiperItem>
+          </Swiper.Item>
+          <Swiper.Item>
             <div style={{ backgroundColor: '#fff', padding: '10px' }}>
               Tab 3
             </div>
-          </SwiperItem>
+          </Swiper.Item>
         </Swiper>
         <h2>{translated.title10}</h2>
         <Tabs

--- a/src/packages/tabs/demo.tsx
+++ b/src/packages/tabs/demo.tsx
@@ -3,7 +3,6 @@ import { Dongdong, Jd } from '@nutui/icons-react'
 import { Tabs } from './tabs'
 import Swiper from '../swiper'
 import { useTranslate } from '../../sites/assets/locale'
-import SwiperItem from '@/packages/swiperitem'
 
 interface T {
   basic: string
@@ -181,21 +180,21 @@ const TabsDemo = () => {
             setTabIndex(page)
           }}
         >
-          <SwiperItem>
+          <Swiper.Item>
             <div style={{ backgroundColor: '#fff', padding: '10px' }}>
               Tab 1
             </div>
-          </SwiperItem>
-          <SwiperItem>
+          </Swiper.Item>
+          <Swiper.Item>
             <div style={{ backgroundColor: '#fff', padding: '10px' }}>
               Tab 2
             </div>
-          </SwiperItem>
-          <SwiperItem>
+          </Swiper.Item>
+          <Swiper.Item>
             <div style={{ backgroundColor: '#fff', padding: '10px' }}>
               Tab 3
             </div>
-          </SwiperItem>
+          </Swiper.Item>
         </Swiper>
         <h2>{translated.title10}</h2>
         <Tabs

--- a/src/packages/tabs/doc.en-US.md
+++ b/src/packages/tabs/doc.en-US.md
@@ -128,7 +128,7 @@ export default App;
 
 ```tsx
 import React, { useState } from "react";
-import { Tabs, Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Tabs, Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [tab2value, setTab2value] = useState('0');
@@ -155,21 +155,21 @@ const App = () => {
           setTabIndex(page)
         }}
       >
-        <SwiperItem>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 1
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 2
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 3
           </div>
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </>
   );

--- a/src/packages/tabs/doc.md
+++ b/src/packages/tabs/doc.md
@@ -128,7 +128,7 @@ export default App;
 
 ```tsx
 import React, { useState } from "react";
-import { Tabs, Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Tabs, Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [tab2value, setTab2value] = useState('0');
@@ -155,21 +155,21 @@ const App = () => {
           setTabIndex(page)
         }}
       >
-        <SwiperItem>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 1
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 2
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 3
           </div>
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </>
   );

--- a/src/packages/tabs/doc.taro.md
+++ b/src/packages/tabs/doc.taro.md
@@ -128,7 +128,7 @@ export default App;
 
 ```tsx
 import React, { useState } from "react";
-import { Tabs, Swiper, SwiperItem } from '@nutui/nutui-react-taro';
+import { Tabs, Swiper } from '@nutui/nutui-react-taro';
 
 const App = () => {
   const [tab2value, setTab2value] = useState('0');
@@ -155,21 +155,21 @@ const App = () => {
           setTabIndex(page)
         }}
       >
-        <SwiperItem>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 1
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 2
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 3
           </div>
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </>
   );

--- a/src/packages/tabs/doc.zh-TW.md
+++ b/src/packages/tabs/doc.zh-TW.md
@@ -128,7 +128,7 @@ export default App;
 
 ```tsx
 import React, { useState } from "react";
-import { Tabs, Swiper, SwiperItem } from '@nutui/nutui-react';
+import { Tabs, Swiper } from '@nutui/nutui-react';
 
 const App = () => {
   const [tab2value, setTab2value] = useState('0');
@@ -155,21 +155,21 @@ const App = () => {
           setTabIndex(page)
         }}
       >
-        <SwiperItem>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 1
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 2
           </div>
-        </SwiperItem>
-        <SwiperItem>
+        </Swiper.Item>
+        <Swiper.Item>
           <div style={{ backgroundColor: '#fff', padding: '10px' }}>
             Tab 3
           </div>
-        </SwiperItem>
+        </Swiper.Item>
       </Swiper>
     </>
   );

--- a/src/packages/tag/demo.taro.tsx
+++ b/src/packages/tag/demo.taro.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Taro from '@tarojs/taro'
 import { CircleClose } from '@nutui/icons-react-taro'
-import { CellGroup, Cell, Tag } from '@/packages/nutui.react.taro'
+import { Cell, Tag } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 import { useTranslate } from '@/sites/assets/locale/taro'
 
@@ -39,7 +39,7 @@ const TagDemo = () => {
       <Header />
       <div className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
         <h2>{translated.basic}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title="primary"
             extra={<Tag type="primary">{translated.tag}</Tag>}
@@ -56,10 +56,10 @@ const TagDemo = () => {
             title="warning"
             extra={<Tag type="warning">{translated.tag}</Tag>}
           />
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated.style}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title={translated.plain}
             extra={<Tag plain>{translated.tag}</Tag>}
@@ -93,10 +93,10 @@ const TagDemo = () => {
               </Tag>
             }
           />
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated.customColor}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title={translated.backgroundColor}
             extra={<Tag background="#FA685D">{translated.tag}</Tag>}
@@ -117,7 +117,7 @@ const TagDemo = () => {
               </Tag>
             }
           />
-        </CellGroup>
+        </Cell.Group>
       </div>
     </>
   )

--- a/src/packages/tag/demo.tsx
+++ b/src/packages/tag/demo.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { CircleClose } from '@nutui/icons-react'
 import { Tag } from './tag'
 import Cell from '@/packages/cell'
-import CellGroup from '@/packages/cellgroup'
 import { useTranslate } from '@/sites/assets/locale'
 
 const TagDemo = () => {
@@ -38,7 +37,7 @@ const TagDemo = () => {
     <>
       <div className="demo">
         <h2>{translated.basic}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title="primary"
             extra={<Tag type="primary">{translated.tag}</Tag>}
@@ -55,10 +54,10 @@ const TagDemo = () => {
             title="warning"
             extra={<Tag type="warning">{translated.tag}</Tag>}
           />
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated.style}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title={translated.plain}
             extra={<Tag plain>{translated.tag}</Tag>}
@@ -100,10 +99,10 @@ const TagDemo = () => {
               </Tag>
             }
           />
-        </CellGroup>
+        </Cell.Group>
 
         <h2>{translated.customColor}</h2>
-        <CellGroup>
+        <Cell.Group>
           <Cell
             title={translated.backgroundColor}
             extra={<Tag background="#FA685D">{translated.tag}</Tag>}
@@ -124,7 +123,7 @@ const TagDemo = () => {
               </Tag>
             }
           />
-        </CellGroup>
+        </Cell.Group>
       </div>
     </>
   )

--- a/src/packages/virtuallist/demo.taro.tsx
+++ b/src/packages/virtuallist/demo.taro.tsx
@@ -1,12 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import Taro from '@tarojs/taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
-import {
-  Cell,
-  CellGroup,
-  Radio,
-  VirtualList,
-} from '@/packages/nutui.react.taro'
+import { Cell, Radio, VirtualList } from '@/packages/nutui.react.taro'
 import Header from '@/sites/components/header'
 
 const ListDemo = () => {
@@ -143,7 +138,7 @@ const ListDemo = () => {
     <>
       <Header />
       <div className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Radio.Group
               value={radioVal}
@@ -154,7 +149,7 @@ const ListDemo = () => {
               <Radio value="2">{translated.text2}</Radio>
             </Radio.Group>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
         <div style={{ height: '100%' }}>{showNode()}</div>
       </div>
     </>

--- a/src/packages/virtuallist/demo.tsx
+++ b/src/packages/virtuallist/demo.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import Radio from '@/packages/radio'
 import Cell from '@/packages/cell'
-import CellGroup from '@/packages/cellgroup'
 import { useTranslate } from '../../sites/assets/locale'
 import VirtualList from './index'
 
@@ -133,7 +132,7 @@ const ListDemo = () => {
   return (
     <>
       <div className="demo">
-        <CellGroup>
+        <Cell.Group>
           <Cell>
             <Radio.Group
               value={radioVal}
@@ -146,7 +145,7 @@ const ListDemo = () => {
               <Radio value="4">{translated.text4}</Radio>
             </Radio.Group>
           </Cell>
-        </CellGroup>
+        </Cell.Group>
         <div key={radioVal} className="nut-virtualList-demo-box hideScrollbar">
           {showNode()}
         </div>


### PR DESCRIPTION
… Swiper.Item

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
对子组件的使用方式进行统一，例如 MenuItem 改为 Menu.Item，CellGroup 改为 Cell.Group，SwiperItem 改为 Swiper.Item

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
