### PR TITLE
feat: configprovider 组件支持传入 className 和 style 属性

### DIFF
--- a/src/packages/configprovider/__test__/__snapshots__/configprovider.spec.tsx.snap
+++ b/src/packages/configprovider/__test__/__snapshots__/configprovider.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`configprovider should match snapshot 1`] = `
+<div>
+  <div
+    class="nut-configprovider aa"
+    style="margin: 8px;"
+  >
+    测试
+  </div>
+</div>
+`;

--- a/src/packages/configprovider/__test__/configprovider.spec.tsx
+++ b/src/packages/configprovider/__test__/configprovider.spec.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import { ConfigProvider } from '../configprovider'
+
+describe('configprovider', () => {
+  let container: any
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container)
+    container = null
+  })
+
+  test('should match snapshot', () => {
+    const { container } = render(
+      <ConfigProvider className="aa" style={{ margin: 8 }}>
+        测试
+      </ConfigProvider>
+    )
+    expect(container.firstChild?.nodeName).toBe('DIV')
+    expect(container).toMatchSnapshot()
+  })
+
+  test('should children correctly', () => {
+    const darkTheme = {
+      nutuiBrandColor: 'green',
+      nutuiBrandColorStart: 'green',
+      nutuiBrandColorEnd: 'green',
+    }
+    const { getByText, container } = render(
+      <ConfigProvider
+        data-testid="configprovider"
+        className="bb"
+        style={{ margin: 8 }}
+        theme={darkTheme}
+      >
+        测试
+      </ConfigProvider>
+    )
+    expect(getByText('测试')).toHaveTextContent('测试')
+    expect(container.querySelector('.nut-configprovider')).toHaveClass(
+      'nut-configprovider bb'
+    )
+    expect(container.querySelector('.nut-configprovider')).toHaveStyle(
+      '--nutui-brand-color: green; --nutui-brand-color-start: green; --nutui-brand-color-end: green; margin: 8px;'
+    )
+  })
+})

--- a/src/packages/configprovider/__test__/configprovider.spec.tsx
+++ b/src/packages/configprovider/__test__/configprovider.spec.tsx
@@ -2,8 +2,9 @@ import * as React from 'react'
 
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import enUS from '@/locales/en-US'
 
-import { ConfigProvider } from '../configprovider'
+import { ConfigProvider, useConfig } from '../configprovider'
 
 describe('configprovider', () => {
   let container: any
@@ -28,27 +29,32 @@ describe('configprovider', () => {
     expect(container).toMatchSnapshot()
   })
 
-  test('should theme variable injection correctly', () => {
+  test('should theme variable and locale variable injection correctly', () => {
+    const Children: React.FC = () => {
+      const { locale } = useConfig()
+      return <>{locale.save}</>
+    }
     const darkTheme = {
       nutuiBrandColor: 'green',
       nutuiBrandColorStart: 'green',
       nutuiBrandColorEnd: 'green',
     }
-    const { getByText, container } = render(
+    const { container } = render(
       <ConfigProvider
         data-testid="configprovider"
+        locale={enUS}
         className="bb"
         style={{ margin: 8 }}
         theme={darkTheme}
       >
-        测试
+        <Children />
       </ConfigProvider>
     )
-    expect(getByText('测试')).toHaveTextContent('测试')
-    expect(container.querySelector('.nut-configprovider')).toHaveClass(
-      'nut-configprovider bb'
-    )
-    expect(container.querySelector('.nut-configprovider')).toHaveStyle(
+
+    const ele = container.querySelector('.nut-configprovider')
+    expect(ele).toHaveTextContent('Save')
+    expect(ele).toHaveClass('nut-configprovider bb')
+    expect(ele).toHaveStyle(
       '--nutui-brand-color: green; --nutui-brand-color-start: green; --nutui-brand-color-end: green; margin: 8px;'
     )
   })

--- a/src/packages/configprovider/__test__/configprovider.spec.tsx
+++ b/src/packages/configprovider/__test__/configprovider.spec.tsx
@@ -28,7 +28,7 @@ describe('configprovider', () => {
     expect(container).toMatchSnapshot()
   })
 
-  test('should children correctly', () => {
+  test('should theme variable injection correctly', () => {
     const darkTheme = {
       nutuiBrandColor: 'green',
       nutuiBrandColorStart: 'green',

--- a/src/packages/configprovider/configprovider.taro.tsx
+++ b/src/packages/configprovider/configprovider.taro.tsx
@@ -1,24 +1,19 @@
-import React, {
-  FunctionComponent,
-  createContext,
-  useContext,
-  CSSProperties,
-} from 'react'
+import React, { FunctionComponent, createContext, useContext } from 'react'
 import classNames from 'classnames'
 import kebabCase from 'lodash.kebabcase'
 import { BaseLang } from '@/locales/base'
 import zhCN from '@/locales/zh-CN'
+import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import type { NutCSSVariables } from './types'
 
-export interface ConfigProviderProps {
+export interface ConfigProviderProps extends BasicComponent {
   locale: BaseLang
   theme?: Record<string | NutCSSVariables, string>
-  className?: string
-  style?: CSSProperties
   [key: string]: any
 }
 
 const defaultProps = {
+  ...ComponentDefaults,
   locale: zhCN,
 } as ConfigProviderProps
 

--- a/src/packages/configprovider/configprovider.taro.tsx
+++ b/src/packages/configprovider/configprovider.taro.tsx
@@ -2,9 +2,9 @@ import React, {
   FunctionComponent,
   createContext,
   useContext,
-  useMemo,
   CSSProperties,
 } from 'react'
+import classNames from 'classnames'
 import kebabCase from 'lodash.kebabcase'
 import { BaseLang } from '@/locales/base'
 import zhCN from '@/locales/zh-CN'
@@ -13,13 +13,16 @@ import type { NutCSSVariables } from './types'
 export interface ConfigProviderProps {
   locale: BaseLang
   theme?: Record<string | NutCSSVariables, string>
-
+  className?: string
+  style?: CSSProperties
   [key: string]: any
 }
 
 const defaultProps = {
   locale: zhCN,
 } as ConfigProviderProps
+
+const classPrefix = 'nut-configprovider'
 
 export const defaultConfigRef: {
   current: ConfigProviderProps
@@ -55,13 +58,12 @@ function convertThemeVarsToCSSVars(themeVars: Record<string, string | number>) {
 export const ConfigProvider: FunctionComponent<
   Partial<ConfigProviderProps> & React.HTMLAttributes<HTMLDivElement>
 > = (props) => {
-  const { children, ...config } = { ...defaultProps, ...props }
+  const { children, className, ...config } = { ...defaultProps, ...props }
   const parentConfig = useConfig()
-  const theme = config.theme || {}
-  const style = useMemo<CSSProperties | undefined>(
-    () => convertThemeVarsToCSSVars(theme),
-    [theme]
-  )
+  const style = {
+    ...convertThemeVarsToCSSVars(config.theme || {}),
+    ...config.style,
+  }
 
   return (
     <ConfigContext.Provider
@@ -70,7 +72,9 @@ export const ConfigProvider: FunctionComponent<
         ...config,
       }}
     >
-      <div style={style}>{children}</div>
+      <div className={classNames(classPrefix, className)} style={style}>
+        {children}
+      </div>
     </ConfigContext.Provider>
   )
 }

--- a/src/packages/configprovider/configprovider.tsx
+++ b/src/packages/configprovider/configprovider.tsx
@@ -1,24 +1,19 @@
-import React, {
-  FunctionComponent,
-  createContext,
-  useContext,
-  CSSProperties,
-} from 'react'
+import React, { FunctionComponent, createContext, useContext } from 'react'
 import classNames from 'classnames'
 import kebabCase from 'lodash.kebabcase'
 import { BaseLang } from '@/locales/base'
 import zhCN from '@/locales/zh-CN'
+import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import type { NutCSSVariables } from './types'
 
-export interface ConfigProviderProps {
+export interface ConfigProviderProps extends BasicComponent {
   locale: BaseLang
   theme?: Record<string | NutCSSVariables, string>
-  className?: string
-  style?: CSSProperties
   [key: string]: any
 }
 
 const defaultProps = {
+  ...ComponentDefaults,
   locale: zhCN,
 } as ConfigProviderProps
 

--- a/src/packages/configprovider/configprovider.tsx
+++ b/src/packages/configprovider/configprovider.tsx
@@ -2,9 +2,9 @@ import React, {
   FunctionComponent,
   createContext,
   useContext,
-  useMemo,
   CSSProperties,
 } from 'react'
+import classNames from 'classnames'
 import kebabCase from 'lodash.kebabcase'
 import { BaseLang } from '@/locales/base'
 import zhCN from '@/locales/zh-CN'
@@ -13,13 +13,16 @@ import type { NutCSSVariables } from './types'
 export interface ConfigProviderProps {
   locale: BaseLang
   theme?: Record<string | NutCSSVariables, string>
-
+  className?: string
+  style?: CSSProperties
   [key: string]: any
 }
 
 const defaultProps = {
   locale: zhCN,
 } as ConfigProviderProps
+
+const classPrefix = 'nut-configprovider'
 
 export const defaultConfigRef: {
   current: ConfigProviderProps
@@ -55,13 +58,12 @@ function convertThemeVarsToCSSVars(themeVars: Record<string, string | number>) {
 export const ConfigProvider: FunctionComponent<
   Partial<ConfigProviderProps> & React.HTMLAttributes<HTMLDivElement>
 > = (props) => {
-  const { children, ...config } = { ...defaultProps, ...props }
+  const { children, className, ...config } = { ...defaultProps, ...props }
   const parentConfig = useConfig()
-  const theme = config.theme || {}
-  const style = useMemo<CSSProperties | undefined>(
-    () => convertThemeVarsToCSSVars(theme),
-    [theme]
-  )
+  const style = {
+    ...convertThemeVarsToCSSVars(config.theme || {}),
+    ...config.style,
+  }
 
   return (
     <ConfigContext.Provider
@@ -70,7 +72,9 @@ export const ConfigProvider: FunctionComponent<
         ...config,
       }}
     >
-      <div style={style}>{children}</div>
+      <div className={classNames(classPrefix, className)} style={style}>
+        {children}
+      </div>
     </ConfigContext.Provider>
   )
 }

--- a/src/packages/configprovider/doc.en-US.md
+++ b/src/packages/configprovider/doc.en-US.md
@@ -37,6 +37,8 @@ You can override these CSS variables directly in your code, and the styling of t
 
 The ConfigProvider component provides the ability to override CSS variables, and you need to wrap a ConfigProvider component at the root node and pass the theme Properties to configure some theme variables.
 
+> "ConfigProvider" component is not a virtual component, it generates a "div" tag.
+
 :::demo
 
 ```tsx

--- a/src/packages/configprovider/doc.md
+++ b/src/packages/configprovider/doc.md
@@ -37,6 +37,8 @@ NutUI-React 可以通过 [CSS 变量](https://developer.mozilla.org/zh-CN/docs/W
 
 ConfigProvider 组件提供了覆盖 CSS 变量的能力，你需要在根节点包裹一个 ConfigProvider 组件，并通过 theme 属性来配置一些主题变量。
 
+> ConfigProvider 组件不是一个虚拟组件，它会生成一个 div 标签。
+
 :::demo
 
 ```tsx

--- a/src/packages/configprovider/doc.taro.md
+++ b/src/packages/configprovider/doc.taro.md
@@ -37,6 +37,8 @@ NutUI-React 可以通过 [CSS 变量](https://developer.mozilla.org/zh-CN/docs/W
 
 ConfigProvider 组件提供了覆盖 CSS 变量的能力，你需要在根节点包裹一个 ConfigProvider 组件，并通过 theme 属性来配置一些主题变量。
 
+> ConfigProvider 组件不是一个虚拟组件，它会生成一个 View 标签。
+
 :::demo
 
 ```tsx

--- a/src/packages/configprovider/doc.zh-TW.md
+++ b/src/packages/configprovider/doc.zh-TW.md
@@ -37,6 +37,8 @@ NutUI-React 可以通過 \[CSS 變數\]（https://developer.mozilla.org/zh-CN/do
 
 ConfigProvider 元件提供了覆蓋 CSS 變數的能力，你需要在根節點包裹一個 ConfigProvider 元件，並通過 theme 屬性來配置一些主題變數。
 
+> ConfigProvider 組件不是一個虛擬組件，它會生成一個 div 標簽。
+
 :::demo
 
 ```tsx


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
`configprovider` 组件实际上会生成一个 `div` 节点，该节点可能对上下文布局产生影响，却没有方式去改变该节点的样式，故此为组件增加了`className` 和 `style` 属性
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
