### PR TITLE
docs(searchbar): fix `autoFocus` spelling mistakes

### DIFF
--- a/src/packages/searchbar/doc.en-US.md
+++ b/src/packages/searchbar/doc.en-US.md
@@ -161,7 +161,7 @@ export default App;
 |background | search box external background color |string | - |
 |inputbackground | search box background color |string | - |
 |inputalign | alignment, optional `center` `right` | string | `left` |
-|autofocus | auto focus | boolean | `false` |
+|autoFocus | auto focus | boolean | `false` |
 |label | left text of search box | string | - |
 |actiontext | cancel button text | ReactNode | - |
 |leftinicon | input box, left Icon | ReactNode | `< Icon name="search" size="12" />` |

--- a/src/packages/searchbar/doc.md
+++ b/src/packages/searchbar/doc.md
@@ -162,7 +162,7 @@ export default App;
 | background          | 搜索框外部背景色 | string | -     |
 | inputBackground          | 搜索框背景色 | string | -     |
 | inputAlign | 对齐方式，可选 `center` `right` | string | `left` |
-| autofocus  | 是否自动聚焦 | boolean | `false` |
+| autoFocus  | 是否自动聚焦 | boolean | `false` |
 | label | 搜索框左侧文本 | string | - |
 | actionText | 取消按钮文本 | ReactNode | - |
 | leftinIcon     | 输入框内，左icon  | ReactNode | `<Icon name="search" size="12" />` |

--- a/src/packages/searchbar/doc.taro.md
+++ b/src/packages/searchbar/doc.taro.md
@@ -161,7 +161,7 @@ export default App;
 | background          | 搜索框外部背景色 | string | -     |
 | inputBackground          | 搜索框背景色 | string | -     |
 | inputAlign | 对齐方式，可选 `center` `right` | string | `left` |
-| autofocus  | 是否自动聚焦 | boolean | `false` |
+| autoFocus  | 是否自动聚焦 | boolean | `false` |
 | label | 搜索框左侧文本 | string | - |
 | actionText | 取消按钮文本 | ReactNode | - |
 | leftinIcon     | 输入框内，左icon  | ReactNode | `<Icon name="search" size="12" />` |

--- a/src/packages/searchbar/doc.zh-TW.md
+++ b/src/packages/searchbar/doc.zh-TW.md
@@ -161,7 +161,7 @@ export default App;
 | background |蒐索框外部背景色| string | - |
 | inputBackground |蒐索框背景色| string | - |
 | inputAlign |對齊管道，可選`center` `right` | string | `left` |
-| autofocus |是否自動聚焦| boolean | `false` |
+| autoFocus |是否自動聚焦| boolean | `false` |
 | label |蒐索框左側文字| string | - |
 | actionText |取消按鈕文字| ReactNode | - |
 | leftinIcon |輸入框內，左icon | ReactNode | `< Icon name=“search”size=“12”/>` |


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
![image](https://github.com/jdf2e/nutui-react/assets/22173084/54b6e71b-ad5a-4ffd-a94b-35827ce5c05c)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
修改文档中的`autofocus` 为驼峰写法
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
