### PR TITLE
feat: picker 支持自定义挂载节点和弹出位置

### DIFF
--- a/src/packages/picker/demo.taro.tsx
+++ b/src/packages/picker/demo.taro.tsx
@@ -281,6 +281,7 @@ const PickerDemo = () => {
         />
         <Picker
           title="请选择城市"
+          portal={document.body}
           visible={isVisible1}
           options={listData1}
           onConfirm={(list, values) => confirmPicker('base', list, values)}

--- a/src/packages/picker/picker.taro.tsx
+++ b/src/packages/picker/picker.taro.tsx
@@ -26,6 +26,8 @@ export interface PickerProps extends Omit<BasicComponent, 'children'> {
   visible?: boolean | undefined
   title?: string
   options: (PickerOption | PickerOption[])[]
+  portal?: HTMLElement | (() => HTMLElement) | null
+  position?: string
   value?: (number | string)[]
   defaultValue?: (number | string)[]
   threeDimensional?: boolean
@@ -60,6 +62,7 @@ const defaultProps = {
   defaultValue: [],
   threeDimensional: true,
   duration: 1000,
+  position: 'bottom',
 } as PickerProps
 const InternalPicker: ForwardRefRenderFunction<unknown, Partial<PickerProps>> =
   (props, ref) => {
@@ -74,6 +77,8 @@ const InternalPicker: ForwardRefRenderFunction<unknown, Partial<PickerProps>> =
       style,
       threeDimensional,
       duration,
+      portal,
+      position,
       onConfirm,
       onClose,
       afterClose,
@@ -367,7 +372,8 @@ const InternalPicker: ForwardRefRenderFunction<unknown, Partial<PickerProps>> =
         {typeof children === 'function' && children(selectedValue)}
         <Popup
           visible={innerVisible}
-          position="bottom"
+          position={position}
+          portal={portal}
           afterClose={() => {
             closePicker()
           }}


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 在 h5 场景下 picker 存在滚动穿透的问题，可以通过指定挂载节点来解决
2. 业务场景中 picker 的弹出位置可能是多样的，不仅限于 bottom

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
