### PR TITLE
fix: 执行 form.setFieldsValue({example: value}) 时 value 为 null|false|0 传递不到子组件、子组件接收到的为 undefined 的问题

### DIFF
--- a/src/packages/formitem/formitem.taro.tsx
+++ b/src/packages/formitem/formitem.taro.tsx
@@ -80,7 +80,9 @@ export class FormItem extends React.Component<
     const controlled = {
       ...children.props,
       [this.props.valuePropName || 'value']:
-        getFieldValue(name) || this.props.initialValue,
+        getFieldValue(name) === undefined
+          ? this.props.initialValue
+          : getFieldValue(name),
       [this.props.trigger || 'onChange']: (...args: any) => {
         // args [a, b]
         const originOnChange = (children as any).props[


### PR DESCRIPTION
fix: 执行 form.setFieldsValue({example: value}) 时 value 为 null|false|0 传递不到子组件、子组件接收到的为 undefined 的问题

- [x] 日常 bug 修复