### PR TITLE
fix(button): 增加 CSS 变量配置颜色的例子，完善 color 属性的使用场景描述

### DIFF
--- a/src/packages/button/button.taro.tsx
+++ b/src/packages/button/button.taro.tsx
@@ -110,7 +110,6 @@ export const Button = React.forwardRef<HTMLButtonElement, Partial<ButtonProps>>(
       // eslint-disable-next-line react/button-has-type
       <button
         {...rest}
-        // type={Taro.getEnv() === 'WEB''reset'}
         ref={ref}
         className={classNames(
           prefixCls,

--- a/src/packages/button/demo.taro.tsx
+++ b/src/packages/button/demo.taro.tsx
@@ -459,19 +459,46 @@ const ButtonDemo = () => {
         <h2>{translated['781b07fd']}</h2>
 
         <Cell style={{ flexWrap: 'wrap' }}>
-          <Button color="#7232dd" style={{ margin: 8 }}>
+          <Button
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': 'blue',
+              '--nutui-button-default-color': '#fff',
+              '--nutui-button-default-background-color': 'blue',
+            }}
+          >
             {translated['1076d771']}
           </Button>
-          <Button fill="outline" color="#7232dd" style={{ margin: 8 }}>
+          <Button
+            fill="outline"
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': '#7232dd',
+              '--nutui-button-default-color': '#7232dd',
+            }}
+          >
             {translated['1076d771']}
           </Button>
-          <Button color="rgba(10,101,208,0.75)" style={{ margin: 8 }}>
+          <Button
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': 'transparent',
+              '--nutui-button-default-color': '#fff',
+              '--nutui-button-default-background-color':
+                'rgba(10,101,208,0.75)',
+            }}
+          >
             {translated['1076d771']}
           </Button>
           <Button
             type="primary"
-            color="linear-gradient(to right, #ff6034, #ee0a24)"
-            style={{ margin: 8 }}
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': 'transparent',
+              '--nutui-button-default-color': '#fff',
+              '--nutui-button-default-background-color':
+                'linear-gradient(to right, #ff6034, #ee0a24)',
+            }}
           >
             {translated['6ab47cd2']}
           </Button>

--- a/src/packages/button/demo.tsx
+++ b/src/packages/button/demo.tsx
@@ -452,19 +452,46 @@ const ButtonDemo = () => {
         <h2>{translated['781b07fd']}</h2>
 
         <Cell style={{ flexWrap: 'wrap' }}>
-          <Button color="blue" style={{ margin: 8 }}>
+          <Button
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': 'blue',
+              '--nutui-button-default-color': '#fff',
+              '--nutui-button-default-background-color': 'blue',
+            }}
+          >
             {translated['1076d771']}
           </Button>
-          <Button fill="outline" color="#7232dd" style={{ margin: 8 }}>
+          <Button
+            fill="outline"
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': '#7232dd',
+              '--nutui-button-default-color': '#7232dd',
+            }}
+          >
             {translated['1076d771']}
           </Button>
-          <Button color="rgba(10,101,208,0.75)" style={{ margin: 8 }}>
+          <Button
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': 'transparent',
+              '--nutui-button-default-color': '#fff',
+              '--nutui-button-default-background-color':
+                'rgba(10,101,208,0.75)',
+            }}
+          >
             {translated['1076d771']}
           </Button>
           <Button
             type="primary"
-            color="linear-gradient(to right, #ff6034, #ee0a24)"
-            style={{ margin: 8 }}
+            style={{
+              margin: 8,
+              '--nutui-button-default-border-color': 'transparent',
+              '--nutui-button-default-color': '#fff',
+              '--nutui-button-default-background-color':
+                'linear-gradient(to right, #ff6034, #ee0a24)',
+            }}
           >
             {translated['6ab47cd2']}
           </Button>

--- a/src/packages/button/doc.en-US.md
+++ b/src/packages/button/doc.en-US.md
@@ -270,10 +270,47 @@ import { Button } from '@nutui/nutui-react';
 const App = () => {
   return (
     <>
-      <Button color="#7232dd">Monochrome</Button>
-      <Button color="#7232dd" fill="outline">Monochrome</Button>
-      <Button color="rgba(10,101,208,0.75)">Monochrome</Button>
-      <Button color="linear-gradient(to right, #ff6034, #ee0a24)">
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'blue',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color': 'blue',
+        }}
+      >
+        Monochrome
+      </Button>
+      <Button
+        fill="outline"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': '#7232dd',
+          '--nutui-button-default-color': '#7232dd',
+        }}
+      >
+        Monochrome
+      </Button>
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'rgba(10,101,208,0.75)',
+        }}
+      >
+        Monochrome
+      </Button>
+      <Button
+        type="primary"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'linear-gradient(to right, #ff6034, #ee0a24)',
+        }}
+      >
         Gradient
       </Button>
     </>
@@ -293,7 +330,7 @@ export default App;
 | type | button style | `default` \| `primary` \| `warning` \| `danger` \| `success` \| `info` | `default` |
 | size | button size | `normal` \| `large` \| `small` | `normal` |
 | shape | button shape | `square` \| `round` | `round` | 
-| color | button color | `string` | `-` |
+| color | Button color, supports linear-gradient gradient color. In outline and dashed modes, color is set. In other cases, background is set. It is recommended to use color configuration implemented by CSS variables. | `string` | `-` |
 | fill | fill pattern | `solid` \| `outline`  \| `dashed` \| `none` | `solid` |
 | disabled | disable the button | `boolean` | `false` |
 | block | block element | `boolean` | `false` |

--- a/src/packages/button/doc.md
+++ b/src/packages/button/doc.md
@@ -395,10 +395,47 @@ import { Button } from '@nutui/nutui-react';
 const App = () => {
   return (
     <>
-      <Button color="#7232dd">单色按钮</Button>
-      <Button color="#7232dd" fill="outline">单色按钮</Button>
-      <Button color="rgba(10,101,208,0.75)">单色按钮</Button>
-      <Button color="linear-gradient(to right, #ff6034, #ee0a24)">
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'blue',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color': 'blue',
+        }}
+      >
+        单色按钮
+      </Button>
+      <Button
+        fill="outline"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': '#7232dd',
+          '--nutui-button-default-color': '#7232dd',
+        }}
+      >
+        单色按钮
+      </Button>
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'rgba(10,101,208,0.75)',
+        }}
+      >
+        单色按钮
+      </Button>
+      <Button
+        type="primary"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'linear-gradient(to right, #ff6034, #ee0a24)',
+        }}
+      >
         渐变色按钮
       </Button>
     </>
@@ -418,7 +455,7 @@ export default App;
 | type | 按钮的样式 | `default` \| `primary` \| `warning` \| `danger` \| `success` \| `info` | `default` |
 | size | 按钮的尺寸 | `normal` \| `large` \| `small` | `normal` |
 | shape | 按钮的形状 | `square` \| `round` | `round` |
-| color | 按钮颜色，支持传入 linear-gradient 渐变色 | `string` | `-` |
+| color | 按钮颜色，支持传入 linear-gradient 渐变色, outline 和 dashed 模式下设置的是 color，其他情况设置的是background，建议使用CSS变量实现的颜色配置 | `string` | `-` |
 | fill | 填充模式 | `solid` \| `outline` \| `dashed` \| `none` | `solid` |
 | disabled | 是否禁用按钮 | `boolean` | `false` |
 | block | 是否为块级元素 | `boolean` | `false` |

--- a/src/packages/button/doc.taro.md
+++ b/src/packages/button/doc.taro.md
@@ -416,10 +416,47 @@ import { Button } from '@nutui/nutui-react-taro';
 const App = () => { 
   return (
     <>
-      <Button color="#7232dd">单色按钮</Button>
-      <Button color="#7232dd" fill="outline">单色按钮</Button>
-      <Button color="rgba(10,101,208,0.75)">单色按钮</Button>
-      <Button color="linear-gradient(to right, #ff6034, #ee0a24)">
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'blue',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color': 'blue',
+        }}
+      >
+        单色按钮
+      </Button>
+      <Button
+        fill="outline"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': '#7232dd',
+          '--nutui-button-default-color': '#7232dd',
+        }}
+      >
+        单色按钮
+      </Button>
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'rgba(10,101,208,0.75)',
+        }}
+      >
+        单色按钮
+      </Button>
+      <Button
+        type="primary"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'linear-gradient(to right, #ff6034, #ee0a24)',
+        }}
+      >
         渐变色按钮
       </Button>
     </>
@@ -439,7 +476,7 @@ export default App;
 | type | 按钮的样式 | `default` \| `primary` \| `warning` \| `danger` \| `success` \| `info` | `default` |
 | size | 按钮的尺寸 | `normal` \| `large` \| `small` | `normal` |
 | shape | 按钮的形状 | `square` \| `round` | `round` |
-| color | 按钮颜色，支持传入 linear-gradient 渐变色 | `string` | `-` |
+| color | 按钮颜色，支持传入 linear-gradient 渐变色, outline 和 dashed 模式下设置的是 color，其他情况设置的是background，建议使用CSS变量实现的颜色配置 | `string` | `-` |
 | fill | 填充模式 | `solid` \| `outline`  \| `dashed` \| `none` | `solid` |
 | disabled | 是否禁用按钮 | `boolean` | `false` |
 | block | 是否为块级元素 | `boolean` | `false` |

--- a/src/packages/button/doc.zh-TW.md
+++ b/src/packages/button/doc.zh-TW.md
@@ -395,10 +395,47 @@ import { Button } from '@nutui/nutui-react';
 const App = () => {
   return (
     <>
-      <Button color="#7232dd">單色按鈕</Button>
-      <Button color="#7232dd" fill="outline">單色按鈕</Button>
-      <Button color="rgba(10,101,208,0.75)">單色按鈕</Button>
-      <Button color="linear-gradient(to right, #ff6034, #ee0a24)">
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'blue',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color': 'blue',
+        }}
+      >
+        單色按鈕
+      </Button>
+      <Button
+        fill="outline"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': '#7232dd',
+          '--nutui-button-default-color': '#7232dd',
+        }}
+      >
+        單色按鈕
+      </Button>
+      <Button
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'rgba(10,101,208,0.75)',
+        }}
+      >
+        單色按鈕
+      </Button>
+      <Button
+        type="primary"
+        style={{
+          margin: 8,
+          '--nutui-button-default-border-color': 'transparent',
+          '--nutui-button-default-color': '#fff',
+          '--nutui-button-default-background-color':
+            'linear-gradient(to right, #ff6034, #ee0a24)',
+        }}
+      >
         漸變色按鈕
       </Button>
     </>
@@ -418,7 +455,7 @@ export default App;
 | type | 按鈕的樣式 | `default` \| `primary` \| `warning` \| `danger` \| `success` \| `info` | `default` |
 | size | 按鈕的尺寸 | `normal` \| `large` \| `small` | `normal` |
 | shape | 按鈕的形狀 | `square` \| `round` | `round` |
-| color | 按鈕顏色，支持傳入 linear-gradient 漸變色 | `string` | `-` |
+| color | 按鈕顏色，支援傳入 linear-gradient 漸層色, outline 和 dashed 模式下設定的是 color，其他情況設定的是background，建議使用CSS變數實現的顏色配置 | `string` | `-` |
 | fill | 填充模式 | `solid` \| `outline` \| `dashed` \| `none` | `solid` |
 | disabled | 是否禁用按鈕 | `boolean` | `false` |
 | block | 是否為塊級元素 | `boolean` | `false` |


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？


- [x] 日常 bug 修复
- [x] 站点、文档改进
- [x] 演示代码改进

### 🔗 相关 Issue

按钮 color 属性的使用存在不明确的地方，在不同的按钮模式下设置color有可能表现异常，所以要更加准确的描述 color 的使用场景。

### 💡 需求背景和解决方案

1.更准确的描述 color 属性的使用场景或实现逻辑。
2.自定义颜色 demo 和文档更新为基于 css 变量的实现。
3.建议复杂配色使用 css 变量，而不是通过 color 使用，因为 color 属性无法处理文本和背景颜色相同的情况，如果处理此情况，还要增加 background 属性。所以建议逐渐废弃此属性。


