### PR TITLE
style(input): 样式优化

### DIFF
--- a/src/packages/input/input.scss
+++ b/src/packages/input/input.scss
@@ -6,7 +6,6 @@
   width: 100%;
   padding: $input-padding;
   line-height: 24px;
-  background: $white;
   font-size: $input-font-size;
   box-sizing: border-box;
   border-bottom: $input-border-bottom-width solid $input-border-bottom;


### PR DESCRIPTION
去掉nut-input的背景颜色，自动适配元素的颜色，解决父元素有背景颜色的情况，input框多一个背景颜色，样式表现不一致的问题。

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 组件样式/交互改进

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
去掉nut-input的背景颜色，自动适配元素的颜色，解决父元素有背景颜色的情况，input框多一个背景颜色，样式表现不一致的问题。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
