### PR TITLE
解决ios和android下点击button时出现半透明灰色遮罩

### DIFF
--- a/src/packages/button/button.scss
+++ b/src/packages/button/button.scss
@@ -14,7 +14,7 @@
   -webkit-appearance: none;
   user-select: none;
   touch-action: manipulation;
-
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
   color: $button-default-color;
   background: $button-default-bg-color;
   border: $button-border-width solid $button-default-border-color;

--- a/src/packages/input/input.scss
+++ b/src/packages/input/input.scss
@@ -19,6 +19,7 @@
     width: 100%;
     color: $gray1;
     flex: 1;
+    background-color: transparent;
     padding: 0;
     border: 0;
     outline: 0 none;


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 组件样式/交互改进


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

解决按钮在移动设备上点击是会多一个半透明遮罩的样式问题

https://github.com/jdf2e/nutui-react/assets/26473919/d7ce7847-f69c-4b3a-b903-e955731bf657


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
