### PR TITLE
loading组件实现

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -710,6 +710,17 @@
           "author": "swag~jun"
         },
         {
+          "version": "1.0.0",
+          "name": "Loading",
+          "type": "component",
+          "cName": "加载中",
+          "desc": "加载图标，用于显示正在加载中的状态",
+          "sort": 15,
+          "show": true,
+          "taro": false,
+          "author": "mike8625"
+        },
+        {
           "version": "2.0.0",
           "name": "NoticeBar",
           "type": "component",

--- a/src/packages/loading/__test__/loading.spec.tsx
+++ b/src/packages/loading/__test__/loading.spec.tsx
@@ -57,7 +57,7 @@ test('custom icon test', () => {
   const { container } = render(
     <Loading vertical icon={<Category width="30" height="30" color="red" />} />
   )
-  expect(container.querySelector('.nut-loading-text')).toHaveClass(
+  expect(container.querySelector('svg')).toHaveClass(
     'nut-icon-Category'
   )
 })

--- a/src/packages/loading/__test__/loading.spec.tsx
+++ b/src/packages/loading/__test__/loading.spec.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import { Category } from '@nutui/icons-react'
+import { Loading } from '../loading'
+
+test('type test', () => {
+  const { container } = render(<Loading type="circular" />)
+  expect(container.querySelector('svg')).toHaveClass('nut-icon-Loading1')
+})
+
+test('color test', () => {
+  const { container } = render(<Loading type="circular" color="#fa2c19" />)
+  expect(container.querySelector('svg')).toHaveAttribute('color', '#fa2c19')
+})
+
+test('size test', () => {
+  const { container } = render(<Loading type="circular" size="20" />)
+  expect(container.querySelector('svg')).toHaveAttribute(
+    'style',
+    'width: 20px; height: 20px;'
+  )
+})
+
+test('text test', () => {
+  const { container } = render(<Loading>加载中</Loading>)
+  const el: any = container.querySelectorAll('.nut-loading-text').length
+  expect(el > 0).toBe(true)
+})
+
+test('vertical test', () => {
+  const { container } = render(<Loading vertical>加载中</Loading>)
+  expect(container.querySelector('.nut-loading')).toHaveClass(
+    'nut-loading-vertical'
+  )
+})
+
+test('text color test', () => {
+  const { container } = render(<Loading textColor="#396aca">加载中</Loading>)
+  expect(container.querySelector('.nut-loading-text')).toHaveAttribute(
+    'style',
+    'font-size: 14px; color: rgb(57, 106, 202);'
+  )
+})
+
+test('text size test', () => {
+  const { container } = render(<Loading textSize="20">加载中</Loading>)
+  expect(container.querySelector('.nut-loading-text')).toHaveAttribute(
+    'style',
+    'font-size: 20px; color: rgb(158, 169, 175);'
+  )
+})
+
+test('custom icon test', () => {
+  const { container } = render(
+    <Loading vertical icon={<Category width="30" height="30" color="red" />} />
+  )
+  expect(container.querySelector('.nut-loading-text')).toHaveClass(
+    'nut-icon-Category'
+  )
+})

--- a/src/packages/loading/demo.taro.tsx
+++ b/src/packages/loading/demo.taro.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react'
+import { Category } from '@nutui/icons-react-taro'
+import { Loading, Button, Cell, Overlay } from '@/packages/nutui.react.taro'
+
+const LoadingDemo = () => {
+  const [visible, setVisible] = useState(false)
+
+  const WrapperStyle = {
+    display: 'flex',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }
+
+  function showOverlay() {
+    setVisible(true)
+    setTimeout(() => {
+      setVisible(false)
+    }, 2000)
+  }
+
+  return (
+    <>
+      <div className="demo">
+        <h2>基础用法</h2>
+        <Cell>
+          <Loading type="circular" />
+          <Loading type="spinner" />
+        </Cell>
+        <h2>自定义颜色</h2>
+        <Cell>
+          <Loading type="circular" color="#fa2c19" />
+          <Loading type="spinner" color="#396aca" />
+        </Cell>
+        <h2>自定义大小</h2>
+        <Cell>
+          <Loading type="circular" size="20" />
+          <Loading type="spinner" size={40} />
+        </Cell>
+        <h2>带文字</h2>
+        <Cell>
+          <Loading>加载中</Loading>
+        </Cell>
+        <h2>带文字(竖向排列)</h2>
+        <Cell>
+          <Loading vertical>加载中</Loading>
+        </Cell>
+        <h2>自定义文字颜色和大小</h2>
+        <Cell>
+          <Loading textColor="#396aca">加载中</Loading>
+          <Loading textSize="20">加载中</Loading>
+        </Cell>
+        <h2>自定义图标</h2>
+        <Cell>
+          <Loading
+            vertical
+            icon={<Category width="30" height="30" color="red" />}
+          />
+        </Cell>
+        <h2>与遮罩层结合</h2>
+        <Cell>
+          <Button type="success" onClick={() => showOverlay()}>
+            遮罩层loading(两秒后关闭)
+          </Button>
+        </Cell>
+      </div>
+      <Overlay visible={visible}>
+        <div className="wrapper" style={WrapperStyle}>
+          <Loading vertical>加载中</Loading>
+        </div>
+      </Overlay>
+    </>
+  )
+}
+
+export default LoadingDemo

--- a/src/packages/loading/demo.tsx
+++ b/src/packages/loading/demo.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { Loading } from './loading'
+import Cell from '../cell'
+import Button from '../button'
+import Overlay from '../overlay'
+import { Category } from '@nutui/icons-react'
+
+const LoadingDemo = () => {
+  const [visible, setVisible] = useState(false)
+
+  const WrapperStyle = {
+    display: 'flex',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }
+
+  function showOverlay() {
+    setVisible(true)
+    setTimeout(() => {
+      setVisible(false)
+    }, 2000)
+  }
+
+  return (
+    <>
+      <div className="demo">
+        <h2>基础用法</h2>
+        <Cell>
+          <Loading type="circular" />
+          <Loading type="spinner" />
+        </Cell>
+        <h2>自定义颜色</h2>
+        <Cell>
+          <Loading type="circular" color="#fa2c19" />
+          <Loading type="spinner" color="#396aca" />
+        </Cell>
+        <h2>自定义大小</h2>
+        <Cell>
+          <Loading type="circular" size="20" />
+          <Loading type="spinner" size={40} />
+        </Cell>
+        <h2>带文字</h2>
+        <Cell>
+          <Loading>加载中</Loading>
+        </Cell>
+        <h2>带文字(竖向排列)</h2>
+        <Cell>
+          <Loading vertical>加载中</Loading>
+        </Cell>
+        <h2>自定义文字颜色和大小</h2>
+        <Cell>
+          <Loading textColor="#396aca">加载中</Loading>
+          <Loading textSize="20">加载中</Loading>
+        </Cell>
+        <h2>自定义图标</h2>
+        <Cell>
+          <Loading
+            vertical
+            icon={<Category width="30" height="30" color="red" />}
+          />
+        </Cell>
+        <h2>与遮罩层结合</h2>
+        <Cell>
+          <Button type="success" onClick={showOverlay}>
+            遮罩层loading(两秒后关闭)
+          </Button>
+        </Cell>
+      </div>
+      <Overlay visible={visible}>
+        <div className="wrapper" style={WrapperStyle}>
+          <Loading vertical>加载中</Loading>
+        </div>
+      </Overlay>
+    </>
+  )
+}
+
+export default LoadingDemo

--- a/src/packages/loading/demo.tsx
+++ b/src/packages/loading/demo.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
+import { Category } from '@nutui/icons-react'
 import { Loading } from './loading'
 import Cell from '../cell'
 import Button from '../button'
 import Overlay from '../overlay'
-import { Category } from '@nutui/icons-react'
 
 const LoadingDemo = () => {
   const [visible, setVisible] = useState(false)
@@ -62,7 +62,7 @@ const LoadingDemo = () => {
         </Cell>
         <h2>与遮罩层结合</h2>
         <Cell>
-          <Button type="success" onClick={showOverlay}>
+          <Button type="success" onClick={() => showOverlay()}>
             遮罩层loading(两秒后关闭)
           </Button>
         </Cell>

--- a/src/packages/loading/doc.en-US.md
+++ b/src/packages/loading/doc.en-US.md
@@ -1,0 +1,216 @@
+#  Loading
+
+### Intro
+
+A loading icon, Used to show the loading state
+
+### Install
+
+```tsx
+import { Loading } from '@nutui/nutui-react';
+```
+
+## Demo
+
+### Basic Usage
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular'/>
+      <Loading type='spinner'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### Custom color
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' color='#fa2c19'/>
+      <Loading type='spinner' color='#396aca'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### Custom size
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' size='20'/>
+      <Loading type='spinner' size={40}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### With text
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading>loading</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### With text(vertical)
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical>loading</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### Custom text color and size
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading textColor='#396aca'>loading</Loading>
+      <Loading textSize='20'>loading</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### Custom icon
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+import { Category } from '@nutui/icons-react'
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical icon={<Category width='30' height='30' color='red'/>}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### With overlay
+
+:::demo
+
+```jsx
+import React, { useState } from 'react'
+import { Loading, Cell, Button, Overlay } from '@nutui/nutui-react';
+
+const App = () => {
+
+  const [visible, setVisible] = useState(false)
+
+  const WrapperStyle = {
+    display: 'flex',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+
+  function showOverlay() {
+    setVisible(true);
+    setTimeout(()=>{
+      setVisible(false);
+    }, 2000)
+  }  
+
+  return (
+    <>
+      <Cell>
+        <Button type="success" onClick={showOverlay}>with overlay(closed in 2 seconds)</Button>
+      </Cell>
+      <Overlay visible={visible}>
+        <div className="wrapper" style={WrapperStyle}>
+          <Loading vertical>loading</Loading>
+        </div>
+      </Overlay>   
+    </> 
+  );
+};
+export default App;
+```
+
+:::
+
+## API
+
+### Props
+
+| Name         | Description                          | type   | default           |
+|--------------|----------------------------------|--------|------------------|
+| type         | loading icon type                    | circular \| spinner | `circular`          |
+| color        | loading icon color                   | String              | `#9EA9AF`           |
+| size         | loading icon size                    | String \| Number    | `32`                |
+| textColor    | text color                           | String              | `#9EA9AF`           |
+| textSize     | text size                            | String \| Number    | `14`                |
+| vertical     | whether icon and text are layout vertical     |  Boolean            | `false`
+| icon         | custom loading icon                  | JSX.Element         |  `-`

--- a/src/packages/loading/doc.en-US.md
+++ b/src/packages/loading/doc.en-US.md
@@ -178,7 +178,7 @@ const App = () => {
 
   function showOverlay() {
     setVisible(true);
-    setTimeout(()=>{
+    setTimeout(() => {
       setVisible(false);
     }, 2000)
   }  
@@ -186,7 +186,7 @@ const App = () => {
   return (
     <>
       <Cell>
-        <Button type="success" onClick={showOverlay}>with overlay(closed in 2 seconds)</Button>
+        <Button type="success" onClick={() => showOverlay()}>with overlay(closed in 2 seconds)</Button>
       </Cell>
       <Overlay visible={visible}>
         <div className="wrapper" style={WrapperStyle}>

--- a/src/packages/loading/doc.md
+++ b/src/packages/loading/doc.md
@@ -186,7 +186,7 @@ const App = () => {
   return (
     <>
       <Cell>
-        <Button type="success" onClick={showOverlay}>遮罩层loading(两秒后关闭)</Button>
+        <Button type="success" onClick={() => showOverlay()}>遮罩层loading(两秒后关闭)</Button>
       </Cell>
       <Overlay visible={visible}>
         <div className="wrapper" style={WrapperStyle}>

--- a/src/packages/loading/doc.md
+++ b/src/packages/loading/doc.md
@@ -1,0 +1,216 @@
+#  Loading 加载中
+
+### 介绍
+
+加载图标，用于显示正在加载中的状态
+
+### 安装
+
+```tsx
+import { Loading } from '@nutui/nutui-react';
+```
+
+## 代码演示
+
+### 基础用法
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular'/>
+      <Loading type='spinner'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义颜色
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' color='#fa2c19'/>
+      <Loading type='spinner' color='#396aca'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义大小
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' size='20'/>
+      <Loading type='spinner' size={40}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 带文字
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading>加载中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 带文字(竖向排列)
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical>加载中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义文字颜色和大小
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading textColor='#396aca'>加载中</Loading>
+      <Loading textSize='20'>加载中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义图标
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+import { Category } from '@nutui/icons-react'
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical icon={<Category width='30' height='30' color='red'/>}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 与遮罩层结合
+
+:::demo
+
+```jsx
+import React, { useState } from 'react'
+import { Loading, Cell, Button, Overlay } from '@nutui/nutui-react';
+
+const App = () => {
+
+  const [visible, setVisible] = useState(false)
+
+  const WrapperStyle = {
+    display: 'flex',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+
+  function showOverlay() {
+    setVisible(true);
+    setTimeout(()=>{
+      setVisible(false);
+    }, 2000)
+  }  
+
+  return (
+    <>
+      <Cell>
+        <Button type="success" onClick={showOverlay}>遮罩层loading(两秒后关闭)</Button>
+      </Cell>
+      <Overlay visible={visible}>
+        <div className="wrapper" style={WrapperStyle}>
+          <Loading vertical>加载中</Loading>
+        </div>
+      </Overlay>   
+    </> 
+  );
+};
+export default App;
+```
+
+:::
+
+## API
+
+### Props
+
+| 参数         | 说明                             | 类型   | 默认值           |
+|--------------|----------------------------------|--------|------------------|
+| type         | loading图标的样式                    | circular \| spinner | `circular`          |
+| color        | loading图标的颜色                    | String              | `#9EA9AF`           |
+| size         | loading图标的大小                    | String \| Number    | `32`                |
+| textColor    | 文字的颜色                           | String              | `#9EA9AF`           |
+| textSize     | 文字的大小                           | String \| Number    | `14`                |
+| vertical     | loading图标和文字是否竖向排列        |  Boolean            | `false`
+| icon         | 自定义loading的图标                  | JSX.Element         |  `-`

--- a/src/packages/loading/doc.taro.md
+++ b/src/packages/loading/doc.taro.md
@@ -186,7 +186,7 @@ const App = () => {
   return (
     <>
       <Cell>
-        <Button type="success" onClick={showOverlay}>遮罩层loading(两秒后关闭)</Button>
+        <Button type="success" onClick={() => showOverlay()}>遮罩层loading(两秒后关闭)</Button>
       </Cell>
       <Overlay visible={visible}>
         <div className="wrapper" style={WrapperStyle}>

--- a/src/packages/loading/doc.taro.md
+++ b/src/packages/loading/doc.taro.md
@@ -1,0 +1,216 @@
+#  Loading 加载中
+
+### 介绍
+
+加载图标，用于显示正在加载中的状态
+
+### 安装
+
+```tsx
+import { Loading } from '@nutui/nutui-react-taro';
+```
+
+## 代码演示
+
+### 基础用法
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react-taro';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular'/>
+      <Loading type='spinner'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义颜色
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react-taro';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' color='#fa2c19'/>
+      <Loading type='spinner' color='#396aca'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义大小
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react-taro';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' size='20'/>
+      <Loading type='spinner' size={40}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 带文字
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react-taro';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading>加载中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 带文字(竖向排列)
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react-taro';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical>加载中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义文字颜色和大小
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react-taro';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading textColor='#396aca'>加载中</Loading>
+      <Loading textSize='20'>加载中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定义图标
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react-taro';
+import { Category } from '@nutui/icons-react'
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical icon={<Category width='30' height='30' color='red'/>}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 与遮罩层结合
+
+:::demo
+
+```jsx
+import React, { useState } from 'react'
+import { Loading, Cell, Button, Overlay } from '@nutui/nutui-react-taro';
+
+const App = () => {
+
+  const [visible, setVisible] = useState(false)
+
+  const WrapperStyle = {
+    display: 'flex',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+
+  function showOverlay() {
+    setVisible(true);
+    setTimeout(()=>{
+      setVisible(false);
+    }, 2000)
+  }  
+
+  return (
+    <>
+      <Cell>
+        <Button type="success" onClick={showOverlay}>遮罩层loading(两秒后关闭)</Button>
+      </Cell>
+      <Overlay visible={visible}>
+        <div className="wrapper" style={WrapperStyle}>
+          <Loading vertical>加载中</Loading>
+        </div>
+      </Overlay>   
+    </> 
+  );
+};
+export default App;
+```
+
+:::
+
+## API
+
+### Props
+
+| 参数         | 说明                             | 类型   | 默认值           |
+|--------------|----------------------------------|--------|------------------|
+| type         | loading图标的样式                    | circular \| spinner | `circular`          |
+| color        | loading图标的颜色                    | String              | `#9EA9AF`           |
+| size         | loading图标的大小                    | String \| Number    | `32`                |
+| textColor    | 文字的颜色                           | String              | `#9EA9AF`           |
+| textSize     | 文字的大小                           | String \| Number    | `14`                |
+| vertical     | loading图标和文字是否竖向排列        |  Boolean            | `false`
+| icon         | 自定义loading的图标                  | JSX.Element         |  `-`

--- a/src/packages/loading/doc.zh-TW.md
+++ b/src/packages/loading/doc.zh-TW.md
@@ -186,7 +186,7 @@ const App = () => {
   return (
     <>
       <Cell>
-        <Button type="success" onClick={showOverlay}>遮罩層loading(兩秒後關閉)</Button>
+        <Button type="success" onClick={() => showOverlay()}>遮罩層loading(兩秒後關閉)</Button>
       </Cell>
       <Overlay visible={visible}>
         <div className="wrapper" style={WrapperStyle}>

--- a/src/packages/loading/doc.zh-TW.md
+++ b/src/packages/loading/doc.zh-TW.md
@@ -1,0 +1,216 @@
+#  Loading 加載中
+
+### 介紹
+
+加載圖標，用於顯示正在加載中的狀態
+
+### 安裝
+
+```tsx
+import { Loading } from '@nutui/nutui-react';
+```
+
+## 代碼演示
+
+### 基礎用法
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular'/>
+      <Loading type='spinner'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定義顏色
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' color='#fa2c19'/>
+      <Loading type='spinner' color='#396aca'/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定義大小
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading type='circular' size='20'/>
+      <Loading type='spinner' size={40}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 帶文字
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading>加載中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 帶文字(豎向排列)
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical>加載中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定義文字顏色和大小
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading textColor='#396aca'>加載中</Loading>
+      <Loading textSize='20'>加載中</Loading>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 自定義圖標
+
+:::demo
+
+```jsx
+import  React from "react";
+import { Loading, Cell } from '@nutui/nutui-react';
+import { Category } from '@nutui/icons-react'
+
+const App = () => {
+  return (
+    <Cell>
+      <Loading vertical icon={<Category width='30' height='30' color='red'/>}/>
+    </Cell>
+  );
+};
+export default App;
+```
+
+:::
+
+### 與遮罩層結合
+
+:::demo
+
+```jsx
+import React, { useState } from 'react'
+import { Loading, Cell, Button, Overlay } from '@nutui/nutui-react';
+
+const App = () => {
+
+  const [visible, setVisible] = useState(false)
+
+  const WrapperStyle = {
+    display: 'flex',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+
+  function showOverlay() {
+    setVisible(true);
+    setTimeout(()=>{
+      setVisible(false);
+    }, 2000)
+  }  
+
+  return (
+    <>
+      <Cell>
+        <Button type="success" onClick={showOverlay}>遮罩層loading(兩秒後關閉)</Button>
+      </Cell>
+      <Overlay visible={visible}>
+        <div className="wrapper" style={WrapperStyle}>
+          <Loading vertical>加載中</Loading>
+        </div>
+      </Overlay>   
+    </> 
+  );
+};
+export default App;
+```
+
+:::
+
+## API
+
+### Props
+
+| 參數         | 說明                             | 類型   | 默認值           |
+|--------------|----------------------------------|--------|------------------|
+| type         | loading圖標的樣式                    | circular \| spinner | `circular`          |
+| color        | loading圖標的顏色                    | String              | `#9EA9AF`           |
+| size         | loading圖標的大小                    | String \| Number    | `32`                |
+| textColor    | 文字的顏色                           | String              | `#9EA9AF`           |
+| textSize     | 文字的大小                           | String \| Number    | `14`                |
+| vertical     | loading圖標和文字是否豎向排列        |  Boolean            | `false`
+| icon         | 自定義loading的圖標                  | JSX.Element         |  `-`

--- a/src/packages/loading/index.taro.ts
+++ b/src/packages/loading/index.taro.ts
@@ -1,0 +1,2 @@
+import {Loading} from './loading.taro'
+export default Loading

--- a/src/packages/loading/index.taro.ts
+++ b/src/packages/loading/index.taro.ts
@@ -1,2 +1,3 @@
-import {Loading} from './loading.taro'
+import { Loading } from './loading.taro'
+
 export default Loading

--- a/src/packages/loading/index.ts
+++ b/src/packages/loading/index.ts
@@ -1,0 +1,2 @@
+import {Loading} from './loading'
+export default Loading

--- a/src/packages/loading/index.ts
+++ b/src/packages/loading/index.ts
@@ -1,2 +1,3 @@
-import {Loading} from './loading'
+import { Loading } from './loading'
+
 export default Loading

--- a/src/packages/loading/loading.scss
+++ b/src/packages/loading/loading.scss
@@ -1,0 +1,26 @@
+.nut-loading {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  &.nut-loading-vertical {
+    flex-direction: column;
+  }
+  .nut-loading-icon {
+    display: inline-block;
+    font-size: 0;
+    line-height: 0;
+    animation: nut-loading-rotation 1s infinite linear;
+  }
+  .nut-loading-text {
+    padding: 4px;
+  }
+}
+@keyframes nut-loading-rotation {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}

--- a/src/packages/loading/loading.taro.tsx
+++ b/src/packages/loading/loading.taro.tsx
@@ -1,0 +1,103 @@
+import React, { FunctionComponent } from 'react'
+import classNames from 'classnames'
+import './loading.scss'
+import {
+  Loading as IconLoading,
+  Loading1 as IconLoading1,
+} from '@nutui/icons-react-taro'
+import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+
+export type LoadingType = 'spinner' | 'circular'
+
+export interface LoadingProps extends BasicComponent {
+  // loading的类型
+  type: LoadingType
+  // loading的颜色
+  color: string
+  // loading的大小 下面会把size转成width和height
+  size: number | string
+  // 文字的大小
+  textSize: number | string
+  // 文字的颜色
+  textColor: string
+  // 是否竖向排列loading图标和文字
+  vertical: boolean
+  // 自定义图标
+  icon?: JSX.Element
+}
+
+// 方便以后扩展设置为键值对形式
+const loadingMap = {
+  circular: IconLoading1,
+  spinner: IconLoading,
+}
+
+const defaultProps = {
+  ...ComponentDefaults,
+  // 对比一下,个人感觉还是Loading1比较好看一些,所以用它作为了默认的loading图标
+  type: 'circular',
+  color: '#9EA9AF',
+  size: 32,
+  textColor: '#9EA9AF',
+  textSize: 14,
+  vertical: false,
+} as LoadingProps
+export const Loading: FunctionComponent<
+  Partial<LoadingProps> & React.HTMLAttributes<HTMLDivElement>
+> = (props) => {
+  const {
+    className,
+    style,
+    children,
+    color,
+    size,
+    textColor,
+    textSize,
+    vertical,
+    icon,
+    ...rest
+  } = {
+    ...defaultProps,
+    ...props,
+  }
+
+  // 样式class前缀
+  const classPrefix = 'nut-loading'
+
+  let CurLoadingIcon = loadingMap[rest.type] || IconLoading1
+
+  return (
+    <div
+      className={classNames(
+        classPrefix,
+        className,
+        vertical ? `${classPrefix}-vertical` : ''
+      )}
+      style={style}
+    >
+      <div className={`${classPrefix}-icon`}>
+        {icon ? (
+          icon
+        ) : (
+          <CurLoadingIcon color={color} width={size} height={size} />
+        )}
+      </div>
+      {children ? (
+        <div
+          className={`${classPrefix}-text`}
+          style={{
+            fontSize: parseInt(textSize.toString()) + 'px',
+            color: textColor,
+          }}
+        >
+          {children}
+        </div>
+      ) : (
+        ''
+      )}
+    </div>
+  )
+}
+
+Loading.defaultProps = defaultProps
+Loading.displayName = 'NutLoading'

--- a/src/packages/loading/loading.taro.tsx
+++ b/src/packages/loading/loading.taro.tsx
@@ -64,7 +64,7 @@ export const Loading: FunctionComponent<
   // 样式class前缀
   const classPrefix = 'nut-loading'
 
-  let CurLoadingIcon = loadingMap[rest.type] || IconLoading1
+  const CurLoadingIcon = loadingMap[rest.type] || IconLoading1
 
   return (
     <div
@@ -76,17 +76,13 @@ export const Loading: FunctionComponent<
       style={style}
     >
       <div className={`${classPrefix}-icon`}>
-        {icon ? (
-          icon
-        ) : (
-          <CurLoadingIcon color={color} width={size} height={size} />
-        )}
+        {icon || <CurLoadingIcon color={color} width={size} height={size} />}
       </div>
       {children ? (
         <div
           className={`${classPrefix}-text`}
           style={{
-            fontSize: parseInt(textSize.toString()) + 'px',
+            fontSize: `${parseInt(textSize.toString())}px`,
             color: textColor,
           }}
         >

--- a/src/packages/loading/loading.taro.tsx
+++ b/src/packages/loading/loading.taro.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from 'react'
 import classNames from 'classnames'
-import './loading.scss'
 import {
   Loading as IconLoading,
   Loading1 as IconLoading1,

--- a/src/packages/loading/loading.tsx
+++ b/src/packages/loading/loading.tsx
@@ -1,0 +1,103 @@
+import React, { FunctionComponent } from 'react'
+import classNames from 'classnames'
+import './loading.scss'
+import {
+  Loading as IconLoading,
+  Loading1 as IconLoading1,
+} from '@nutui/icons-react'
+import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+
+export type LoadingType = 'spinner' | 'circular'
+
+export interface LoadingProps extends BasicComponent {
+  // loading的类型
+  type: LoadingType
+  // loading的颜色
+  color: string
+  // loading的大小 下面会把size转成width和height
+  size: number | string
+  // 文字的大小
+  textSize: number | string
+  // 文字的颜色
+  textColor: string
+  // 是否竖向排列loading图标和文字
+  vertical: boolean
+  // 自定义图标
+  icon?: JSX.Element
+}
+
+// 方便以后扩展设置为键值对形式
+const loadingMap = {
+  circular: IconLoading1,
+  spinner: IconLoading,
+}
+
+const defaultProps = {
+  ...ComponentDefaults,
+  // 对比一下,个人感觉还是Loading1比较好看一些,所以用它作为了默认的loading图标
+  type: 'circular',
+  color: '#9EA9AF',
+  size: 32,
+  textColor: '#9EA9AF',
+  textSize: 14,
+  vertical: false,
+} as LoadingProps
+export const Loading: FunctionComponent<
+  Partial<LoadingProps> & React.HTMLAttributes<HTMLDivElement>
+> = (props) => {
+  const {
+    className,
+    style,
+    children,
+    color,
+    size,
+    textColor,
+    textSize,
+    vertical,
+    icon,
+    ...rest
+  } = {
+    ...defaultProps,
+    ...props,
+  }
+
+  // 样式class前缀
+  const classPrefix = 'nut-loading'
+
+  let CurLoadingIcon = loadingMap[rest.type] || IconLoading1
+
+  return (
+    <div
+      className={classNames(
+        classPrefix,
+        className,
+        vertical ? `${classPrefix}-vertical` : ''
+      )}
+      style={style}
+    >
+      <div className={`${classPrefix}-icon`}>
+        {icon ? (
+          icon
+        ) : (
+          <CurLoadingIcon color={color} width={size} height={size} />
+        )}
+      </div>
+      {children ? (
+        <div
+          className={`${classPrefix}-text`}
+          style={{
+            fontSize: parseInt(textSize.toString()) + 'px',
+            color: textColor,
+          }}
+        >
+          {children}
+        </div>
+      ) : (
+        ''
+      )}
+    </div>
+  )
+}
+
+Loading.defaultProps = defaultProps
+Loading.displayName = 'NutLoading'

--- a/src/packages/loading/loading.tsx
+++ b/src/packages/loading/loading.tsx
@@ -64,7 +64,7 @@ export const Loading: FunctionComponent<
   // 样式class前缀
   const classPrefix = 'nut-loading'
 
-  let CurLoadingIcon = loadingMap[rest.type] || IconLoading1
+  const CurLoadingIcon = loadingMap[rest.type] || IconLoading1
 
   return (
     <div
@@ -76,17 +76,13 @@ export const Loading: FunctionComponent<
       style={style}
     >
       <div className={`${classPrefix}-icon`}>
-        {icon ? (
-          icon
-        ) : (
-          <CurLoadingIcon color={color} width={size} height={size} />
-        )}
+        {icon || <CurLoadingIcon color={color} width={size} height={size} />}
       </div>
       {children ? (
         <div
           className={`${classPrefix}-text`}
           style={{
-            fontSize: parseInt(textSize.toString()) + 'px',
+            fontSize: `${parseInt(textSize.toString())}px`,
             color: textColor,
           }}
         >

--- a/src/packages/loading/loading.tsx
+++ b/src/packages/loading/loading.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from 'react'
 import classNames from 'classnames'
-import './loading.scss'
 import {
   Loading as IconLoading,
   Loading1 as IconLoading1,


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [  ☑️ ] 新特性提交


### 🔗 相关 Issue

https://github.com/jdf2e/nutui-rfcs/blob/main/react/Loading.md

### 💡 需求背景和解决方案

实现了nutui2.0的loading组件的h5版本,  引入Loading组件后, 使用<Loading type="circular" />标签即可显示. 
目前由于我是在windows10中开发,试了很多方法都无法启动taro版本的小程序,询问了几个大佬,他们都是在mac下开发. 所以taro的代码目前都是盲写的,已经把config.json中的taro设置为了false.
本来想等windows中可以测试完成后再提pr, 但是询问了佟小牙大佬后,她说先提交一下,taro的功能后面再完善.

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [☑️ ] 文档已补充或无须补充
- [ ☑️] 代码演示已提供或无须提供
- [☑️ ] TypeScript 定义已补充或无须补充
- [☑️ ] fork仓库代码是否为最新避免文件冲突
- [ ☑️] Files changed 没有 package.json lock 等无关文件
