### PR TITLE
修复Popup组件zIndex props无效的问题

### DIFF
--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -134,7 +134,7 @@ export const Popup: FunctionComponent<
   const open = () => {
     if (!innerVisible) {
       setInnerVisible(true)
-      setIndex(++_zIndex)
+      setIndex(++zIndex)
     }
     if (destroyOnClose) {
       setShowChildren(true)


### PR DESCRIPTION
在open中，setIndex应该使用当前zIndex状态来设置新值！