### PR TITLE
feat(dialog): 新增按钮 loading 属性

### DIFF
--- a/src/packages/dialog/__test__/dialog.spec.tsx
+++ b/src/packages/dialog/__test__/dialog.spec.tsx
@@ -80,3 +80,31 @@ test('dialog cancelText confirmText', async () => {
   expect(footerOkEle).toHaveTextContent('确定文案自定义')
   expect(footerCancelEle).toHaveTextContent('取消文案自定义')
 })
+
+test('dialog confirmLoading', async () => {
+  const { container } = render(
+    <Dialog visible confirmLoading>
+      content
+    </Dialog>
+  )
+
+  const footerOkEle = container.querySelector('.nut-dialog-footer-ok')!
+  const footerCancelEle = container.querySelector('.nut-dialog-footer-cancel')!
+
+  expect(footerOkEle.classList.contains('nut-button-loading')).toBeTruthy()
+  expect(!footerCancelEle.classList.contains('nut-button-loading')).toBeTruthy()
+})
+
+test('dialog cancelLoading', async () => {
+  const { container } = render(
+    <Dialog visible cancelLoading>
+      content
+    </Dialog>
+  )
+
+  const footerOkEle = container.querySelector('.nut-dialog-footer-ok')!
+  const footerCancelEle = container.querySelector('.nut-dialog-footer-cancel')!
+
+  expect(!footerOkEle.classList.contains('nut-button-loading')).toBeTruthy()
+  expect(footerCancelEle.classList.contains('nut-button-loading')).toBeTruthy()
+})

--- a/src/packages/dialog/config.ts
+++ b/src/packages/dialog/config.ts
@@ -15,6 +15,8 @@ export interface BasicDialogProps extends BasicComponent {
   footer?: ReactNode
   confirmText?: ReactNode
   cancelText?: ReactNode
+  confirmLoading?: boolean
+  cancelLoading?: boolean
   overlay?: boolean
   hideConfirmButton?: boolean
   hideCancelButton?: boolean

--- a/src/packages/dialog/demo.tsx
+++ b/src/packages/dialog/demo.tsx
@@ -21,6 +21,7 @@ interface T {
   confirmText: string
   cancelText: string
   header: string
+  confirmLoading: string
 }
 
 const DialogDemo = () => {
@@ -42,6 +43,7 @@ const DialogDemo = () => {
       confirmText: '确定',
       cancelText: '取消',
       header: '顶部带插图',
+      confirmLoading: '确认按钮 loading',
     },
     'en-US': {
       funUse: 'Function use',
@@ -61,6 +63,7 @@ const DialogDemo = () => {
       confirmText: 'confirm',
       cancelText: 'cancel',
       header: 'Top with illustration',
+      confirmLoading: 'Confirm button loading',
     },
   })
 
@@ -71,6 +74,8 @@ const DialogDemo = () => {
   const [visible5, setVisible5] = useState(false)
   const [visible6, setVisible6] = useState(false)
   const [visible7, setVisible7] = useState(false)
+  const [visible8, setVisible8] = useState(false)
+  const [confirmLoading8, setConfirmLoading8] = useState(false)
 
   return (
     <>
@@ -263,6 +268,28 @@ const DialogDemo = () => {
           onCancel={() => setVisible7(false)}
         >
           {translated.content}
+        </Dialog>
+        <Cell
+          title={translated.confirmLoading}
+          onClick={() => {
+            setVisible8(true)
+          }}
+        />
+        <Dialog
+          title={translated.tips}
+          visible={visible8}
+          confirmLoading={confirmLoading8}
+          onConfirm={() => {
+            setConfirmLoading8(true)
+
+            setTimeout(() => {
+              setConfirmLoading8(false)
+              setVisible8(false)
+            }, 500)
+          }}
+          onCancel={() => setVisible8(false)}
+        >
+          {translated.confirmLoading}
         </Dialog>
       </div>
     </>

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -25,6 +25,8 @@ const defaultProps = {
   footer: '',
   confirmText: '',
   cancelText: '',
+  confirmLoading: false,
+  cancelLoading: false,
   overlay: true,
   closeOnOverlayClick: true,
   hideConfirmButton: false,
@@ -64,6 +66,8 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
       onOverlayClick,
       confirmText,
       cancelText,
+      confirmLoading,
+      cancelLoading,
       overlay,
       onClose,
       onCancel,
@@ -108,6 +112,7 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
             <Button
               type="default"
               className={`${classPrefix}-footer-cancel`}
+              loading={cancelLoading}
               onClick={(e) => handleCancel(e)}
             >
               {cancelText || locale.cancel}
@@ -120,6 +125,7 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
                 disabled: disableConfirmButton,
               })}
               disabled={disableConfirmButton}
+              loading={confirmLoading}
               onClick={(e) => handleOk(e)}
             >
               {confirmText || locale.confirm}

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -18,6 +18,8 @@ const defaultProps = {
   ...ComponentDefaults,
   confirmText: '',
   cancelText: '',
+  confirmLoading: false,
+  cancelLoading: false,
   overlay: true,
   closeOnOverlayClick: true,
   hideConfirmButton: false,
@@ -44,6 +46,8 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
     closeOnOverlayClick,
     confirmText,
     cancelText,
+    confirmLoading,
+    cancelLoading,
     onClose,
     onCancel,
     onConfirm,
@@ -77,6 +81,7 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
             <Button
               type="default"
               className={`${classPrefix}-footer-cancel`}
+              loading={cancelLoading}
               onClick={(e) => handleCancel(e)}
             >
               {cancelText || locale.cancel}
@@ -89,6 +94,7 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
                 disabled: disableConfirmButton,
               })}
               disabled={disableConfirmButton}
+              loading={confirmLoading}
               onClick={(e) => handleOk(e)}
             >
               {confirmText || locale.confirm}

--- a/src/packages/dialog/doc.en-US.md
+++ b/src/packages/dialog/doc.en-US.md
@@ -172,8 +172,10 @@ export default App;
 | title | title | `ReactNode` | `-` |
 | content | The content of the dialog box is suitable for function calls | `ReactNode` | `-` |
 | footer | Customize the notes, but it will not be displayed in NULL | `ReactNode` | `-` |
-| confirmText | Confirm the button copywriting | `ReactNode` | `Sure` |
-| cancelText | Cancellation of buttons | `ReactNode` | `Cancel` |
+| confirmText | Confirm button text | `ReactNode` | `Sure` |
+| cancelText | Cancel button text | `ReactNode` | `Cancel` |
+| confirmLoading | The loading state of the confirmation button | `boolean` | `false` |
+| cancelLoading | Cancel the loading state of the button | `boolean` | `false` |
 | overlay | Whether to show a overlay | `boolean` | `true` |
 | hideConfirmButton | Whether to hide the OK button | `boolean` | `false` |
 | hideCancelButton | Whether to hide the cancel button | `boolean` | `false` |

--- a/src/packages/dialog/doc.md
+++ b/src/packages/dialog/doc.md
@@ -102,6 +102,9 @@ const App = () => {
   const [visible1, setVisible1] = useState(false);
   const [visible2, setVisible2] = useState(false);
   const [visible3, setVisible3] = useState(false);
+  const [visible4, setVisible4] = useState(false);
+  const [visible5, setVisible5] = useState(false);
+  const [confirmLoading5, setConfirmLoading5] = useState(false);
   return (
     <>
       <Cell title="基础弹框" onClick={() => setVisible1(true)} />
@@ -164,20 +167,41 @@ const App = () => {
       <Cell
         title="顶部带插图"
         onClick={() => {
-          setVisible7(true)
+          setVisible4(true)
         }}
       />
       <Dialog
         className="test-dialog"
         title="顶部带插图"
-        visible={visible7}
+        visible={visible4}
         header={
           <Image src="https://img13.360buyimg.com/imagetools/jfs/t1/219330/27/30033/11784/6544af3fF5c0fd98f/64c41bb05ef09189.png" />
         }
-        onConfirm={() => setVisible7(false)}
-        onCancel={() => setVisible7(false)}
+        onConfirm={() => setVisible4(false)}
+        onCancel={() => setVisible4(false)}
       >
         如果需要在弹窗内嵌入组件或其他自定义内容，可以使用组件调用的方式。
+      </Dialog>
+      <Cell
+        title="确认按钮 loading"
+        onClick={() => {
+          setVisible5(true)
+        }}
+      />
+      <Dialog
+        title="提示"
+        visible={visible5}
+        onConfirm={() => {
+          setConfirmLoading5(true)
+
+          setTimeout(() => {
+            setConfirmLoading5(false)
+            setVisible5(false)
+          }, 500)
+        }}
+        onCancel={() => setVisible5(false)}
+      >
+        确定按钮 loading
       </Dialog>
     </>
   )
@@ -200,6 +224,8 @@ export default App;
 | footer | 自定义页脚，传入 null 则不显示 | `ReactNode` | `-` |
 | confirmText | 确认按钮文案 | `ReactNode` | `确定` |
 | cancelText | 取消按钮文案 | `ReactNode` | `取消` |
+| confirmLoading | 确认按钮 loading 状态 | `boolean` | `false` |
+| cancelLoading | 取消按钮 loading 状态 | `boolean` | `false` |
 | overlay | 是否展示遮罩 | `boolean` | `true` |
 | hideConfirmButton | 是否隐藏确定按钮 | `boolean` | `false` |
 | hideCancelButton | 是否隐藏取消按钮 | `boolean` | `false` |

--- a/src/packages/dialog/doc.taro.md
+++ b/src/packages/dialog/doc.taro.md
@@ -65,8 +65,9 @@ const App = () => {
   const [visible4, setVisible4] = useState(false)
   const [visible5, setVisible5] = useState(false)
   const [visible6, setVisible6] = useState(false)
-  const [visible7, setVisible7] = useState(false);
-
+  const [visible7, setVisible7] = useState(false)
+  const [visible8, setVisible8] = useState(false)
+  const [confirmLoading8, setConfirmLoading8] = useState(false)
   return (
     <>
       <Cell title="基础弹框" onClick={() => setVisible1(true)} />
@@ -167,6 +168,28 @@ const App = () => {
       >
         如果需要在弹窗内嵌入组件或其他自定义内容，可以使用组件调用的方式。
       </Dialog>
+      <Cell
+          title="确认按钮 loading"
+          onClick={() => {
+            setVisible8(true)
+          }}
+        />
+        <Dialog
+          title="提示"
+          visible={visible8}
+          confirmLoading={confirmLoading8}
+          onConfirm={() => {
+            setConfirmLoading8(true)
+
+            setTimeout(() => {
+              setConfirmLoading8(false)
+              setVisible8(false)
+            }, 500)
+          }}
+          onCancel={() => setVisible8(false)}
+        >
+          确认按钮 loading
+        </Dialog>
     </>
   )
 }
@@ -188,6 +211,8 @@ export default App;
 | footer | 自定义页脚，传入 null 则不显示 | `ReactNode` | `-` |
 | confirmText | 确认按钮文案 | `ReactNode` | `确定` |
 | cancelText | 取消按钮文案 | `ReactNode` | `取消` |
+| confirmLoading | 确认按钮 loading 状态 | `boolean` | `false` |
+| cancelLoading | 取消按钮 loading 状态 | `boolean` | `false` |
 | overlay | 是否展示遮罩 | `boolean` | `true` |
 | hideConfirmButton | 是否隐藏确定按钮 | `boolean` | `false` |
 | hideCancelButton | 是否隐藏取消按钮 | `boolean` | `false` |

--- a/src/packages/dialog/doc.zh-TW.md
+++ b/src/packages/dialog/doc.zh-TW.md
@@ -102,6 +102,9 @@ const App = () => {
   const [visible1, setVisible1] = useState(false);
   const [visible2, setVisible2] = useState(false);
   const [visible3, setVisible3] = useState(false);
+  const [visible4, setVisible4] = useState(false);
+  const [visible5, setVisible5] = useState(false);
+  const [confirmLoading5, setConfirmLoading5] = useState(false);
   return (
     <>
       <Cell title="基礎彈框" onClick={() => setVisible1(true)} />
@@ -164,20 +167,41 @@ const App = () => {
       <Cell
         title="頂部帶插圖"
         onClick={() => {
-          setVisible7(true)
+          setVisible4(true)
         }}
       />
       <Dialog
         className="test-dialog"
         title="頂部帶插圖"
-        visible={visible7}
+        visible={visible4}
         header={
           <Image src="https://img13.360buyimg.com/imagetools/jfs/t1/219330/27/30033/11784/6544af3fF5c0fd98f/64c41bb05ef09189.png" />
         }
-        onConfirm={() => setVisible7(false)}
-        onCancel={() => setVisible7(false)}
+        onConfirm={() => setVisible4(false)}
+        onCancel={() => setVisible4(false)}
       >
         如果需要在彈窗內嵌入組件或其他自定義內容，可以使用組件調用的方式。
+      </Dialog>
+      <Cell
+        title="確認按鈕 loading"
+        onClick={() => {
+          setVisible5(true)
+        }}
+      />
+      <Dialog
+        title="提示"
+        visible={visible5}
+        onConfirm={() => {
+          setConfirmLoading5(true)
+
+          setTimeout(() => {
+            setConfirmLoading5(false)
+            setVisible5(false)
+          }, 500)
+        }}
+        onCancel={() => setVisible5(false)}
+      >
+        確認按鈕 loading
       </Dialog>
     </>
   )
@@ -200,6 +224,8 @@ export default App;
 | footer | 自定義頁腳，傳入 null 則不顯示 | `ReactNode` | `-` |
 | confirmText | 確認按鈕文案 | `ReactNode` | `確定` |
 | cancelText | 取消按鈕文案 | `ReactNode` | `取消` |
+| confirmLoading | 確認按鈕 loading 狀態 | `boolean` | `false` |
+| cancelLoading | 取消按鈕 loading 狀態 | `boolean` | `false` |
 | overlay | 是否展示遮罩 | `boolean` | `true` |
 | hideConfirmButton | 是否隱藏確定按鈕 | `boolean` | `false` |
 | hideCancelButton | 是否隱藏取消按鈕 | `boolean` | `false` |


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

达到类似 [React Native Xiaoshu 对话框的「确认弹窗:自定义颜色、文案」](https://hjfruit.github.io/xiaoshu-doc/component/feedback/dialog) 效果，对话框按钮有 loading 状态变化

新增 confirmLoading、cancelLoading 属性，在标签式使用中配合异步回调

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
