### PR TITLE
fix(Address): 修复Address组件通过点击CloseIcon和Overlay关闭后，无法再次打开的问题

### DIFF
--- a/src/packages/address/__test__/address.spec.tsx
+++ b/src/packages/address/__test__/address.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import React, { useRef } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Address } from '../address'
 
@@ -178,4 +178,59 @@ test('Address: exist defaultIcon & selectIcon', async () => {
 
   fireEvent.click(items[1])
   expect(items[1].innerHTML).toContain('<div class="select">456</div>')
+})
+
+function sleep(delay = 0): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay)
+  })
+}
+
+describe('Address', () => {
+  interface WrapperProps {
+    visible: boolean
+  }
+
+  const Wrapper: React.FC<WrapperProps> = ({ visible }) => {
+    const ref = useRef<any>()
+    return (
+      <div>
+        <button onClick={() => ref.current?.open()}>Open</button>
+        <button onClick={() => ref.current?.close()}>Close</button>
+        <Address
+          defaultVisible={visible}
+          ref={ref}
+          options={optionsDemo1}
+          title="选择地址"
+        />
+      </div>
+    )
+  }
+
+  it('should handle open and close methods', async () => {
+    const screen = render(<Wrapper visible={false} />)
+
+    fireEvent.click(screen.getByText('Open'))
+    await waitFor(
+      async () => {
+        await sleep(1000)
+        const title = screen.container.querySelector('.nut-popup-title')
+        expect(title?.innerHTML).toBe('选择地址')
+      },
+      {
+        timeout: 2000,
+      }
+    )
+
+    fireEvent.click(screen.getByText('Close'))
+    await waitFor(
+      async () => {
+        await sleep(1000)
+        expect(screen.container.querySelector('.nut-popup-title')).toBe(null)
+      },
+      {
+        timeout: 2000,
+      }
+    )
+  })
 })

--- a/src/packages/address/address.taro.tsx
+++ b/src/packages/address/address.taro.tsx
@@ -92,7 +92,9 @@ export const Address: FunctionComponent<
 
   const handClose = () => {
     setShowPopup(false)
+    onClose && onClose()
   }
+
   useEffect(() => {
     setShowPopup(visible)
   }, [visible])
@@ -154,6 +156,7 @@ export const Address: FunctionComponent<
           closeable
           closeIcon={closeIcon}
           title={title || locale.address.selectRegion}
+          onClose={handClose}
         >
           <div
             className={`${classPrefix} ${className || ''}`}

--- a/src/packages/address/address.tsx
+++ b/src/packages/address/address.tsx
@@ -90,7 +90,9 @@ export const Address: FunctionComponent<
 
   const handClose = () => {
     setShowPopup(false)
+    onClose && onClose()
   }
+
   useEffect(() => {
     setShowPopup(visible)
   }, [visible])
@@ -152,6 +154,7 @@ export const Address: FunctionComponent<
           closeable
           closeIcon={closeIcon}
           title={title || locale.address.selectRegion}
+          onClose={handClose}
         >
           <div
             className={`${classPrefix} ${className || ''}`}

--- a/src/packages/address/address.tsx
+++ b/src/packages/address/address.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, useEffect, useState } from 'react'
+import React, {
+  ForwardRefRenderFunction,
+  useImperativeHandle,
+  forwardRef,
+  useState,
+} from 'react'
 import { Left } from '@nutui/icons-react'
 import Popup from '@/packages/popup'
 import { CustomRender } from './customRender'
@@ -12,9 +17,16 @@ import {
   CascaderValue,
 } from '@/packages/cascader/index'
 import { ComponentDefaults } from '@/utils/typings'
+import { usePropsValue } from '@/utils/use-props-value'
+
+type AddressRef = {
+  open: () => void
+  close: () => void
+}
 
 export interface AddressProps extends CascaderProps {
   visible: boolean
+  defaultVisible: boolean
   value?: CascaderValue
   defaultValue?: CascaderValue
   type: string
@@ -34,7 +46,6 @@ export interface AddressProps extends CascaderProps {
 
 const defaultProps = {
   ...ComponentDefaults,
-  visible: false,
   defaultValue: [],
   type: 'custom',
   options: [],
@@ -49,16 +60,18 @@ const defaultProps = {
   backIcon: null,
 } as unknown as AddressProps
 
-export const Address: FunctionComponent<
+export const InternalAddress: ForwardRefRenderFunction<
+  AddressRef,
   Partial<AddressProps> &
     Omit<
       React.HTMLAttributes<HTMLDivElement>,
       'onChange' | 'defaultValue' | 'onLoad' | 'title'
     >
-> = (props) => {
+> = (props, ref) => {
   const { locale } = useConfig()
   const {
     visible,
+    defaultVisible,
     defaultValue,
     children,
     type,
@@ -86,16 +99,27 @@ export const Address: FunctionComponent<
   }
   const classPrefix = 'nut-address'
   const [currentType, setCurrentType] = useState<string>(type)
-  const [showPopup, setShowPopup] = useState(visible)
+  const [innerVisible, setInnerVisible] = usePropsValue<boolean>({
+    value: visible,
+    defaultValue: defaultVisible,
+    finalValue: defaultVisible,
+  })
 
-  const handClose = () => {
-    setShowPopup(false)
+  useImperativeHandle(ref, () => {
+    return {
+      open() {
+        setInnerVisible(true)
+      },
+      close() {
+        setInnerVisible(false)
+      },
+    }
+  })
+
+  const handleClose = () => {
+    setInnerVisible(false)
     onClose && onClose()
   }
-
-  useEffect(() => {
-    setShowPopup(visible)
-  }, [visible])
 
   const renderLeftOnCustomSwitch = () => {
     return (
@@ -115,7 +139,7 @@ export const Address: FunctionComponent<
 
   const selectedExistItem = (data: AddressList) => {
     onExistSelect && onExistSelect(data)
-    handClose()
+    handleClose()
   }
 
   // 切换地址选择模式
@@ -131,7 +155,7 @@ export const Address: FunctionComponent<
     <>
       {currentType === 'custom' || currentType === 'custom2' ? (
         <CustomRender
-          visible={showPopup}
+          visible={innerVisible}
           closeable
           title={title || locale.address.selectRegion}
           left={renderLeftOnCustomSwitch()}
@@ -141,20 +165,20 @@ export const Address: FunctionComponent<
           optionKey={optionKey}
           type={currentType}
           height={height}
-          onClose={handClose}
+          onClose={handleClose}
           onChange={(val: CascaderValue, params?: any) => {
             onChange?.(val, params)
           }}
         />
       ) : (
         <Popup
-          visible={showPopup}
+          visible={innerVisible}
           position="bottom"
           round
           closeable
           closeIcon={closeIcon}
           title={title || locale.address.selectRegion}
-          onClose={handClose}
+          onClose={handleClose}
         >
           <div
             className={`${classPrefix} ${className || ''}`}
@@ -178,6 +202,8 @@ export const Address: FunctionComponent<
     </>
   )
 }
+
+export const Address = forwardRef(InternalAddress)
 
 Address.defaultProps = defaultProps
 Address.displayName = 'NutAddress'

--- a/src/packages/address/demo.taro.tsx
+++ b/src/packages/address/demo.taro.tsx
@@ -353,7 +353,14 @@ const AddressDemo = () => {
   const showAddress = (tag: string) => {
     setShowPopup({
       ...showPopup,
-      [tag]: !(showPopup as any)[tag],
+      [tag]: true,
+    })
+  }
+
+  const closeAddress = (tag: string) => {
+    setShowPopup({
+      ...showPopup,
+      [tag]: false,
     })
   }
 
@@ -460,6 +467,7 @@ const AddressDemo = () => {
           onChange={(value, params) => {
             change1(value, params, 'one')
           }}
+          onClose={() => closeAddress('normal')}
         />
 
         <Address
@@ -474,6 +482,7 @@ const AddressDemo = () => {
           onChange={(value, params) => {
             change1(value, params, 'six')
           }}
+          onClose={() => closeAddress('select')}
         />
 
         <Address
@@ -484,7 +493,7 @@ const AddressDemo = () => {
           onChange={(value, params) => {
             change1(value, params, 'five')
           }}
-          // onClose={close5}
+          onClose={() => closeAddress('normal2')}
         />
 
         <Address
@@ -493,6 +502,7 @@ const AddressDemo = () => {
           existList={existList2}
           onExistSelect={selectedTwo}
           title={translated.delivery}
+          onClose={() => closeAddress('exist')}
         />
 
         <Address
@@ -502,7 +512,7 @@ const AddressDemo = () => {
           onExistSelect={selectedThree}
           defaultIcon={icon.defaultIcon}
           selectIcon={icon.selectIcon}
-          // closeIcon={icon.closeIcon}
+          onClose={() => closeAddress('customImg')}
         />
 
         <Address
@@ -519,6 +529,7 @@ const AddressDemo = () => {
           onChange={(value, params) => {
             change1(value, params, 'four')
           }}
+          onClose={() => closeAddress('other')}
         />
       </div>
     </>

--- a/src/packages/address/demo.taro.tsx
+++ b/src/packages/address/demo.taro.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { Heart1, HeartFill, Left, Close } from '@nutui/icons-react-taro'
 import Taro from '@tarojs/taro'
 import { Address, Cell } from '@/packages/nutui.react.taro'
@@ -33,6 +33,8 @@ interface T {
   [props: string]: string
 }
 const AddressDemo = () => {
+  const addressRef = useRef<any>(null)
+
   const [translated] = useTranslate<T>({
     'zh-CN': {
       basic: '基础用法',
@@ -45,6 +47,7 @@ const AddressDemo = () => {
       change: '自定义地址与已有地址切换',
       delivery: '配送',
       other: '选择其他地址',
+      uncontrolled: '非受控方式',
     },
     'zh-TW': {
       basic: '基础用法',
@@ -57,6 +60,7 @@ const AddressDemo = () => {
       change: '自定義地址與已有地址切換',
       delivery: '配送',
       other: '選擇其他地址',
+      uncontrolled: '非受控方式',
     },
     'en-US': {
       basic: 'Basic Usage',
@@ -69,6 +73,7 @@ const AddressDemo = () => {
       change: 'Custom Or Exist',
       delivery: 'Delivery',
       other: 'Choose Other Address',
+      uncontrolled: 'Uncontrolled',
     },
   })
 
@@ -224,6 +229,7 @@ const AddressDemo = () => {
     four: translated.title,
     five: translated.title,
     six: translated.title,
+    seven: translated.title,
   })
 
   const [showPopup, setShowPopup] = useState({
@@ -459,6 +465,12 @@ const AddressDemo = () => {
           description={text.four}
           onClick={() => showAddress('other')}
         />
+        <h2>{translated.uncontrolled}</h2>
+        <Cell
+          title={translated.title}
+          description={text.seven}
+          onClick={() => addressRef.current?.open()}
+        />
 
         <Address
           visible={showPopup.normal}
@@ -530,6 +542,17 @@ const AddressDemo = () => {
             change1(value, params, 'four')
           }}
           onClose={() => closeAddress('other')}
+        />
+
+        <Address
+          ref={addressRef}
+          defaultVisible={false}
+          options={optionsDemo1}
+          title={translated.title}
+          onChange={(value, params) => {
+            change1(value, params, 'one')
+          }}
+          onClose={() => addressRef.current?.close()}
         />
       </div>
     </>

--- a/src/packages/address/demo.tsx
+++ b/src/packages/address/demo.tsx
@@ -354,7 +354,14 @@ const AddressDemo = () => {
   const showAddress = (tag: string) => {
     setShowPopup({
       ...showPopup,
-      [tag]: !(showPopup as any)[tag],
+      [tag]: true,
+    })
+  }
+
+  const closeAddress = (tag: string) => {
+    setShowPopup({
+      ...showPopup,
+      [tag]: false,
     })
   }
 
@@ -460,6 +467,7 @@ const AddressDemo = () => {
           onChange={(value, params) => {
             change1(value, params, 'one')
           }}
+          onClose={() => closeAddress('normal')}
         />
 
         <Address
@@ -474,18 +482,8 @@ const AddressDemo = () => {
           onChange={(value, params) => {
             change1(value, params, 'six')
           }}
+          onClose={() => closeAddress('select')}
         />
-
-        {/* <Address
-          visible={showPopup.normal2}
-          type="custom2"
-          defaultValue={[1, 7, 3]}
-          height="270px"
-          onChange={(value, params) => {
-            change1(value, params, 'five')
-          }}
-          // onClose={close5}
-        /> */}
 
         <Address
           visible={showPopup.exist}
@@ -493,6 +491,7 @@ const AddressDemo = () => {
           existList={existList2}
           onExistSelect={selectedTwo}
           title={translated.delivery}
+          onClose={() => closeAddress('exist')}
         />
 
         <Address
@@ -502,7 +501,7 @@ const AddressDemo = () => {
           onExistSelect={selectedThree}
           defaultIcon={icon.defaultIcon}
           selectIcon={icon.selectIcon}
-          // closeIcon={icon.closeIcon}
+          onClose={() => closeAddress('customImg')}
         />
 
         <Address
@@ -519,6 +518,7 @@ const AddressDemo = () => {
           onChange={(value, params) => {
             change1(value, params, 'four')
           }}
+          onClose={() => closeAddress('other')}
         />
       </div>
     </>

--- a/src/packages/address/demo.tsx
+++ b/src/packages/address/demo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { Heart1, HeartFill, Left, Close } from '@nutui/icons-react'
 import { useTranslate } from '../../sites/assets/locale'
 import { Address } from './address'
@@ -33,6 +33,8 @@ interface T {
 }
 
 const AddressDemo = () => {
+  const addressRef = useRef<any>(null)
+
   const [translated] = useTranslate<T>({
     'zh-CN': {
       basic: '基础用法',
@@ -45,6 +47,7 @@ const AddressDemo = () => {
       change: '自定义地址与已有地址切换',
       delivery: '配送',
       other: '选择其他地址',
+      uncontrolled: '非受控方式',
     },
     'zh-TW': {
       basic: '基础用法',
@@ -57,6 +60,7 @@ const AddressDemo = () => {
       change: '自定義地址與已有地址切換',
       delivery: '配送',
       other: '選擇其他地址',
+      uncontrolled: '非受控方式',
     },
     'en-US': {
       basic: 'Basic Usage',
@@ -69,6 +73,7 @@ const AddressDemo = () => {
       change: 'Custom Or Exist',
       delivery: 'Delivery',
       other: 'Choose Other Address',
+      uncontrolled: 'Uncontrolled',
     },
   })
 
@@ -225,6 +230,7 @@ const AddressDemo = () => {
     four: translated.title,
     five: translated.title,
     six: translated.title,
+    seven: translated.title,
   })
 
   const [showPopup, setShowPopup] = useState({
@@ -459,6 +465,12 @@ const AddressDemo = () => {
           description={text.four}
           onClick={() => showAddress('other')}
         />
+        <h2>{translated.uncontrolled}</h2>
+        <Cell
+          title={translated.title}
+          description={text.seven}
+          onClick={() => addressRef.current?.open()}
+        />
 
         <Address
           visible={showPopup.normal}
@@ -519,6 +531,17 @@ const AddressDemo = () => {
             change1(value, params, 'four')
           }}
           onClose={() => closeAddress('other')}
+        />
+
+        <Address
+          ref={addressRef}
+          defaultVisible={false}
+          options={optionsDemo1}
+          title={translated.title}
+          onChange={(value, params) => {
+            change1(value, params, 'one')
+          }}
+          onClose={() => addressRef.current?.close()}
         />
       </div>
     </>

--- a/src/packages/address/doc.en-US.md
+++ b/src/packages/address/doc.en-US.md
@@ -89,7 +89,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="Choose Address" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="Choose Address" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           options={optionsDemo1}
@@ -97,6 +97,7 @@ const App = () => {
           onChange={(value, params) => {
             setText(value)
           }}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -120,7 +121,7 @@ const App = () => {
   const [text, setText] = useState('Choose Address')
   const [visible, setVisible] = useState(false)
   const [value2] = useState(['FuJian', 'FuZhou', 'TaiJiang'])
-    const [optionsDemo2] = useState([
+  const [optionsDemo2] = useState([
     {
       value1: 'ZheJiang',
       text1: 'ZheJiang',
@@ -186,7 +187,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="Choose Address" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="Choose Address" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={visible}
         defaultValue={value2}
@@ -199,6 +200,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -271,13 +273,14 @@ const App = () => {
 
   return (
     <>
-      <Cell title="Choose Address" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="Choose Address" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
           existList={existList}
           onExistSelect={selectedTwo}
           title="Delivery"
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -353,7 +356,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="Choose Address" description={text}  onClick={()=>setCustomImg(true)} />
+      <Cell title="Choose Address" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
@@ -361,6 +364,7 @@ const App = () => {
           onExistSelect={selectedThree}
           defaultIcon={icon.defaultIcon}
           selectIcon={icon.selectIcon}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -458,7 +462,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="Choose Address" description={text}  onClick={()=>setOther(true)} />
+      <Cell title="Choose Address" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={showPopup.other}
         type="exist"
@@ -473,6 +477,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -490,6 +495,7 @@ export default App;
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | visible | Whether to open address | `boolean` | `-` |
+| defaultVisible | Initial open/close state of the address selection | `boolean` | - |
 | type | Choose type: exist/custom | `string` | `custom` |
 | existList | Exist address list data | `Array` | `[]` |
 | defaultIcon | Exist address default icon | `ReactNode` | `-` |
@@ -499,5 +505,15 @@ export default App;
 | custom | Whether to change custom address | `boolean` \| `string` | `true` |
 | onExistSelect | Emitted when to selected exist address | `(data: AddressList) => void` | `-` |
 | onSwitch | Click to select another address or custom address to select the upper left corner of the return button triggered | `(data: { type: string }) => void` | `-` |
+| onClose | Fired when the component is closed | `-` | `-` |
+
+### Ref
+
+You can get the Address instance and call instance methods through ref.
+
+| Method | Description | Parameter |
+| ----- | ----- | -- |
+| open | Open address selection | `-` |
+| close | Close address selection | `-` |
 
 More properties in Cascader.

--- a/src/packages/address/doc.md
+++ b/src/packages/address/doc.md
@@ -89,7 +89,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           options={optionsDemo1}
@@ -97,6 +97,7 @@ const App = () => {
           onChange={(value, params) => {
             setText(value)
           }}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -186,7 +187,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={visible}
         defaultValue={value2}
@@ -199,6 +200,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -265,13 +267,14 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
           existList={existList}
           onExistSelect={selectedTwo}
           title="配送"
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -347,7 +350,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setCustomImg(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
@@ -355,6 +358,7 @@ const App = () => {
           onExistSelect={selectedThree}
           defaultIcon={icon.defaultIcon}
           selectIcon={icon.selectIcon}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -452,7 +456,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setOther(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={showPopup.other}
         type="exist"
@@ -467,6 +471,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -484,6 +489,7 @@ export default App;
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | visible | 是否打开地址选择 | `boolean` | `-` |
+| defaultVisible | 初始地址选择打开/关闭状态 | `boolean` | `-` |
 | type | 地址选择类型 exist/custom | `string` | `custom` |
 | existList | 已存在地址列表，每个地址对象中，必传值provinceName、cityName、countyName、townName、addressDetail、selectedAddress（字段解释见下） | `Array` | `[]` |
 | defaultIcon | 已有地址列表默认图标，type='exist' 时生效 | `ReactNode` | `-` |
@@ -493,5 +499,15 @@ export default App;
 | custom | 是否可以切换自定义地址选择，type='exist' 时生效 | `boolean` \| `string` | `true` |
 | onExistSelect | 选择已有地址列表时触发 | `(data: AddressList) => void` | `-` |
 | onSwitch | 点击'选择其他地址'或自定义地址选择左上角返回按钮触发 | `(data: { type: string }) => void` | `-` |
+| onClose | 关闭弹框时触发 | `-` | `-` |
+
+### Ref
+
+通过 ref 可以获取到 Address 实例并调用实例方法。
+
+| 方法名 | 说明 | 参数 |
+| ----- | ----- | -- |
+| open | 打开地址选择 | `-` |
+| close | 关闭地址选择 | `-` |
 
 更多参数可参考 `Cascader` 组件。

--- a/src/packages/address/doc.md
+++ b/src/packages/address/doc.md
@@ -121,7 +121,7 @@ const App = () => {
   const [text, setText] = useState('请选择地址')
   const [visible, setVisible] = useState(false)
   const [value2] = useState(['福建', '福州', '台江区'])
-    const [optionsDemo2] = useState([
+  const [optionsDemo2] = useState([
     {
       value1: '浙江',
       text1: '浙江',
@@ -478,6 +478,103 @@ const App = () => {
 };
 export default App;
 
+```
+
+:::
+
+### 非受控模式
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from "react";
+import { Address, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  const addressRef = useRef<any>(null)
+  const [text, setText] = useState('请选择地址')
+
+  const [optionsDemo] = useState([
+    {
+      value1: '浙江',
+      text1: '浙江',
+      items: [
+        {
+          value1: '杭州',
+          text1: '杭州',
+          disabled: true,
+          items: [
+            { value1: '西湖区', text1: '西湖区', disabled: true },
+            { value1: '余杭区', text1: '余杭区' },
+          ],
+        },
+        {
+          value1: '温州',
+          text1: '温州',
+          items: [
+            { value1: '鹿城区', text1: '鹿城区' },
+            { value1: '瓯海区', text1: '瓯海区' },
+          ],
+        },
+      ],
+    },
+    {
+      value1: '湖南',
+      text1: '湖南',
+      disabled: true,
+      items: [
+        {
+          value1: '长沙',
+          text1: '长沙',
+          disabled: true,
+          items: [
+            { value1: '西湖区', text1: '西湖区' },
+            { value1: '余杭区', text1: '余杭区' },
+          ],
+        },
+        {
+          value1: '温州',
+          text1: '温州',
+          items: [
+            { value1: '鹿城区', text1: '鹿城区' },
+            { value1: '瓯海区', text1: '瓯海区' },
+          ],
+        },
+      ],
+    },
+    {
+      value1: '福建',
+      text1: '福建',
+      items: [
+        {
+          value1: '福州',
+          text1: '福州',
+          items: [
+            { value1: '鼓楼区', text1: '鼓楼区' },
+            { value1: '台江区', text1: '台江区' },
+          ],
+        },
+      ],
+    },
+  ])
+
+  return (
+    <>
+      <Cell title="选择地址" description={text}  onClick={() => addressRef.current?.open()} />
+      <Address
+        ref={addressRef}
+          defaultVisible={false}
+          options={optionsDemo}
+          title="选择地址"
+          onChange={(value, params) => {
+            setText(value)
+          }}
+          onClose={() => addressRef.current?.close()}
+      />
+    </>
+  );
+};
+export default App;
 ```
 
 :::

--- a/src/packages/address/doc.taro.md
+++ b/src/packages/address/doc.taro.md
@@ -89,7 +89,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           options={optionsDemo1}
@@ -97,6 +97,7 @@ const App = () => {
           onChange={(value, params) => {
             setText(value)
           }}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -186,7 +187,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={visible}
         defaultValue={value2}
@@ -199,6 +200,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -265,13 +267,14 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
           existList={existList}
           onExistSelect={selectedTwo}
           title="配送"
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -299,6 +302,7 @@ const App = () => {
     closeIcon: <Close />,
     backIcon: <Left />,
   })
+
   const [visible, setVisible] = useState(false)
   const [existList, setExistAddress] = useState([
     {
@@ -346,7 +350,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setCustomImg(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
@@ -354,6 +358,7 @@ const App = () => {
           onExistSelect={selectedThree}
           defaultIcon={icon.defaultIcon}
           selectIcon={icon.selectIcon}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -418,7 +423,6 @@ const App = () => {
     },
   ])
 
-  
   const [optionsDemo5] = useState([
     { value: '北京', text: '北京', id: 1, pidd: null },
     { value: '朝阳区', text: '朝阳区', id: 11, pidd: 1 },
@@ -449,9 +453,10 @@ const App = () => {
         console.log('点击了自定义地址左上角的返回按钮')
       }
   }
+
   return (
     <>
-      <Cell title="选择地址" description={text}  onClick={()=>setOther(true)} />
+      <Cell title="选择地址" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={showPopup.other}
         type="exist"
@@ -466,6 +471,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -483,6 +489,7 @@ export default App;
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | visible | 是否打开地址选择 | `boolean` | `-` |
+| defaultVisible | 初始地址选择打开/关闭状态 | `boolean` | `-` |
 | type | 地址选择类型 exist/custom | `string` | `custom` |
 | existList | 已存在地址列表，每个地址对象中，必传值provinceName、cityName、countyName、townName、addressDetail、selectedAddress（字段解释见下） | `Array` | `[]` |
 | defaultIcon | 已有地址列表默认图标，type='exist' 时生效 | `ReactNode` | `-` |
@@ -492,6 +499,15 @@ export default App;
 | custom | 是否可以切换自定义地址选择，type='exist' 时生效 | `boolean` \| `string` | `true` |
 | onExistSelect | 选择已有地址列表时触发 | `(data: AddressList) => void` | `-` |
 | onSwitch | 点击'选择其他地址'或自定义地址选择左上角返回按钮触发 | `(data: { type: string }) => void` | `-` |
-0%) !default` |
+| onClose | 关闭弹框时触发 | `-` | `-` |
+
+### Ref
+
+通过 ref 可以获取到 Address 实例并调用实例方法。
+
+| 方法名 | 说明 | 参数 |
+| ----- | ----- | -- |
+| open | 打开地址选择 | `-` |
+| close | 关闭地址选择 | `-` |
 
 更多参数可参考 `Cascader` 组件。

--- a/src/packages/address/doc.taro.md
+++ b/src/packages/address/doc.taro.md
@@ -477,9 +477,103 @@ const App = () => {
   );
 };
 export default App;
-
 ```
+:::
 
+### 非受控模式
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from "react";
+import { Address, Cell } from '@nutui/nutui-react';
+
+const App = () => {
+  const addressRef = useRef<any>(null)
+  const [text, setText] = useState('请选择地址')
+
+  const [optionsDemo] = useState([
+    {
+      value1: '浙江',
+      text1: '浙江',
+      items: [
+        {
+          value1: '杭州',
+          text1: '杭州',
+          disabled: true,
+          items: [
+            { value1: '西湖区', text1: '西湖区', disabled: true },
+            { value1: '余杭区', text1: '余杭区' },
+          ],
+        },
+        {
+          value1: '温州',
+          text1: '温州',
+          items: [
+            { value1: '鹿城区', text1: '鹿城区' },
+            { value1: '瓯海区', text1: '瓯海区' },
+          ],
+        },
+      ],
+    },
+    {
+      value1: '湖南',
+      text1: '湖南',
+      disabled: true,
+      items: [
+        {
+          value1: '长沙',
+          text1: '长沙',
+          disabled: true,
+          items: [
+            { value1: '西湖区', text1: '西湖区' },
+            { value1: '余杭区', text1: '余杭区' },
+          ],
+        },
+        {
+          value1: '温州',
+          text1: '温州',
+          items: [
+            { value1: '鹿城区', text1: '鹿城区' },
+            { value1: '瓯海区', text1: '瓯海区' },
+          ],
+        },
+      ],
+    },
+    {
+      value1: '福建',
+      text1: '福建',
+      items: [
+        {
+          value1: '福州',
+          text1: '福州',
+          items: [
+            { value1: '鼓楼区', text1: '鼓楼区' },
+            { value1: '台江区', text1: '台江区' },
+          ],
+        },
+      ],
+    },
+  ])
+
+  return (
+    <>
+      <Cell title="选择地址" description={text}  onClick={() => addressRef.current?.open()} />
+      <Address
+        ref={addressRef}
+          defaultVisible={false}
+          options={optionsDemo}
+          title="选择地址"
+          onChange={(value, params) => {
+            setText(value)
+          }}
+          onClose={() => addressRef.current?.close()}
+      />
+    </>
+  );
+};
+export default App;
+```
 :::
 
 ## Address

--- a/src/packages/address/doc.zh-TW.md
+++ b/src/packages/address/doc.zh-TW.md
@@ -89,7 +89,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="選擇地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="選擇地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           options={optionsDemo1}
@@ -97,6 +97,7 @@ const App = () => {
           onChange={(value, params) => {
             setText(value)
           }}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -120,7 +121,7 @@ const App = () => {
   const [text, setText] = useState('請選擇地址')
   const [visible, setVisible] = useState(false)
   const [value2] = useState(['福建', '福州', '臺江區'])
-    const [optionsDemo2] = useState([
+  const [optionsDemo2] = useState([
     {
       value1: '浙江',
       text1: '浙江',
@@ -186,7 +187,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="選擇地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="選擇地址" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={visible}
         defaultValue={value2}
@@ -199,6 +200,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -265,13 +267,14 @@ const App = () => {
 
   return (
     <>
-      <Cell title="選擇地址" description={text}  onClick={()=>setVisible(true)} />
+      <Cell title="選擇地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
           existList={existList}
           onExistSelect={selectedTwo}
           title="配送"
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -347,7 +350,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="選擇地址" description={text}  onClick={()=>setCustomImg(true)} />
+      <Cell title="選擇地址" description={text}  onClick={() => setVisible(true)} />
         <Address
           visible={visible}
           type="exist"
@@ -355,6 +358,7 @@ const App = () => {
           onExistSelect={selectedThree}
           defaultIcon={icon.defaultIcon}
           selectIcon={icon.selectIcon}
+          onClose={() => setVisible(false)}
         />
     </>
   );
@@ -452,7 +456,7 @@ const App = () => {
 
   return (
     <>
-      <Cell title="選擇地址" description={text}  onClick={()=>setOther(true)} />
+      <Cell title="選擇地址" description={text}  onClick={() => setVisible(true)} />
       <Address
         visible={showPopup.other}
         type="exist"
@@ -467,6 +471,7 @@ const App = () => {
         onChange={(value, params) => {
           setText(value)
         }}
+        onClose={() => setVisible(false)}
       />
     </>
   );
@@ -484,6 +489,7 @@ export default App;
 | 屬性 | 說明 | 類型 | 默認值 |
 | --- | --- | --- | --- |
 | visible | 是否打開地址選擇 | `boolean` | `-` |
+| defaultVisible | 初始地址選擇打開/關閉狀態 | `boolean` | - |
 | type | 地址選擇類型 exist/custom | `string` | `custom` |
 | existList | 已存在地址列錶，每個地址對象中，必傳值provinceName、cityName、countyName、townName、addressDetail、selectedAddress（字段解釋見下） | `Array` | `[]` |
 | defaultIcon | 已有地址列錶默認圖標，type='exist' 時生效 | `ReactNode` | `-` |
@@ -493,5 +499,15 @@ export default App;
 | custom | 是否可以切換自定義地址選擇，type='exist' 時生效 | `boolean` \| `string` | `true` |
 | onExistSelect | 選擇已有地址列錶時觸發 | `(data: AddressList) => void` | `-` |
 | onSwitch | 點擊'選擇其他地址'或自定義地址選擇左上角返回按鈕觸發 | `(data: { type: string }) => void` | `-` |
+| onClose | 關閉彈框時觸發 | `-` | `-` |
+
+### Ref
+
+透過 ref 可以獲取到 Address 實例並調用實例方法。
+
+| 方法名 | 說明 | 參數 |
+| ---- | ---- | ---- |
+| open | 打開地址選擇 | `-` |
+| close | 關閉地址選擇 | `-` |
 
 更多參數可參考 `Cascader` 組件。


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
目前 Address 通过props传入的 `visible` 属性来控制组件的显示和隐藏。当组件通过点击 CloseIcon 和 Overlay 关闭后，它没有调用传入的 `onClose` 方法来通知父组件变更 `visible` 状态。从而导致`Address`组件无法再次展示。

PS：项目提供的[demo](https://github.com/jdf2e/nutui-react/blob/837422027b6fd35adb8ae62ab10f9b4fb3a5c523/src/packages/address/demo.taro.tsx#L353C9-L353C20)中，`showAddress`方法通过取反来改变`visible`状态，恰巧规避了这个问题，但是又没有完全规避。需要点击两次，才能正常展示Address。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ x] 文档已补充或无须补充
- [ x] 代码演示已提供或无须提供
- [ x] TypeScript 定义已补充或无须补充
- [x ] fork仓库代码是否为最新避免文件冲突
- [x ] Files changed 没有 package.json lock 等无关文件
