### PR TITLE
fix(Avatar): 解决在小程序环境下，使用Avatar.Group无法正常展示头像问题

### DIFF
--- a/src/packages/avatar/avatar.taro.tsx
+++ b/src/packages/avatar/avatar.taro.tsx
@@ -6,6 +6,7 @@ import React, {
   useContext,
 } from 'react'
 import type { MouseEvent } from 'react'
+import Taro, { getEnv } from '@tarojs/taro'
 import classNames from 'classnames'
 import { My } from '@nutui/icons-react-taro'
 import Image from '@/packages/image/index.taro'
@@ -105,13 +106,26 @@ export const Avatar: FunctionComponent<
     }
   }, [])
 
+  const isAvatarInClassList = (element: any) => {
+    if (getEnv() === Taro.ENV_TYPE.WEB) {
+      return (
+        element.classList[0] === 'nut-avatar' ||
+        element.classList.values().next().value === 'nut-avatar'
+      )
+    }
+
+    return (
+      element.classList?.tokenList[0] === 'nut-avatar' ||
+      element.classList?.tokenList.values().next().value === 'nut-avatar'
+    )
+  }
+
   const avatarLength = (children: any) => {
     for (let i = 0; i < children.length; i++) {
       if (
         children[i] &&
         children[i].classList &&
-        (children[i].classList[0] === 'nut-avatar' ||
-          children[i].classList.values().next().value === 'nut-avatar')
+        isAvatarInClassList(children[i])
       ) {
         children[i].setAttribute('data-index', i + 1)
       }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
现象：
在小程序环境下，使用`Avatar.Group`展示一组头像时，头像无法正常展示，且控制台报错。
原因：
小程序环境下想要获取类名列表，需要从`classList.tokenList`中获取。

![image](https://github.com/jdf2e/nutui-react/assets/11178409/6fedabf2-a1c1-4feb-8832-6a6604a4a07f)


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
