### PR TITLE
fix(form): 表单自定义校验promise 返回错误，异步不能正确收集错误问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v2.0.19
+`2023-09-27`
+
+* :sparkles: feat(menu):  overlay onclick 事件中调用 hideMenuItem 实现关闭 (#1505) @oasis-cloud
+* :sparkles: feat(menu): onClose 事件增加触发来源参数 (#1502) @oasis-cloud
+* :sparkles: feat(swiper): swiperItem 支持设置 className (#1504) @oasis-cloud
+* :bug: fix(uploader): 受控模式调整，props 类型调整，回调参数修正 (#1500) @oasis-cloud
+* :bug: fix: imagepreview with control (#1480) @xiaoyatong
+* :bug: fix: indicator 超长换行 (#1486) @oasis-cloud
+* :bug: fix: menu 在 lockscroll 的时候不需要加滚动事件 (#1509) @oasis-cloud
+* :bug: fix: ios和android下点击button时出现半透明灰色遮罩 (#1495) @Kurisu
+
+
+
 # v2.0.18
 `2023-09-20`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nutui/nutui-react",
-  "version": "2.0.18",
+  "name": "@nutui/nutui-react-taro",
+  "version": "2.0.19",
   "style": "dist/style.css",
   "main": "dist/nutui.react.umd.js",
   "module": "dist/esm/nutui-react.es.js",

--- a/src/packages/form/useform.taro.ts
+++ b/src/packages/form/useform.taro.ts
@@ -3,7 +3,6 @@ import Schema from 'async-validator'
 import { Store, Callbacks, FormInstance, FieldEntity, NamePath } from './types'
 
 export const SECRET = 'NUT_FORM_INTERNAL'
-
 /**
  * 用于存储表单的数据
  */
@@ -87,11 +86,11 @@ class FormStore {
       ...this.store,
       ...newStore,
     }
-    this.fieldEntities.forEach((enetity: FieldEntity) => {
-      const { name } = enetity.props
+    this.fieldEntities.forEach((entity: FieldEntity) => {
+      const { name } = entity.props
       Object.keys(newStore).forEach((key) => {
         if (key === name) {
-          enetity.onStoreChange('update')
+          entity.onStoreChange('update')
         }
       })
     })
@@ -104,10 +103,18 @@ class FormStore {
     }
   }
 
-  validate = () => {
-    const err: any = []
+  validateFields = async (nameList?: NamePath[]) => {
+    let filterEntitys = []
+    const errs = []
     this.errors.length = 0
-    this.fieldEntities.forEach((entity: FieldEntity) => {
+    if (!nameList || nameList.length === 0) {
+      filterEntitys = this.fieldEntities
+    } else {
+      filterEntitys = this.fieldEntities.filter(({ props: { name } }) =>
+        nameList.includes(name)
+      )
+    }
+    for (const entity of filterEntitys) {
       const { name, rules = [] } = entity.props
       const descriptor: any = {}
       if (rules.length) {
@@ -122,55 +129,24 @@ class FormStore {
         }
       }
       const validator = new Schema(descriptor)
-      validator.messages()
-      validator.validate({ [name]: this.store?.[name] }, (errors) => {
+      // 此处合并无值message 没有意义？
+      // validator.messages()
+      try {
+        this.errors[name] = []
+        await validator.validate({ [name]: this.store?.[name] })
+      } catch ({ errors }: any) {
         if (errors) {
-          err.push(...errors)
+          errs.push(...(errors as any[]))
           this.errors[name] = errors
         }
-        entity.onStoreChange('validate')
-      })
-    })
-    return err
-  }
-
-  validateFields = (nameList?: NamePath[]) => {
-    if (!nameList || nameList.length === 0) {
-      this.validate()
-      return
+      }
+      entity.onStoreChange('validate')
     }
-    this.fieldEntities
-      .filter(({ props: { name } }) => {
-        return nameList.includes(name)
-      })
-      .forEach((entity) => {
-        const { name, rules = [] } = entity.props
-        const descriptor: any = {}
-        if (rules.length) {
-          // 多条校验规则
-          if (rules.length > 1) {
-            descriptor[name] = []
-            rules.forEach((v: any) => {
-              descriptor[name].push(v)
-            })
-          } else {
-            descriptor[name] = rules[0]
-          }
-        }
-        const validator = new Schema(descriptor)
-        validator.messages()
-        validator.validate({ [name]: this.store?.[name] }, (errors) => {
-          this.errors[name] = []
-          if (errors) {
-            this.errors[name] = errors
-          }
-          entity.onStoreChange('validate')
-        })
-      })
+    return errs
   }
 
-  submit = () => {
-    const errors = this.validate()
+  submit = async () => {
+    const errors = await this.validateFields()
     if (errors.length === 0) {
       this.callbacks.onFinish?.(this.store)
     } else if (errors.length > 0) {

--- a/src/packages/form/useform.ts
+++ b/src/packages/form/useform.ts
@@ -86,11 +86,11 @@ class FormStore {
       ...this.store,
       ...newStore,
     }
-    this.fieldEntities.forEach((enetity: FieldEntity) => {
-      const { name } = enetity.props
+    this.fieldEntities.forEach((entity: FieldEntity) => {
+      const { name } = entity.props
       Object.keys(newStore).forEach((key) => {
         if (key === name) {
-          enetity.onStoreChange('update')
+          entity.onStoreChange('update')
         }
       })
     })
@@ -103,10 +103,18 @@ class FormStore {
     }
   }
 
-  validate = () => {
-    const err: any = []
+  validateFields = async (nameList?: NamePath[]) => {
+    let filterEntitys = []
+    const errs = []
     this.errors.length = 0
-    this.fieldEntities.forEach((entity: FieldEntity) => {
+    if (!nameList || nameList.length === 0) {
+      filterEntitys = this.fieldEntities
+    } else {
+      filterEntitys = this.fieldEntities.filter(({ props: { name } }) =>
+        nameList.includes(name)
+      )
+    }
+    for (const entity of filterEntitys) {
       const { name, rules = [] } = entity.props
       const descriptor: any = {}
       if (rules.length) {
@@ -121,55 +129,24 @@ class FormStore {
         }
       }
       const validator = new Schema(descriptor)
-      validator.messages()
-      validator.validate({ [name]: this.store?.[name] }, (errors) => {
+      // 此处合并无值message 没有意义？
+      // validator.messages()
+      try {
+        this.errors[name] = []
+        await validator.validate({ [name]: this.store?.[name] })
+      } catch ({ errors }: any) {
         if (errors) {
-          err.push(...errors)
+          errs.push(...(errors as any[]))
           this.errors[name] = errors
         }
-        entity.onStoreChange('validate')
-      })
-    })
-    return err
-  }
-
-  validateFields = (nameList?: NamePath[]) => {
-    if (!nameList || nameList.length === 0) {
-      this.validate()
-      return
+      }
+      entity.onStoreChange('validate')
     }
-    this.fieldEntities
-      .filter(({ props: { name } }) => {
-        return nameList.includes(name)
-      })
-      .forEach((entity) => {
-        const { name, rules = [] } = entity.props
-        const descriptor: any = {}
-        if (rules.length) {
-          // 多条校验规则
-          if (rules.length > 1) {
-            descriptor[name] = []
-            rules.forEach((v: any) => {
-              descriptor[name].push(v)
-            })
-          } else {
-            descriptor[name] = rules[0]
-          }
-        }
-        const validator = new Schema(descriptor)
-        validator.messages()
-        validator.validate({ [name]: this.store?.[name] }, (errors) => {
-          this.errors[name] = []
-          if (errors) {
-            this.errors[name] = errors
-          }
-          entity.onStoreChange('validate')
-        })
-      })
+    return errs
   }
 
-  submit = () => {
-    const errors = this.validate()
+  submit = async () => {
+    const errors = await this.validateFields()
     if (errors.length === 0) {
       this.callbacks.onFinish?.(this.store)
     } else if (errors.length > 0) {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
--> 

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
自定义校验失败不会不会触发onSubmitFailed
```
  <Form.Item label="本次出库数量："
                    name={`detailList.${index}.applyCount`}
                    required
                    rules={[
                      { validator: (rule, value) => validateApplyCount(rule, value, get(materialList, `${index}.storageCount`)) }
                    ]}

 const validateApplyCount = (rule, value, storageCount) => {
    if (!value) {
      return Promise.reject('请输入数量')
    }
    if (value > storageCount) {
      return Promise.reject('申请数量不能大于库存数量')
    }
    return Promise.resolve()
  }
```

### 💡 需求背景和解决方案

```
同上
```

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件

有个问题： 
form单元测试无法通过，但是demo测试已通过
