### PR TITLE
fix(tabs): 导航滚动到可视范围需要显示指定 name，调整为内置 uuid 替代 name

### DIFF
--- a/src/packages/tabs/demo.taro.tsx
+++ b/src/packages/tabs/demo.taro.tsx
@@ -19,6 +19,7 @@ interface T {
   title6: string
   title12: string
   title13: string
+  title14: string
   title7: string
   title8: string
   title9: string
@@ -53,6 +54,7 @@ const TabsDemo = () => {
       title6: '左右布局-微笑曲线',
       title12: '嵌套布局',
       title13: '嵌套布局2',
+      title14: '滑动切换',
       title7: 'Title 字体尺寸：20px 12px',
       title8: '自定义标签栏',
       title9: 'Tabpane 自动高度',
@@ -84,6 +86,7 @@ const TabsDemo = () => {
       title6: 'Left and Right Layout - Smile Curve',
       title12: 'Tabs in Tabs',
       title13: 'Tabs in Tabs 2',
+      title14: 'Slide to switch',
       title7: 'Title font size: 20px 12px',
       title8: 'custom tab bar',
       title9: 'Tabpane auto height',
@@ -119,7 +122,7 @@ const TabsDemo = () => {
   const [tab81value, setTab81value] = useState<string | number>('0')
   const [tab82value, setTab82value] = useState<string | number>('0')
   const [tab9value, setTab9value] = useState<string | number>('0')
-  const [tab91value, setTab91value] = useState<string | number>('0')
+  const [tab91value, setTab91value] = useState<string | number>('4')
   const [tab92value, setTab92value] = useState<string | number>('0')
   const [tab93value, setTab93value] = useState<string | number>('0')
   const [list8, setList8] = useState<any>([])
@@ -294,7 +297,7 @@ const TabsDemo = () => {
             Tab 3
           </Tabs.TabPane>
         </Tabs>
-        <h2>滑动切换</h2>
+        <h2>{translated.title14}</h2>
         <Tabs
           value={tabIndex}
           onChange={(page) => {

--- a/src/packages/tabs/demo.tsx
+++ b/src/packages/tabs/demo.tsx
@@ -18,6 +18,7 @@ interface T {
   title6: string
   title12: string
   title13: string
+  title14: string
   title7: string
   title8: string
   title9: string
@@ -52,6 +53,7 @@ const TabsDemo = () => {
       title6: '左右布局-微笑曲线',
       title12: '嵌套布局',
       title13: '嵌套布局2',
+      title14: '滑动切换',
       title7: 'Title 字体尺寸：20px 12px',
       title8: '自定义标签栏',
       title9: 'Tabpane 自动高度',
@@ -83,6 +85,7 @@ const TabsDemo = () => {
       title6: 'Left and Right Layout - Smile Curve',
       title12: 'Tabs in Tabs',
       title13: 'Tabs in Tabs 2',
+      title14: 'Slide to switch',
       title7: 'Title font size: 20px 12px',
       title8: 'custom tab bar',
       title9: 'Tabpane auto height',
@@ -292,7 +295,7 @@ const TabsDemo = () => {
             Tab 3
           </Tabs.TabPane>
         </Tabs>
-        <h2>滑动切换</h2>
+        <h2>{translated.title14}</h2>
         <Tabs
           value={tabIndex}
           onChange={(page) => {

--- a/src/packages/tabs/tabs.taro.tsx
+++ b/src/packages/tabs/tabs.taro.tsx
@@ -8,6 +8,7 @@ import TabPane from '@/packages/tabpane/index.taro'
 import { usePropsValue } from '@/utils/use-props-value'
 import { useForceUpdate } from '@/utils/use-force-update'
 import raf from '@/utils/raf'
+import useUuid from '@/utils/use-uuid'
 
 export type TabsTitle = {
   title: string
@@ -36,7 +37,6 @@ export interface TabsProps extends BasicComponent {
 const defaultProps = {
   ...ComponentDefaults,
   tabStyle: {},
-  name: '',
   activeColor: '',
   direction: 'horizontal',
   activeType: 'line',
@@ -67,6 +67,7 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
     ...defaultProps,
     ...props,
   }
+  const uuid = useUuid()
 
   const [value, setValue] = usePropsValue<string | number>({
     value: props.value,
@@ -183,17 +184,16 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
     animate()
   }
   const scrollIntoView = () => {
-    if (!name) return
-
     raf(() => {
       Promise.all([
-        getRect(`#nut-tabs-titles-${name} .nut-tabs-list`),
-        getAllRect(`#nut-tabs-titles-${name} .nut-tabs-titles-item`),
+        getRect(`#nut-tabs-titles-${name || uuid} .nut-tabs-list`),
+        getAllRect(`#nut-tabs-titles-${name || uuid} .nut-tabs-titles-item`),
       ]).then(([navRect, titleRects]: any) => {
         navRectRef.current = navRect
         titleRectRef.current = titleRects
         // @ts-ignore
         const titleRect: RectItem = titleRectRef.current[value]
+        if (!titleRect) return
 
         let to = 0
         if (props.direction === 'vertical') {
@@ -254,7 +254,7 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
         scrollTop={scrollTop}
         showScrollbar={false}
         scrollWithAnimation={scrollWithAnimation.current}
-        id={`nut-tabs-titles-${name}`}
+        id={`nut-tabs-titles-${name || uuid}`}
         className={classesTitle}
         style={{ ...tabStyle }}
       >


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
