### PR TITLE
style(input): Update input.scss

### DIFF
--- a/src/packages/input/input.scss
+++ b/src/packages/input/input.scss
@@ -19,6 +19,7 @@
     width: 100%;
     color: $gray1;
     flex: 1;
+    background-color: transparent;
     padding: 0;
     border: 0;
     outline: 0 none;


### PR DESCRIPTION
优化input组件在暗黑模式下自带一个背景条的问题

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 组件样式/交互改进

### 💡 需求背景和解决方案

1.  优化input组件在暗黑模式下自带一个背景条的问题
之前：
![image](https://github.com/jdf2e/nutui-react/assets/26473919/c5c512c3-d809-47c5-a7c1-e0124ad527d5)
之后：
![image](https://github.com/jdf2e/nutui-react/assets/26473919/fb2cb939-1690-4347-8fe7-be8ad7384b89)

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
