### PR TITLE
fix(searchbar): 修复 taro-h5 下 onSearch 不能触发的问题 1.x

### DIFF
--- a/src/packages/searchbar/demo.taro.tsx
+++ b/src/packages/searchbar/demo.taro.tsx
@@ -85,7 +85,7 @@ const SearchBarDemo = () => {
           background="linear-gradient(to right, #9866F0, #EB4D50)"
           inputBackground="#999"
           align="right"
-          onSearch={(value) => Taro.showToast({ title: value })}
+          onSearch={() => toastShow()}
         />
         <h2>{translated.title4}</h2>
         <SearchBar

--- a/src/packages/searchbar/searchbar.scss
+++ b/src/packages/searchbar/searchbar.scss
@@ -65,10 +65,14 @@
 
   &__icon {
     padding: 0 5px 0 10px;
+    display: flex;
+    justify-content: center;
   }
 
   &__rightin-icon {
     padding: 0 5px;
+    display: flex;
+    justify-content: center;
   }
 
   .nut-searchbar__input-box {
@@ -139,9 +143,13 @@
 
   &__leftout-icon {
     margin-right: 10px;
+    display: flex;
+    justify-content: center;
   }
 
   &__rightout-icon {
     margin-left: 10px;
+    display: flex;
+    justify-content: center;
   }
 }

--- a/src/packages/searchbar/searchbar.taro.tsx
+++ b/src/packages/searchbar/searchbar.taro.tsx
@@ -287,7 +287,7 @@ export const SearchBar: FunctionComponent<
   }
 
   const onKeypress = (e: any) => {
-    if (e.keyCode === 13) {
+    if (e.key === 'Enter' || e.keyCode === 13) {
       if (typeof e.cancelable !== 'boolean' || e.cancelable) {
         e.preventDefault()
       }

--- a/src/packages/searchbar/searchbar.tsx
+++ b/src/packages/searchbar/searchbar.tsx
@@ -174,7 +174,7 @@ export const SearchBar: FunctionComponent<
         disabled={disabled}
         readOnly={readOnly}
         maxLength={maxLength}
-        onKeyPress={onKeypress}
+        onKeyDown={onKeydown}
         onChange={(e: any) => change(e)}
         onFocus={(e: any) => focus(e)}
         onBlur={(e: any) => blur(e)}
@@ -284,7 +284,7 @@ export const SearchBar: FunctionComponent<
     return null
   }
 
-  const onKeypress = (e: React.KeyboardEvent) => {
+  const onKeydown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       const event = e.nativeEvent
       if (typeof event.cancelable !== 'boolean' || event.cancelable) {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

1、修复 Taro-H5 下 onSearch 不能触发的问题
2、Taro 端 icon 样式垂直居中
3、H5 端 keypress -> keydown

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
