### PR TITLE
fix: 修复 popup 的 left title description 仅在 position='bottom' 的情况下生效的问题

### DIFF
--- a/src/packages/popover/popover.taro.tsx
+++ b/src/packages/popover/popover.taro.tsx
@@ -318,6 +318,7 @@ export const Popover: FunctionComponent<
       <div className={classes} style={getRootPosition()}>
         <Popup
           className={`nut-popover-content nut-popover-content-${location}`}
+          // @ts-ignore
           position="default"
           overlay={overlay}
           visible={showPopup}

--- a/src/packages/popover/popover.tsx
+++ b/src/packages/popover/popover.tsx
@@ -307,6 +307,7 @@ export const Popover: FunctionComponent<
           className={`nut-popover-content nut-popover-content-${location}`}
           visible={showPopup}
           overlay={overlay}
+          // @ts-ignore
           position="default"
           {...rest}
         >

--- a/src/packages/popup/demo.taro.tsx
+++ b/src/packages/popup/demo.taro.tsx
@@ -27,6 +27,10 @@ interface T {
   c9e6df49: string
 }
 
+const demoCommonPopupStyle = {
+  width: '75vw',
+}
+
 const PopupDemo = () => {
   const [translated] = useTranslate<T>({
     'zh-CN': {
@@ -120,7 +124,7 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showBasic}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           onClose={() => {
             setShowBasic(false)
           }}
@@ -260,7 +264,7 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showOverlayStop}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           onClose={() => {
             setShowOverlayStop(false)
           }}
@@ -319,7 +323,7 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showMountNode}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           portal={document.body}
           onClose={() => {
             setShowMountNode(false)
@@ -337,7 +341,7 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showMutiple}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           onClose={() => {
             setShowMutiple(false)
           }}
@@ -352,7 +356,7 @@ const PopupDemo = () => {
         </Popup>
         <Popup
           visible={showMutipleInner}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           overlayStyle={{ backgroundColor: 'transparent' }}
           onClose={() => {
             setShowMutipleInner(false)

--- a/src/packages/popup/demo.tsx
+++ b/src/packages/popup/demo.tsx
@@ -24,6 +24,10 @@ interface T {
   c9e6df49: string
 }
 
+const demoCommonPopupStyle = {
+  width: '75vw',
+}
+
 const PopupDemo = () => {
   const [translated] = useTranslate<T>({
     'zh-CN': {
@@ -113,10 +117,12 @@ const PopupDemo = () => {
         <Popup
           visible={showBasic}
           zIndex={2000}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           onClose={() => {
             setShowBasic(false)
           }}
+          title="我是标题"
+          closeable
         >
           {translated.b840c88f}
         </Popup>
@@ -135,6 +141,8 @@ const PopupDemo = () => {
           onClose={() => {
             setShowTop(false)
           }}
+          title="我是标题"
+          closeable
         />
         <Cell
           title={translated.cfbdc781}
@@ -157,11 +165,13 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showLeft}
-          style={{ width: '40%', height: '100%' }}
+          style={{ width: '60%', height: '100%' }}
           position="left"
           onClose={() => {
             setShowLeft(false)
           }}
+          title="我是标题"
+          closeable
         />
         <Cell
           title={translated.e51e4582}
@@ -171,11 +181,13 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showRight}
-          style={{ width: '40%', height: '100%' }}
+          style={{ width: '60%', height: '100%' }}
           position="right"
           onClose={() => {
             setShowRight(false)
           }}
+          title="我是标题"
+          closeable
         />
 
         <h2>{translated['7db1a8b2']}</h2>
@@ -236,7 +248,7 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showOverlayStop}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           onClose={() => {
             setShowOverlayStop(false)
           }}
@@ -294,7 +306,7 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showMountNode}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           portal={document.body}
           onClose={() => {
             setShowMountNode(false)
@@ -312,7 +324,7 @@ const PopupDemo = () => {
         />
         <Popup
           visible={showMutiple}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           onClose={() => {
             setShowMutiple(false)
           }}
@@ -327,7 +339,7 @@ const PopupDemo = () => {
         </Popup>
         <Popup
           visible={showMutipleInner}
-          style={{ padding: '30px 50px' }}
+          style={demoCommonPopupStyle}
           overlayStyle={{ backgroundColor: 'transparent' }}
           onClose={() => {
             setShowMutipleInner(false)

--- a/src/packages/popup/doc.md
+++ b/src/packages/popup/doc.md
@@ -27,7 +27,7 @@ const App = () => {
   return (
     <>
       <Cell title="展示弹出层"  onClick={() => { setShowBasic(true) }}/>
-      <Popup visible={ showBasic } style={{ padding: '30px 50px' }} onClose={ () => { setShowBasic(false) } }>正文</Popup>
+      <Popup visible={ showBasic } style={{ width: '75vw' }} onClose={ () => { setShowBasic(false) } }>正文</Popup>
     </>
   );
 };
@@ -139,7 +139,7 @@ const App = () => {
   return (
     <>
       <Cell title="指定节点挂载"  onClick={() => { setShowMountNode(true) }}/>
-      <Popup visible={showMountNode} style={{ padding: '30px 50px' }} portal={ document.body } onClose={() => { setShowMountNode(false) }}>
+      <Popup visible={showMountNode} style={{ width: '75vw' }} portal={ document.body } onClose={() => { setShowMountNode(false) }}>
         body
       </Popup>
     </>
@@ -167,7 +167,7 @@ const App = () => {
         <Cell title="多层堆叠"  onClick={() => { setShowMutiple(true) }}/>
         <Popup
           visible={showMutiple}
-          style={{ padding: '30px 50px' }}
+          style={{ width: '75vw' }}
           onClose={() => {
             setShowMutiple(false)
           }}
@@ -176,7 +176,7 @@ const App = () => {
         </Popup>
         <Popup
           visible={showMutipleInner}
-          style={{ padding: '30px 50px' }}
+          style={{ width: '75vw' }}
           onClose={() => {
             setShowMutipleInner(false)
           }}

--- a/src/packages/popup/doc.taro.md
+++ b/src/packages/popup/doc.taro.md
@@ -27,7 +27,7 @@ const App = () => {
   return (
     <>
         <Cell title="展示弹出层"  onClick={() => { setShowBasic(true) }}/>
-        <Popup visible={ showBasic } style={{ padding: '30px 50px' }} onClose={ () => { setShowBasic(false) } }>正文</Popup>
+        <Popup visible={ showBasic } style={{ width: '75vw' }} onClose={ () => { setShowBasic(false) } }>正文</Popup>
     </>
   );
 };
@@ -139,7 +139,7 @@ const App = () => {
   return (
     <>
         <Cell title="指定节点挂载"  onClick={() => { setShowMountNode(true) }}/>
-        <Popup visible={showMountNode} style={{ padding: '30px 50px' }} portal={ document.body } onClose={() => { setShowMountNode(false) }}>
+        <Popup visible={showMountNode} style={{ width: '75vw' }} portal={ document.body } onClose={() => { setShowMountNode(false) }}>
           body
         </Popup>
     </>
@@ -167,7 +167,7 @@ const App = () => {
         <Cell title="多层堆叠"  onClick={() => { setShowMutiple(true) }}/>
         <Popup
           visible={showMutiple}
-          style={{ padding: '30px 50px' }}
+          style={{ width: '75vw' }}
           onClose={() => {
             setShowMutiple(false)
           }}
@@ -176,7 +176,7 @@ const App = () => {
         </Popup>
         <Popup
           visible={showMutipleInner}
-          style={{ padding: '30px 50px' }}
+          style={{ width: '75vw' }}
           onClose={() => {
             setShowMutipleInner(false)
           }}

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -24,7 +24,7 @@ import { useLockScrollTaro } from '@/utils/use-lock-scoll-taro'
 type Teleport = HTMLElement | (() => HTMLElement) | null
 
 export interface PopupProps extends OverlayProps {
-  position: string
+  position: 'top' | 'bottom' | 'left' | 'right' | 'center'
   transition: string
   overlayStyle: React.CSSProperties
   overlayClassName: string
@@ -204,45 +204,30 @@ export const Popup: FunctionComponent<
   }
 
   const renderTitle = () => {
+    const closeElement = closeable && (
+      <View className={closeClasses} onClick={onHandleClickCloseIcon}>
+        {React.isValidElement(closeIcon) ? closeIcon : <Close />}
+      </View>
+    )
     if (left || title || description) {
       return (
         <View className={`${classPrefix}-title`}>
-          {position === 'bottom' && (
-            <>
-              {left && (
-                <View className={`${classPrefix}-title-left`}>{left}</View>
-              )}
-              {(title || description) && (
-                <div className={`${classPrefix}-title-title`}>
-                  {title}
-                  {description && (
-                    <div className={`${classPrefix}-title-description`}>
-                      {description}
-                    </div>
-                  )}
+          {left && <View className={`${classPrefix}-title-left`}>{left}</View>}
+          {(title || description) && (
+            <div className={`${classPrefix}-title-title`}>
+              {title}
+              {description && (
+                <div className={`${classPrefix}-title-description`}>
+                  {description}
                 </div>
               )}
-            </>
+            </div>
           )}
-          {closeable && (
-            <View className={closeClasses} onClick={onHandleClickCloseIcon}>
-              {React.isValidElement(closeIcon) ? closeIcon : <Close />}
-            </View>
-          )}
+          {closeElement}
         </View>
       )
     }
-    if (closeable) {
-      return (
-        <>
-          {closeable && (
-            <View className={closeClasses} onClick={onHandleClickCloseIcon}>
-              {React.isValidElement(closeIcon) ? closeIcon : <Close />}
-            </View>
-          )}
-        </>
-      )
-    }
+    return closeElement
   }
   const renderPop = () => {
     return (

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -21,7 +21,7 @@ import { useLockScroll } from '@/utils/use-lock-scroll'
 type Teleport = HTMLElement | (() => HTMLElement) | null
 
 export interface PopupProps extends OverlayProps {
-  position: string
+  position: 'top' | 'bottom' | 'left' | 'right' | 'center'
   transition: string
   overlayStyle: React.CSSProperties
   overlayClassName: string
@@ -203,45 +203,30 @@ export const Popup: FunctionComponent<
   }
 
   const renderTitle = () => {
+    const closeElement = closeable && (
+      <div className={closeClasses} onClick={onHandleClickCloseIcon}>
+        {React.isValidElement(closeIcon) ? closeIcon : <Close />}
+      </div>
+    )
     if (left || title || description) {
       return (
         <div className={`${classPrefix}-title`}>
-          {position === 'bottom' && (
-            <>
-              {left && (
-                <div className={`${classPrefix}-title-left`}>{left}</div>
-              )}
-              {(title || description) && (
-                <div className={`${classPrefix}-title-title`}>
-                  {title}
-                  {description && (
-                    <div className={`${classPrefix}-title-description`}>
-                      {description}
-                    </div>
-                  )}
+          {left && <div className={`${classPrefix}-title-left`}>{left}</div>}
+          {(title || description) && (
+            <div className={`${classPrefix}-title-title`}>
+              {title}
+              {description && (
+                <div className={`${classPrefix}-title-description`}>
+                  {description}
                 </div>
               )}
-            </>
-          )}
-          {closeable && (
-            <div className={closeClasses} onClick={onHandleClickCloseIcon}>
-              {React.isValidElement(closeIcon) ? closeIcon : <Close />}
             </div>
           )}
+          {closeElement}
         </div>
       )
     }
-    if (closeable) {
-      return (
-        <>
-          {closeable && (
-            <div className={closeClasses} onClick={onHandleClickCloseIcon}>
-              {React.isValidElement(closeIcon) ? closeIcon : <Close />}
-            </div>
-          )}
-        </>
-      )
-    }
+    return closeElement
   }
   const renderPop = () => {
     return (


### PR DESCRIPTION


fix: 1. 修复Popup的left title description仅在position = 'bottom'的情况下生效的问题; 2. 优化一下position的类型

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
