### PR TITLE
feat(NoticeBar): leftIcon 可自定义，并且支持设置 null 后不展示 icon

### DIFF
--- a/src/packages/noticebar/noticebar.taro.tsx
+++ b/src/packages/noticebar/noticebar.taro.tsx
@@ -41,7 +41,7 @@ const defaultProps = {
   content: '',
   closeable: false,
   wrap: false,
-  leftIcon: null,
+  leftIcon: <Notice width={16} height={16} />,
   rightIcon: null,
   delay: 1,
   scrollable: null,
@@ -439,7 +439,7 @@ export const NoticeBar: FunctionComponent<
     <div className={`${classPrefix} ${className || ''}`} style={style}>
       {showNoticeBar && direction === 'horizontal' ? (
         <div className={noticebarClass} style={barStyle} onClick={handleClick}>
-          <div className="left-icon">{leftIcon || <Notice size={16} />}</div>
+          {leftIcon ? <div className="left-icon">{leftIcon}</div> : null}
           <div ref={wrapRef} className="wrap">
             <div
               ref={contentRef}
@@ -455,7 +455,7 @@ export const NoticeBar: FunctionComponent<
           </div>
           {closeable || rightIcon ? (
             <div className="right-icon" onClick={onClickIcon}>
-              {rightIcon || <Close size={12} />}
+              {closeable ? <Close width={12} height={12} /> : rightIcon}
             </div>
           ) : null}
         </div>
@@ -510,7 +510,7 @@ export const NoticeBar: FunctionComponent<
               handleClickIcon(e)
             }}
           >
-            {rightIcon || (closeable ? <Close size={12} /> : null)}
+            {closeable ? <Close width={12} height={12} /> : rightIcon}
           </div>
         </div>
       ) : null}

--- a/src/packages/noticebar/noticebar.taro.tsx
+++ b/src/packages/noticebar/noticebar.taro.tsx
@@ -41,7 +41,7 @@ const defaultProps = {
   content: '',
   closeable: false,
   wrap: false,
-  leftIcon: <Notice width={16} height={16} />,
+  leftIcon: <Notice size={16} />,
   rightIcon: null,
   delay: 1,
   scrollable: null,
@@ -455,7 +455,7 @@ export const NoticeBar: FunctionComponent<
           </div>
           {closeable || rightIcon ? (
             <div className="right-icon" onClick={onClickIcon}>
-              {closeable ? <Close width={12} height={12} /> : rightIcon}
+              {rightIcon || <Close size={12} />}
             </div>
           ) : null}
         </div>
@@ -510,7 +510,7 @@ export const NoticeBar: FunctionComponent<
               handleClickIcon(e)
             }}
           >
-            {closeable ? <Close width={12} height={12} /> : rightIcon}
+            {rightIcon || (closeable ? <Close size={12} /> : null)}
           </div>
         </div>
       ) : null}

--- a/src/packages/noticebar/noticebar.tsx
+++ b/src/packages/noticebar/noticebar.tsx
@@ -449,7 +449,7 @@ export const NoticeBar: FunctionComponent<
           </div>
           {closeable || rightIcon ? (
             <div className="right-icon" onClick={onClickIcon}>
-              {closeable ? <Close width={12} height={12} /> : rightIcon}
+              {rightIcon || <Close width={12} height={12} />}
             </div>
           ) : null}
         </div>
@@ -504,7 +504,7 @@ export const NoticeBar: FunctionComponent<
               handleClickIcon(e)
             }}
           >
-            {closeable ? <Close width={12} height={12} /> : rightIcon}
+            {rightIcon || (closeable ? <Close width={12} height={12} /> : null)}
           </div>
         </div>
       ) : null}

--- a/src/packages/noticebar/noticebar.tsx
+++ b/src/packages/noticebar/noticebar.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react'
 import { Close, Notice } from '@nutui/icons-react'
 import classNames from 'classnames'
-import { getRect } from '../../utils/use-client-rect'
+import { getRect } from '@/utils/use-client-rect'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 
 export interface NoticeBarProps extends BasicComponent {
@@ -41,7 +41,7 @@ const defaultProps = {
   content: '',
   closeable: false,
   wrap: false,
-  leftIcon: null,
+  leftIcon: <Notice width={16} height={16} />,
   rightIcon: null,
   delay: 1,
   scrollable: null,
@@ -433,9 +433,7 @@ export const NoticeBar: FunctionComponent<
     <div className={`${classPrefix} ${className || ''}`} style={style}>
       {showNoticeBar && direction === 'horizontal' ? (
         <div className={noticebarClass} style={barStyle} onClick={handleClick}>
-          <div className="left-icon">
-            {leftIcon || <Notice width={16} height={16} />}
-          </div>
+          {leftIcon ? <div className="left-icon">{leftIcon}</div> : null}
           <div ref={wrapRef} className="wrap">
             <div
               ref={contentRef}
@@ -451,7 +449,7 @@ export const NoticeBar: FunctionComponent<
           </div>
           {closeable || rightIcon ? (
             <div className="right-icon" onClick={onClickIcon}>
-              {rightIcon || <Close width={12} height={12} />}
+              {closeable ? <Close width={12} height={12} /> : rightIcon}
             </div>
           ) : null}
         </div>
@@ -506,7 +504,7 @@ export const NoticeBar: FunctionComponent<
               handleClickIcon(e)
             }}
           >
-            {rightIcon || (closeable ? <Close width={12} height={12} /> : null)}
+            {closeable ? <Close width={12} height={12} /> : rightIcon}
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
