### PR TITLE
fix: numberkeyboard 设置标题后，完成按钮应该触发 onConfirm 事件

### DIFF
--- a/src/packages/numberkeyboard/doc.en-US.md
+++ b/src/packages/numberkeyboard/doc.en-US.md
@@ -253,7 +253,7 @@ export default App;
 | --- | --- | --- | --- |
 | visible | Whether to show keyboard | `boolean` | `false` |
 | title | Keyboard title | `ReactNode` | `-` |
-| type | Keyboard type, default/rightColumn | `string` | `default` |
+| type | Keyboard type, default/rightColumn | `'default' \| 'rightColumn'` | `default` |
 | random | Whether to shuffle the order of keys | `boolean` | `false` |
 | custom | Content of bottom left key, Array form supports adding up to two | `string[]` | `-` |
 | confirmText | Custom done button text,Such as "pay", "next", "submit" | `string` | `done` |

--- a/src/packages/numberkeyboard/doc.md
+++ b/src/packages/numberkeyboard/doc.md
@@ -253,7 +253,7 @@ export default App;
 | --- | --- | --- | --- |
 | visible | 是否显示键盘 | `boolean` | `false` |
 | title | 键盘标题 | `ReactNode` | `-` |
-| type | 键盘模式, default：默认样式 rightColumn：带右侧栏 | `string` | `default` |
+| type | 键盘模式, default：默认样式 rightColumn：带右侧栏 | `'default' \| 'rightColumn'` | `default` |
 | random | 随机数 | `boolean` | `false` |
 | custom | 自定义键盘额外的键, 数组形式最多支持添加 2 个, 超出默认取前 2 项 | `string[]` | `-` |
 | confirmText | 自定义完成按钮文字，如"支付"，"下一步"，"提交"等 | `string` | `完成` |

--- a/src/packages/numberkeyboard/doc.taro.md
+++ b/src/packages/numberkeyboard/doc.taro.md
@@ -253,7 +253,7 @@ export default App;
 | --- | --- | --- | --- |
 | visible | 是否显示键盘 | `boolean` | `false` |
 | title | 键盘标题 | `ReactNode` | `-` |
-| type | 键盘模式, default：默认样式 rightColumn：带右侧栏 | `string` | `default` |
+| type | 键盘模式, default：默认样式 rightColumn：带右侧栏 | `'default' \| 'rightColumn'` | `default` |
 | random | 随机数 | `boolean` | `false` |
 | custom | 自定义键盘额外的键, 数组形式最多支持添加 2 个, 超出默认取前 2 项 | `string[]` | `-` |
 | confirmText | 自定义完成按钮文字，如"支付"，"下一步"，"提交"等 | `string` | `完成` |

--- a/src/packages/numberkeyboard/doc.zh-TW.md
+++ b/src/packages/numberkeyboard/doc.zh-TW.md
@@ -253,7 +253,7 @@ export default App;
 | --- | --- | --- | --- |
 | visible | 是否顯示鍵盤 | `boolean` | `false` |
 | title | 鍵盤標題 | `ReactNode` | `-` |
-| type | 鍵盤模式, default：默認樣式 rightColumn：帶右側欄 | `string` | `default` |
+| type | 鍵盤模式, default：默認樣式 rightColumn：帶右側欄 | `'default' \| 'rightColumn'` | `default` |
 | random | 隨機數 | `boolean` | `false` |
 | custom | 自定義鍵盤額外的鍵, 數組形式最多支持添加 2 個, 超出默認取前 2 項 | `string[]` | `-` |
 | confirmText | 自定義完成按鈕文字，如"支付"，"下一步"，"提交"等 | `string` | `完成` |

--- a/src/packages/numberkeyboard/numberkeyboard.taro.tsx
+++ b/src/packages/numberkeyboard/numberkeyboard.taro.tsx
@@ -151,7 +151,7 @@ export const NumberKeyboard: FunctionComponent<
             {type === 'default' && (
               <span
                 className={`${classPrefix}__header__close`}
-                onClick={onClose}
+                onClick={onConfirm}
               >
                 {locale.done}
               </span>

--- a/src/packages/numberkeyboard/numberkeyboard.tsx
+++ b/src/packages/numberkeyboard/numberkeyboard.tsx
@@ -155,7 +155,7 @@ export const NumberKeyboard: FunctionComponent<
             {type === 'default' && (
               <span
                 className={`${classPrefix}__header__close`}
-                onClick={onClose}
+                onClick={onConfirm}
               >
                 {locale.done}
               </span>


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
