### PR TITLE
修复Popup组件zIndex props 无效的问题

### DIFF
--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -134,7 +134,7 @@ export const Popup: FunctionComponent<
   const open = () => {
     if (!innerVisible) {
       setInnerVisible(true)
-      if(props.zIndex === undefined) {
+      if (props.zIndex === undefined) {
         setIndex(++_zIndex)
       }
     }

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -134,7 +134,9 @@ export const Popup: FunctionComponent<
   const open = () => {
     if (!innerVisible) {
       setInnerVisible(true)
-      setIndex(++_zIndex)
+      if(props.zIndex === undefined) {
+        setIndex(++_zIndex)
+      }
     }
     if (destroyOnClose) {
       setShowChildren(true)


### PR DESCRIPTION
在open中，自定义的zIndex会被setIndex(++_zIndex)覆盖，这里只需要判断一下， 如果自定义了zIndex的值，就不使用全局_zIndex，也不增加全局_zIndex的值