### PR TITLE
fix: 优化日期选择器日期选择

### DIFF
--- a/src/packages/datepicker/datepicker.taro.tsx
+++ b/src/packages/datepicker/datepicker.taro.tsx
@@ -270,7 +270,6 @@ export const DatePicker: FunctionComponent<
         !isEqual &&
         setCurrentDate(formatValue(date as Date))
     }
-
     props.onChange && props.onChange(selectedOptions, selectedValue, index)
   }
 
@@ -317,7 +316,7 @@ export const DatePicker: FunctionComponent<
         cmin++
       }
 
-      if (cmin <= val) {
+      if (cmin <= Number(val)) {
         index++
       }
     }
@@ -387,7 +386,7 @@ export const DatePicker: FunctionComponent<
           visible={visible}
           options={options}
           onClose={onClose}
-          defaultValue={defaultValueOfPicker}
+          value={defaultValueOfPicker}
           onConfirm={(options: PickerOption[], value: (string | number)[]) =>
             onConfirm && onConfirm(options, value)
           }

--- a/src/packages/datepicker/datepicker.tsx
+++ b/src/packages/datepicker/datepicker.tsx
@@ -316,7 +316,7 @@ export const DatePicker: FunctionComponent<
         cmin++
       }
 
-      if (cmin <= val) {
+      if (cmin <= Number(val)) {
         index++
       }
     }
@@ -381,7 +381,7 @@ export const DatePicker: FunctionComponent<
           visible={visible}
           options={options}
           onClose={onClose}
-          defaultValue={defaultValueOfPicker}
+          value={defaultValueOfPicker}
           onConfirm={(options: PickerOption[], value: (string | number)[]) =>
             onConfirm && onConfirm(options, value)
           }

--- a/src/packages/picker/picker.taro.tsx
+++ b/src/packages/picker/picker.taro.tsx
@@ -105,6 +105,10 @@ const InternalPicker: ForwardRefRenderFunction<unknown, Partial<PickerProps>> =
     const [columnsList, setColumnsList] = useState<PickerOption[][]>([]) // 格式化后每一列的数据
     const isConfirmEvent = useRef(false)
 
+    useEffect(() => {
+      setInnerValue(selectedValue)
+    }, [selectedValue])
+
     const actions: PickerActions = {
       open: () => {
         setInnerVisible(true)

--- a/src/packages/picker/picker.tsx
+++ b/src/packages/picker/picker.tsx
@@ -101,6 +101,10 @@ const InternalPicker: ForwardRefRenderFunction<unknown, Partial<PickerProps>> =
     const [columnsList, setColumnsList] = useState<PickerOption[][]>([]) // 格式化后每一列的数据
     const isConfirmEvent = useRef(false)
 
+    useEffect(() => {
+      setInnerValue(selectedValue)
+    }, [selectedValue])
+
     const actions: PickerActions = {
       open: () => {
         setInnerVisible(true)


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

`DatePicker` 选择 `7月31号`， 然后滑动到6月的时候，变成`6月1号`， 且再次切换7月的时候变成`7月31号`

现在 `DatePicker` 选择 `7月31号`，然后滑动到6月的时候，变成`6月30号`

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
