### PR TITLE
fix(tabbaritem): 属性传递改为 context，精简 props 类型

### DIFF
--- a/src/packages/tabbar/context.ts
+++ b/src/packages/tabbar/context.ts
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export interface TabbarContext {
+  selectIndex: number
+  inactiveColor: string
+  activeColor: string
+  handleClick: (value: number) => void
+}
+
+export default React.createContext<TabbarContext | null>(null)

--- a/src/packages/tabbar/index.taro.ts
+++ b/src/packages/tabbar/index.taro.ts
@@ -1,4 +1,5 @@
 import { Tabbar } from './tabbar.taro'
 
+export type { TabbarContext } from './context'
 export type { TabbarProps } from './tabbar.taro'
 export default Tabbar

--- a/src/packages/tabbar/index.ts
+++ b/src/packages/tabbar/index.ts
@@ -1,4 +1,5 @@
 import { Tabbar } from './tabbar'
 
+export type { TabbarContext } from './context'
 export type { TabbarProps } from './tabbar'
 export default Tabbar

--- a/src/packages/tabbar/tabbar.taro.tsx
+++ b/src/packages/tabbar/tabbar.taro.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import { usePropsValue } from '@/utils/use-props-value'
 import TabbarItem from '../tabbaritem/index.taro'
+import TabbarContext from './context'
 
 export interface TabbarProps extends BasicComponent {
   defaultValue: number
@@ -63,20 +64,19 @@ export const Tabbar: FunctionComponent<Partial<TabbarProps>> & {
       style={style}
     >
       <div className={`${classPrefix}-wrap`}>
-        {React.Children.map(children, (child, idx) => {
-          if (!React.isValidElement(child)) {
-            return null
-          }
-          const childProps = {
-            ...child.props,
-            active: idx === selectIndex,
-            index: idx,
-            inactiveColor,
+        <TabbarContext.Provider
+          value={{
+            selectIndex,
             activeColor,
+            inactiveColor,
             handleClick: setSelectIndex,
-          }
-          return React.cloneElement(child, childProps)
-        })}
+          }}
+        >
+          {React.Children.map(children, (child, index) => {
+            if (!React.isValidElement(child)) return null
+            return React.cloneElement(child, { ...child.props, index })
+          })}
+        </TabbarContext.Provider>
       </div>
       {(fixed || safeArea) && <div className={`${classPrefix}-safe-area`} />}
     </div>

--- a/src/packages/tabbar/tabbar.tsx
+++ b/src/packages/tabbar/tabbar.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import { usePropsValue } from '@/utils/use-props-value'
 import TabbarItem from '../tabbaritem'
+import TabbarContext from './context'
 
 export interface TabbarProps extends BasicComponent {
   defaultValue: number
@@ -63,20 +64,19 @@ export const Tabbar: FunctionComponent<Partial<TabbarProps>> & {
       style={style}
     >
       <div className={`${classPrefix}-wrap`}>
-        {React.Children.map(children, (child, idx) => {
-          if (!React.isValidElement(child)) {
-            return null
-          }
-          const childProps = {
-            ...child.props,
-            active: idx === selectIndex,
-            index: idx,
-            inactiveColor,
+        <TabbarContext.Provider
+          value={{
+            selectIndex,
             activeColor,
+            inactiveColor,
             handleClick: setSelectIndex,
-          }
-          return React.cloneElement(child, childProps)
-        })}
+          }}
+        >
+          {React.Children.map(children, (child, index) => {
+            if (!React.isValidElement(child)) return null
+            return React.cloneElement(child, { ...child.props, index })
+          })}
+        </TabbarContext.Provider>
       </div>
       {(fixed || safeArea) && <div className={`${classPrefix}-safe-area`} />}
     </div>

--- a/src/packages/tabbaritem/tabbaritem.taro.tsx
+++ b/src/packages/tabbaritem/tabbaritem.taro.tsx
@@ -1,29 +1,23 @@
-import React, { FunctionComponent, ReactNode } from 'react'
+import React, { FunctionComponent, ReactNode, useContext } from 'react'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import Badge from '@/packages/badge/index.taro'
+import TabbarContext from '@/packages/tabbar/context'
 
 export interface TabbarItemProps extends BasicComponent {
   title: ReactNode
   icon: ReactNode
-  active: boolean
-  activeColor: string
-  inactiveColor: string
-  index: number
   value: ReactNode
   dot: boolean
   max: number
   top: string
   right: string
-  handleClick: (idx: number) => void
 }
 
 const defaultProps = {
   ...ComponentDefaults,
   title: '',
   icon: null,
-  active: false,
-  index: 0,
   value: '',
   dot: false,
   max: 99,
@@ -34,26 +28,25 @@ const defaultProps = {
 export const TabbarItem: FunctionComponent<Partial<TabbarItemProps>> = (
   props
 ) => {
+  const ctx = useContext(TabbarContext)
   const {
     className,
     style,
     title,
     icon,
-    active,
-    activeColor,
-    inactiveColor,
-    index,
     value,
     dot,
     max,
     top,
     right,
-    handleClick,
+    // @ts-ignore
+    index,
     ...rest
   } = {
     ...defaultProps,
     ...props,
   }
+  const active = index === ctx?.selectIndex
   const classPrefix = 'nut-tabbar-item'
   const tabbarItemClass = classNames(
     classPrefix,
@@ -73,17 +66,17 @@ export const TabbarItem: FunctionComponent<Partial<TabbarItemProps>> = (
     max,
     top,
     right,
-    color: activeColor,
+    color: ctx?.activeColor,
   }
 
   return (
     <div
       className={tabbarItemClass}
       style={{
-        color: active ? activeColor : inactiveColor,
+        color: active ? ctx?.activeColor : ctx?.inactiveColor,
         ...style,
       }}
-      onClick={() => handleClick(index)}
+      onClick={() => ctx?.handleClick(index)}
       {...rest}
     >
       {icon ? (

--- a/src/packages/tabbaritem/tabbaritem.tsx
+++ b/src/packages/tabbaritem/tabbaritem.tsx
@@ -1,29 +1,23 @@
-import React, { FunctionComponent, ReactNode } from 'react'
+import React, { FunctionComponent, ReactNode, useContext } from 'react'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import Badge from '@/packages/badge/index'
+import TabbarContext from '@/packages/tabbar/context'
 
 export interface TabbarItemProps extends BasicComponent {
   title: ReactNode
   icon: ReactNode
-  active: boolean
-  activeColor: string
-  inactiveColor: string
-  index: number
   value: ReactNode
   dot: boolean
   max: number
   top: string
   right: string
-  handleClick: (idx: number) => void
 }
 
 const defaultProps = {
   ...ComponentDefaults,
   title: '',
   icon: null,
-  active: false,
-  index: 0,
   value: '',
   dot: false,
   max: 99,
@@ -34,26 +28,25 @@ const defaultProps = {
 export const TabbarItem: FunctionComponent<Partial<TabbarItemProps>> = (
   props
 ) => {
+  const ctx = useContext(TabbarContext)
   const {
     className,
     style,
     title,
     icon,
-    active,
-    activeColor,
-    inactiveColor,
-    index,
     value,
     dot,
     max,
     top,
     right,
-    handleClick,
+    // @ts-ignore
+    index,
     ...rest
   } = {
     ...defaultProps,
     ...props,
   }
+  const active = index === ctx?.selectIndex
   const classPrefix = 'nut-tabbar-item'
   const tabbarItemClass = classNames(
     classPrefix,
@@ -73,17 +66,17 @@ export const TabbarItem: FunctionComponent<Partial<TabbarItemProps>> = (
     max,
     top,
     right,
-    color: activeColor,
+    color: ctx?.activeColor,
   }
 
   return (
     <div
       className={tabbarItemClass}
       style={{
-        color: active ? activeColor : inactiveColor,
+        color: active ? ctx?.activeColor : ctx?.inactiveColor,
         ...style,
       }}
-      onClick={() => handleClick(index)}
+      onClick={() => ctx?.handleClick(index)}
       {...rest}
     >
       {icon ? (


### PR DESCRIPTION
将 clone 子元素的方法，改为 context 的方式，隐藏内部使用的 props，精简对外暴露的 … props 类型

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
