### PR TITLE
feat: menu 展开关闭事件增加参数

### DIFF
--- a/src/packages/menu/demo.taro.tsx
+++ b/src/packages/menu/demo.taro.tsx
@@ -107,7 +107,12 @@ const MenuDemo = () => {
       <style>{style}</style>
       <div className={`demo demo-full ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
         <h2>{translated.basic}</h2>
-        <Menu closeOnOverlayClick lockScroll={false}>
+        <Menu
+          closeOnOverlayClick
+          lockScroll={false}
+          onClose={(i: number) => console.log('onClose', i)}
+          onOpen={(i: number) => console.log('onOpen', i)}
+        >
           <Menu.Item
             options={options}
             value={0}

--- a/src/packages/menu/demo.tsx
+++ b/src/packages/menu/demo.tsx
@@ -106,7 +106,12 @@ const MenuDemo = () => {
       <style>{style}</style>
       <div className="demo full">
         <h2>{translated.basic}</h2>
-        <Menu closeOnOverlayClick lockScroll={false}>
+        <Menu
+          closeOnOverlayClick
+          lockScroll={false}
+          onClose={(i: number) => console.log('onClose', i)}
+          onOpen={(i: number) => console.log('onOpen', i)}
+        >
           <Menu.Item
             options={options}
             value={0}

--- a/src/packages/menu/doc.en-US.md
+++ b/src/packages/menu/doc.en-US.md
@@ -34,7 +34,12 @@ const App = () => {
   return (
     <>
       <div className="demo full">
-        <Menu>
+        <Menu
+          closeOnOverlayClick
+          lockScroll={false}
+          onClose={(i: number) => console.log('onClose', i)}
+          onOpen={(i: number) => console.log('onOpen', i)}
+        >
           <Menu.Item options={options} value={0} />
           <Menu.Item options={options1} value="a" />
         </Menu>
@@ -288,12 +293,14 @@ export default App
 | lockScroll | Whether the background is locked | `boolean` | `true` |
 | scrollFixed | Whether to fixed when window is scrolled, fixed position can be set | `boolean` \| `string` \| `number` | `true` |
 | icon | Custome title icon | `React.ReactNode` | `-` |
+| onOpen | menu 展开触发 | `(index: number) => void` | `-` |
+| onClose | menu 关闭触发 | `(index: number) => void` | `-` |
 
 ## Menu.Item
 
 ### Props
 
-| 属性 | 说明 | 类型 | 默认值 |
+| Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | title | Item title | `string` | `Current selected value` |
 | options | Options | `Array` | `-` |
@@ -302,10 +309,12 @@ export default App
 | icon | Custome option icon | `React.ReactNode` | `Check` |
 | direction | Expand direction, can be set to up | `string` | `down` |
 | onChange | Emitted select option changed | `(event: any) => void` | `-` |
+| onOpen | menu expand trigger | `(index: number) => void` | `-` |
+| onClose | menu close trigger | `(index: number) => void` | `-` |
 
 ### Ref
 
-| Event | Description | Arguments |
+| Property | Description | Parameters |
 | --- | --- | --- |
 | toggle | Toggle menu display status, true to show，false to hide, no param is negated | `show?: boolean` |
 

--- a/src/packages/menu/doc.md
+++ b/src/packages/menu/doc.md
@@ -34,7 +34,12 @@ const App = () => {
   return (
     <>
       <div className="demo full">
-        <Menu>
+        <Menu
+          closeOnOverlayClick
+          lockScroll={false}
+          onClose={(i: number) => console.log('onClose', i)}
+          onOpen={(i: number) => console.log('onOpen', i)}
+        >
           <Menu.Item options={options} value={0} />
           <Menu.Item options={options1} value="a" />
         </Menu>
@@ -277,6 +282,8 @@ export default App
 | lockScroll | 背景是否锁定 | `boolean` | `true` |
 | scrollFixed | 滚动后是否固定，可设置固定位置 | `boolean` \| `string` \| `number` | `true` |
 | icon | 自定义标题图标 | `React.ReactNode` | `-` |
+| onOpen | menu 展开触发 | `(index: number) => void` | `-` |
+| onClose | menu 关闭触发 | `(index: number) => void` | `-` |
 
 ## Menu.Item
 

--- a/src/packages/menu/doc.taro.md
+++ b/src/packages/menu/doc.taro.md
@@ -34,7 +34,12 @@ const App = () => {
   return (
     <>
       <div className="demo full">
-        <Menu>
+        <Menu
+          closeOnOverlayClick
+          lockScroll={false}
+          onClose={(i: number) => console.log('onClose', i)}
+          onOpen={(i: number) => console.log('onOpen', i)}
+        >
           <Menu.Item options={options} value={0} />
           <Menu.Item options={options1} value="a" />
         </Menu>
@@ -277,6 +282,8 @@ export default App
 | lockScroll | 背景是否锁定 | `boolean` | `true` |
 | scrollFixed | 滚动后是否固定，可设置固定位置 | `boolean` \| `string` \| `number` | `true` |
 | icon | 自定义标题图标 | `React.ReactNode` | `-` |
+| onOpen | menu 展开触发 | `(index: number) => void` | `-` |
+| onClose | menu 关闭触发 | `(index: number) => void` | `-` |
 
 ## Menu.Item
 

--- a/src/packages/menu/doc.zh-TW.md
+++ b/src/packages/menu/doc.zh-TW.md
@@ -34,7 +34,12 @@ const App = () => {
   return (
     <>
       <div className="demo full">
-        <Menu>
+        <Menu
+          closeOnOverlayClick
+          lockScroll={false}
+          onClose={(i: number) => console.log('onClose', i)}
+          onOpen={(i: number) => console.log('onOpen', i)}
+        >
           <Menu.Item options={options} value={0} />
           <Menu.Item options={options1} value="a" />
         </Menu>
@@ -277,6 +282,8 @@ export default App
 | lockScroll | 背景是否鎖定 | `boolean` | `true` |
 | scrollFixed | 滾動後是否固定，可設置固定位置 | `boolean` \| `string` \| `number` | `true` |
 | icon | 自定義標題圖標 | `React.ReactNode` | `-` |
+| onOpen | menu 展开触发 | `(index: number) => void` | `-` |
+| onClose | menu 关闭触发 | `(index: number) => void` | `-` |
 
 ## Menu.Item
 

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -11,8 +11,8 @@ export interface MenuProps extends BasicComponent {
   lockScroll: boolean
   icon: React.ReactNode
   children: React.ReactNode
-  onOpen: () => void
-  onClose: () => void
+  onOpen: (index: number) => void
+  onClose: (index: number) => void
 }
 
 const defaultProps = {
@@ -22,8 +22,8 @@ const defaultProps = {
   scrollFixed: false,
   lockScroll: true,
   icon: null,
-  onOpen: () => {},
-  onClose: () => {},
+  onOpen: (index: number) => {},
+  onClose: (index: number) => {},
 } as MenuProps
 export const Menu: FunctionComponent<Partial<MenuProps>> & {
   Item: typeof MenuItem
@@ -70,9 +70,9 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   const toggleMenuItem = (index: number) => {
     showMenuItem[index] = !showMenuItem[index]
     if (showMenuItem[index]) {
-      onOpen && onOpen()
+      onOpen && onOpen(index)
     } else {
-      onClose && onClose()
+      onClose && onClose(index)
     }
     const temp = showMenuItem.map((i: boolean, idx) =>
       idx === index ? i : false
@@ -82,7 +82,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   const hideMenuItem = (index: number) => {
     showMenuItem[index] = false
     setShowMenuItem([...showMenuItem])
-    onClose && onClose()
+    onClose && onClose(index)
   }
   const updateTitle = (text: string, index: number) => {
     menuItemTitle[index] = text

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -11,8 +11,8 @@ export interface MenuProps extends BasicComponent {
   lockScroll: boolean
   icon: React.ReactNode
   children: React.ReactNode
-  onOpen: () => void
-  onClose: () => void
+  onOpen: (index: number) => void
+  onClose: (index: number) => void
 }
 
 const defaultProps = {
@@ -22,8 +22,8 @@ const defaultProps = {
   scrollFixed: false,
   lockScroll: true,
   icon: null,
-  onOpen: () => {},
-  onClose: () => {},
+  onOpen: (index: number) => {},
+  onClose: (index: number) => {},
 } as MenuProps
 export const Menu: FunctionComponent<Partial<MenuProps>> & {
   Item: typeof MenuItem
@@ -70,9 +70,9 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   const toggleMenuItem = (index: number) => {
     showMenuItem[index] = !showMenuItem[index]
     if (showMenuItem[index]) {
-      onOpen && onOpen()
+      onOpen && onOpen(index)
     } else {
-      onClose && onClose()
+      onClose && onClose(index)
     }
     const temp = showMenuItem.map((i: boolean, idx) =>
       idx === index ? i : false
@@ -82,7 +82,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   const hideMenuItem = (index: number) => {
     showMenuItem[index] = false
     setShowMenuItem([...showMenuItem])
-    onClose && onClose()
+    onClose && onClose(index)
   }
   const updateTitle = (text: string, index: number) => {
     menuItemTitle[index] = text

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -94,7 +94,9 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
   usePageScroll(updateItemOffset)
 
   useImperativeHandle<any, any>(ref, () => ({
-    toggle: parent.toggleMenuItem,
+    toggle: (s: boolean) => {
+      s ? parent.toggleMenuItem(index) : parent.hideMenuItem(index)
+    },
   }))
 
   const getIconCName = (optionVal: string | number, value: string | number) => {

--- a/src/packages/menuitem/menuitem.tsx
+++ b/src/packages/menuitem/menuitem.tsx
@@ -76,7 +76,9 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
   }, [showPopup])
 
   useImperativeHandle<any, any>(ref, () => ({
-    toggle: parent.toggleMenuItem,
+    toggle: (s: boolean) => {
+      s ? parent.toggleMenuItem(index) : parent.hideMenuItem(index)
+    },
   }))
 
   const getIconCName = (optionVal: string | number, value: string | number) => {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 日常 bug 修复

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/1434

### 💡 需求背景和解决方案

在文档中增加 onOpen 和 onClose 的描述，同时给 onOpen 和 onClose 增加 menuItem 索引值的参数，方便知道是哪个 menuItem 触发了事件

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
