### PR TITLE
fix: 无限加载组件 Taro 下 height is null

### DIFF
--- a/src/packages/infiniteloading/infiniteloading.taro.tsx
+++ b/src/packages/infiniteloading/infiniteloading.taro.tsx
@@ -81,7 +81,7 @@ export const InfiniteLoading: FunctionComponent<
     const parentElement = getParentElement('scroller')
     parentElement
       .boundingClientRect((rect: any) => {
-        scrollHeight.current = rect.height
+        scrollHeight.current = rect?.height ?? 0
       })
       .exec()
   }


### PR DESCRIPTION
Fast page switching, can't get the height when the component is not initialized.

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
