### PR TITLE
fix(uploader): uploader preview设置为false时onProgress回调不生效

### DIFF
--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -306,7 +306,8 @@ const InternalUploader: ForwardRefRenderFunction<
         }
         reader.readAsDataURL(file)
       } else {
-        setFileList([...fileList, fileItem])
+        fileList.push(fileItem)
+        setFileList([...fileList])
       }
     })
   }


### PR DESCRIPTION
Fix the problem that the uploader component will not execute `onProgress` when the `preview` property is set  false.

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

demo: https://codesandbox.io/p/sandbox/nutui-react-forked-w58md4  
Uploader preview设置为false时onProgress回调不生效

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
