### PR TITLE
feat(checkbox): 增加至少选择项数量的设置功能

### DIFF
--- a/src/packages/checkbox/__test__/checkbox.spec.tsx
+++ b/src/packages/checkbox/__test__/checkbox.spec.tsx
@@ -40,7 +40,7 @@ test('should fireEvent correctly', () => {
   const handleChange = jest.fn((value) => {
     value
   })
-  const { getByTestId } = render(
+  const { getByTestId, container } = render(
     <CheckboxGroup
       data-testid="group"
       className="test"
@@ -49,7 +49,9 @@ test('should fireEvent correctly', () => {
       min={1}
       onChange={handleChange}
     >
-      <Checkbox value="1">组合复选框</Checkbox>
+      <Checkbox data-testid="checkbox1" value="1">
+        组合复选框
+      </Checkbox>
       <Checkbox value="2">组合复选框</Checkbox>
       <Checkbox data-testid="checkbox" value="3">
         组合复选框
@@ -64,6 +66,11 @@ test('should fireEvent correctly', () => {
   expect(handleChange).toBeCalledWith(['1', '3'])
 
   expect(getByTestId('group')).toHaveClass('test')
+
+  fireEvent.click(getByTestId('checkbox'))
+  fireEvent.click(getByTestId('checkbox1'))
+  const icons = container.querySelectorAll('.nut-checkbox-icon-checked')
+  expect(icons.length).toBe(1)
 })
 
 test('Render checkboxs by configuring options', () => {

--- a/src/packages/checkbox/__test__/checkbox.spec.tsx
+++ b/src/packages/checkbox/__test__/checkbox.spec.tsx
@@ -40,6 +40,7 @@ test('should fireEvent correctly', () => {
   const handleChange = jest.fn((value) => {
     value
   })
+  const limit = jest.fn()
   const { getByTestId, container } = render(
     <CheckboxGroup
       data-testid="group"
@@ -47,30 +48,42 @@ test('should fireEvent correctly', () => {
       defaultValue={['1']}
       max={3}
       min={1}
+      onLimit={limit}
       onChange={handleChange}
     >
       <Checkbox data-testid="checkbox1" value="1">
         组合复选框
       </Checkbox>
-      <Checkbox value="2">组合复选框</Checkbox>
-      <Checkbox data-testid="checkbox" value="3">
+      <Checkbox data-testid="checkbox2" value="2">
         组合复选框
       </Checkbox>
-      <Checkbox value="4">组合复选框</Checkbox>
+      <Checkbox data-testid="checkbox3" value="3">
+        组合复选框
+      </Checkbox>
+      <Checkbox data-testid="checkbox4" value="4">
+        组合复选框
+      </Checkbox>
     </CheckboxGroup>
   )
 
-  fireEvent.click(getByTestId('checkbox'))
+  fireEvent.click(getByTestId('checkbox3'))
 
   expect(handleChange).toBeCalled()
   expect(handleChange).toBeCalledWith(['1', '3'])
 
   expect(getByTestId('group')).toHaveClass('test')
 
-  fireEvent.click(getByTestId('checkbox'))
+  fireEvent.click(getByTestId('checkbox3'))
   fireEvent.click(getByTestId('checkbox1'))
   const icons = container.querySelectorAll('.nut-checkbox-icon-checked')
   expect(icons.length).toBe(1)
+  expect(limit).toBeCalledWith('min')
+
+  fireEvent.click(getByTestId('checkbox1'))
+  fireEvent.click(getByTestId('checkbox2'))
+  fireEvent.click(getByTestId('checkbox3'))
+  fireEvent.click(getByTestId('checkbox4'))
+  expect(limit).toBeCalledWith('max')
 })
 
 test('Render checkboxs by configuring options', () => {

--- a/src/packages/checkbox/__test__/checkbox.spec.tsx
+++ b/src/packages/checkbox/__test__/checkbox.spec.tsx
@@ -45,6 +45,8 @@ test('should fireEvent correctly', () => {
       data-testid="group"
       className="test"
       defaultValue={['1']}
+      max={3}
+      min={1}
       onChange={handleChange}
     >
       <Checkbox value="1">组合复选框</Checkbox>

--- a/src/packages/checkbox/checkbox.taro.tsx
+++ b/src/packages/checkbox/checkbox.taro.tsx
@@ -11,6 +11,7 @@ import CheckboxGroup from '@/packages/checkboxgroup/index.taro'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import Context from '../checkboxgroup/context'
 import { usePropsValue } from '@/utils/use-props-value'
+import { CheckboxLabelPosition } from '@/packages/checkboxgroup/types'
 
 export type CheckboxShape = 'button' | 'round'
 
@@ -19,7 +20,7 @@ export interface CheckboxProps extends BasicComponent {
   disabled: boolean
   defaultChecked: boolean
   shape: CheckboxShape
-  labelPosition: 'left' | 'right'
+  labelPosition: CheckboxLabelPosition
   icon: ReactNode
   activeIcon: ReactNode
   indeterminateIcon: ReactNode
@@ -164,7 +165,9 @@ export const Checkbox: FunctionComponent<
     const latestChecked = !innerChecked
     // 判断是不是有 context 和 max，有的话需要判断是不是超过最大限制
     if (ctx && ctx.max !== undefined) {
-      if (latestChecked && ctx.value.length >= ctx.max) return
+      if (latestChecked && ctx.value.length >= ctx.max) {
+        return ctx.onLimit?.('max')
+      }
     }
     setChecked(latestChecked)
   }

--- a/src/packages/checkbox/checkbox.taro.tsx
+++ b/src/packages/checkbox/checkbox.taro.tsx
@@ -163,12 +163,7 @@ export const Checkbox: FunctionComponent<
     if (disabled) return
     // 先转换状态
     const latestChecked = !innerChecked
-    // 判断是不是有 context 和 max，有的话需要判断是不是超过最大限制
-    if (ctx && ctx.max !== undefined) {
-      if (latestChecked && ctx.value.length >= ctx.max) {
-        return ctx.onLimit?.('max')
-      }
-    }
+
     setChecked(latestChecked)
   }
 

--- a/src/packages/checkbox/checkbox.taro.tsx
+++ b/src/packages/checkbox/checkbox.taro.tsx
@@ -1,5 +1,6 @@
 import React, {
   FunctionComponent,
+  ReactNode,
   useContext,
   useEffect,
   useState,
@@ -19,12 +20,12 @@ export interface CheckboxProps extends BasicComponent {
   defaultChecked: boolean
   shape: CheckboxShape
   labelPosition: 'left' | 'right'
-  icon: React.ReactNode
-  activeIcon: React.ReactNode
-  indeterminateIcon: React.ReactNode
+  icon: ReactNode
+  activeIcon: ReactNode
+  indeterminateIcon: ReactNode
   value: string | number
   indeterminate: boolean
-  label: string | number
+  label: ReactNode
   onChange: (value: boolean) => void
 }
 

--- a/src/packages/checkbox/checkbox.tsx
+++ b/src/packages/checkbox/checkbox.tsx
@@ -166,12 +166,7 @@ export const Checkbox: FunctionComponent<
     if (disabled) return
     // 先转换状态
     const latestChecked = !innerChecked
-    // 判断是不是有 context 和 max，有的话需要判断是不是超过最大限制
-    if (ctx && ctx.max !== undefined) {
-      if (latestChecked && ctx.value.length >= ctx.max) {
-        return ctx.onLimit?.('max')
-      }
-    }
+
     setChecked(latestChecked)
   }
 

--- a/src/packages/checkbox/checkbox.tsx
+++ b/src/packages/checkbox/checkbox.tsx
@@ -11,6 +11,7 @@ import CheckboxGroup from '@/packages/checkboxgroup'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import Context from '../checkboxgroup/context'
 import { usePropsValue } from '@/utils/use-props-value'
+import { CheckboxLabelPosition } from '@/packages/checkboxgroup/types'
 
 export type CheckboxShape = 'button' | 'round'
 
@@ -19,7 +20,7 @@ export interface CheckboxProps extends BasicComponent {
   disabled: boolean
   defaultChecked: boolean
   shape: CheckboxShape
-  labelPosition: 'left' | 'right'
+  labelPosition: CheckboxLabelPosition
   icon: ReactNode
   activeIcon: ReactNode
   indeterminateIcon: ReactNode
@@ -167,7 +168,9 @@ export const Checkbox: FunctionComponent<
     const latestChecked = !innerChecked
     // 判断是不是有 context 和 max，有的话需要判断是不是超过最大限制
     if (ctx && ctx.max !== undefined) {
-      if (latestChecked && ctx.value.length >= ctx.max) return
+      if (latestChecked && ctx.value.length >= ctx.max) {
+        return ctx.onLimit?.('max')
+      }
     }
     setChecked(latestChecked)
   }

--- a/src/packages/checkbox/checkbox.tsx
+++ b/src/packages/checkbox/checkbox.tsx
@@ -1,5 +1,6 @@
 import React, {
   FunctionComponent,
+  ReactNode,
   useContext,
   useEffect,
   useState,
@@ -19,12 +20,12 @@ export interface CheckboxProps extends BasicComponent {
   defaultChecked: boolean
   shape: CheckboxShape
   labelPosition: 'left' | 'right'
-  icon: React.ReactNode
-  activeIcon: React.ReactNode
-  indeterminateIcon: React.ReactNode
+  icon: ReactNode
+  activeIcon: ReactNode
+  indeterminateIcon: ReactNode
   value: string | number
   indeterminate: boolean
-  label: string | number
+  label: ReactNode
   onChange: (value: boolean) => void
 }
 

--- a/src/packages/checkbox/demo.taro.tsx
+++ b/src/packages/checkbox/demo.taro.tsx
@@ -59,7 +59,7 @@ const CheckboxDemo = () => {
       cancelSelection: '取消全选',
       reverse: '反选',
       options: '配置 options 渲染复选按钮',
-      max: 'checkboxGroup使用，限制最大可选数（2个）',
+      max: 'checkboxGroup使用，限制最大可选数（3个）, 至少选择数（1个）',
       threeState: '全选/半选/取消',
     },
     'zh-TW': {
@@ -86,7 +86,7 @@ const CheckboxDemo = () => {
       cancelSelection: '取消全選',
       reverse: '反選',
       options: '配置 options 渲染複選按鈕',
-      max: 'checkboxGroup使用，限制最大可选数（2个）',
+      max: 'checkboxGroup使用，限制最大可选数（2个）, 至少选择数（1个）',
       threeState: '全选/半选/取消',
     },
     'en-US': {
@@ -113,7 +113,7 @@ const CheckboxDemo = () => {
       reverse: 'reverse',
       cancelSelection: 'Cancel All Selection',
       options: 'Render radios by configuring options',
-      max: 'Used by checkboxGroup, limit the maximum number of options (2)',
+      max: 'Used by checkboxGroup, limit the maximum number of options (2), minimum number of options (1)',
       threeState: 'Select All/Half/Cancel',
     },
   })
@@ -457,7 +457,8 @@ const CheckboxDemo = () => {
         <Cell>
           <Checkbox.Group
             defaultValue={checkboxgroup3}
-            max={2}
+            max={3}
+            min={1}
             onChange={(value) => {
               Taro.showToast({
                 title: value.toString(),

--- a/src/packages/checkbox/demo.taro.tsx
+++ b/src/packages/checkbox/demo.taro.tsx
@@ -24,6 +24,7 @@ interface T {
   reverse: string
   selected: string
   options1: string
+  description: string
   Disabled: string
   selectAndCancel: string
   selectAll: string
@@ -53,6 +54,7 @@ const CheckboxDemo = () => {
       cancel: '取消',
       selected: '选中',
       options1: '选项',
+      description: '描述信息',
       Disabled: '禁用',
       selectAndCancel: '全选和取消',
       selectAll: '全选',
@@ -80,6 +82,7 @@ const CheckboxDemo = () => {
       cancel: '取消',
       selected: '您選取了x',
       options1: '選項',
+      description: '描述信息',
       Disabled: '禁用',
       selectAndCancel: '全選和取消',
       selectAll: '全選',
@@ -107,6 +110,7 @@ const CheckboxDemo = () => {
       cancel: 'Cancel',
       selected: 'You selected x',
       options1: 'Options',
+      description: 'Description',
       Disabled: 'Disabled',
       selectAndCancel: 'All Select and Cancel',
       selectAll: 'Select All',
@@ -164,7 +168,18 @@ const CheckboxDemo = () => {
             style={{ marginRight: '8px' }}
             shape="button"
             className="test"
-            label={translated.checkbox}
+            label={
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div>{translated.checkbox}</div>
+                <div style={{ color: 'gray' }}>{translated.description}</div>
+              </div>
+            }
             defaultChecked={!checked}
           />
           <Checkbox
@@ -174,14 +189,36 @@ const CheckboxDemo = () => {
               <Checklist className="nut-checkbox-button-icon-checked" />
             }
             className="test"
-            label={translated.checkbox}
+            label={
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div>{translated.checkbox}</div>
+                <div style={{ color: 'gray' }}>{translated.description}</div>
+              </div>
+            }
             defaultChecked={checked}
           />
           <Checkbox
             shape="button"
             className="test"
             disabled
-            label={translated.checkbox}
+            label={
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div>{translated.checkbox}</div>
+                <div>{translated.description}</div>
+              </div>
+            }
             defaultChecked={checked}
           />
         </Cell>

--- a/src/packages/checkbox/demo.taro.tsx
+++ b/src/packages/checkbox/demo.taro.tsx
@@ -496,9 +496,9 @@ const CheckboxDemo = () => {
             defaultValue={checkboxgroup3}
             max={3}
             min={1}
-            onChange={(value) => {
+            onLimit={(type) => {
               Taro.showToast({
-                title: value.toString(),
+                title: type === 'max' ? '最多选择3项' : '至少选择1项',
                 icon: 'none',
               })
             }}

--- a/src/packages/checkbox/demo.tsx
+++ b/src/packages/checkbox/demo.tsx
@@ -25,6 +25,7 @@ interface T {
   reverse: string
   selected: string
   options1: string
+  description: string
   Disabled: string
   selectAndCancel: string
   selectAll: string
@@ -54,6 +55,7 @@ const CheckboxDemo = () => {
       cancel: '取消',
       selected: '选中',
       options1: '选项',
+      description: '描述信息',
       Disabled: '禁用',
       selectAndCancel: '全选和取消',
       selectAll: '全选',
@@ -81,6 +83,7 @@ const CheckboxDemo = () => {
       cancel: '取消',
       selected: '您選取了x',
       options1: '選項',
+      description: '描述信息',
       Disabled: '禁用',
       selectAndCancel: '全選和取消',
       selectAll: '全選',
@@ -108,6 +111,7 @@ const CheckboxDemo = () => {
       cancel: 'Cancel',
       selected: 'You selected x',
       options1: 'Options',
+      description: 'Description',
       Disabled: 'Disabled',
       selectAndCancel: 'All Select and Cancel',
       selectAll: 'Select All',
@@ -164,7 +168,18 @@ const CheckboxDemo = () => {
             style={{ marginRight: '8px' }}
             shape="button"
             className="test"
-            label={translated.checkbox}
+            label={
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div>{translated.checkbox}</div>
+                <div style={{ color: 'gray' }}>{translated.description}</div>
+              </div>
+            }
             defaultChecked={!checked}
           />
           <Checkbox
@@ -174,14 +189,36 @@ const CheckboxDemo = () => {
               <Checklist className="nut-checkbox-button-icon-checked" />
             }
             className="test"
-            label={translated.checkbox}
+            label={
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div>{translated.checkbox}</div>
+                <div style={{ color: 'gray' }}>{translated.description}</div>
+              </div>
+            }
             defaultChecked={checked}
           />
           <Checkbox
             shape="button"
             className="test"
             disabled
-            label={translated.checkbox}
+            label={
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div>{translated.checkbox}</div>
+                <div>{translated.description}</div>
+              </div>
+            }
             defaultChecked={checked}
           />
         </Cell>

--- a/src/packages/checkbox/demo.tsx
+++ b/src/packages/checkbox/demo.tsx
@@ -60,7 +60,7 @@ const CheckboxDemo = () => {
       cancelSelection: '取消全选',
       reverse: '反选',
       options: '配置 options 渲染复选按钮',
-      max: 'checkboxGroup使用，限制最大可选数（2个）',
+      max: 'checkboxGroup使用，限制最大可选数（3个）, 至少选择数（1个）',
       threeState: '全选/半选/取消',
     },
     'zh-TW': {
@@ -87,7 +87,7 @@ const CheckboxDemo = () => {
       cancelSelection: '取消全選',
       reverse: '反選',
       options: '配置 options 渲染複選按鈕',
-      max: 'checkboxGroup使用，限制最大可选数（2个）',
+      max: 'checkboxGroup使用，限制最大可选数（2个）, 至少选择数（1个）',
       threeState: '全选/半选/取消',
     },
     'en-US': {
@@ -114,7 +114,7 @@ const CheckboxDemo = () => {
       reverse: 'reverse',
       cancelSelection: 'Cancel All Selection',
       options: 'Render radios by configuring options',
-      max: 'Used by checkboxGroup, limit the maximum number of options (2)',
+      max: 'Used by checkboxGroup, limit the maximum number of options (2), minimum number of options (1)',
       threeState: 'Select All/Half/Cancel',
     },
   })
@@ -441,7 +441,7 @@ const CheckboxDemo = () => {
         </Cell>
         <h2>{translated.max}</h2>
         <Cell>
-          <Checkbox.Group defaultValue={checkboxgroup3} max={2}>
+          <Checkbox.Group defaultValue={checkboxgroup3} max={3} min={1}>
             <Checkbox value="1">{translated.options1}</Checkbox>
             <Checkbox value="2">{translated.options1}</Checkbox>
             <Checkbox value="3">{translated.options1}</Checkbox>

--- a/src/packages/checkbox/demo.tsx
+++ b/src/packages/checkbox/demo.tsx
@@ -478,7 +478,14 @@ const CheckboxDemo = () => {
         </Cell>
         <h2>{translated.max}</h2>
         <Cell>
-          <Checkbox.Group defaultValue={checkboxgroup3} max={3} min={1}>
+          <Checkbox.Group
+            defaultValue={checkboxgroup3}
+            max={3}
+            min={1}
+            onLimit={(type) =>
+              Toast.show(type === 'max' ? '最多选择3项' : '至少选择1项')
+            }
+          >
             <Checkbox value="1">{translated.options1}</Checkbox>
             <Checkbox value="2">{translated.options1}</Checkbox>
             <Checkbox value="3">{translated.options1}</Checkbox>

--- a/src/packages/checkbox/doc.en-US.md
+++ b/src/packages/checkbox/doc.en-US.md
@@ -35,13 +35,35 @@ const CheckBoxDemo = () => {
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='Option'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>Option</div>
+            <div style={{ color: 'gray' }}>Description</div>
+          </div>
+        }
         defaultChecked
       />
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='Option'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>Option</div>
+            <div style={{ color: 'gray' }}>Description</div>
+          </div>
+        }
         activeIcon={
           <Checklist className="nut-checkbox-button-icon-checked" />
         }
@@ -51,7 +73,18 @@ const CheckBoxDemo = () => {
         style={{ marginRight: '8px' }}
         shape='button'
         className='test'
-        label='Option'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>Option</div>
+            <div style={{ color: 'gray' }}>Description</div>
+          </div>
+        }
         defaultChecked={false}
       />
     </Cell>

--- a/src/packages/checkbox/doc.en-US.md
+++ b/src/packages/checkbox/doc.en-US.md
@@ -426,9 +426,9 @@ const CheckBoxDemo = () => {
       defaultValue={checkboxgroup2}
       max={3}
       min={1}
-      onChange={(value) => {
-        Toast.show(value)
-      }}
+      onLimit={(type) =>
+        Toast.show(type === 'max' ? 'Choose up to 3 items' : 'Select at least 1 item')
+      }
     >
       <Checkbox value="1">
         Option 1

--- a/src/packages/checkbox/doc.en-US.md
+++ b/src/packages/checkbox/doc.en-US.md
@@ -377,7 +377,7 @@ export default CheckBoxDemo;
 
 :::
 
-## Used by checkboxGroup, limit the maximum number of options (2)
+## Used by checkboxGroup, limit the maximum number of options (2), minimum number of options (1)
 
 :::demo
 
@@ -391,7 +391,8 @@ const CheckBoxDemo = () => {
   return (<>
     <Checkbox.Group
       defaultValue={checkboxgroup2}
-      max={2}
+      max={3}
+      min={1}
       onChange={(value) => {
         Toast.show(value)
       }}
@@ -544,6 +545,7 @@ export default CheckboxGroupOptions;
 | defaultValue | Identifier of the initially selected item | `string` \| `number` | `-` |
 | disabled | Whether to disable selection, will be used for all checkboxes under it | `boolean` | `false` |
 | max | limit the maximum number of options | `number` | `-` |
+| min | Limit the number of choices to at least | `number` | `-` |
 | labelPosition | The position of the text | `left` \| `right` | `right` |
 | direction | Use horizontal and vertical directions Optional values horizontal、vertical | `string` | `vertical` |
 | options | Configure options to render check buttons | `Array<{ label: string value: string disabled?: boolean }>` | `-` |

--- a/src/packages/checkbox/doc.md
+++ b/src/packages/checkbox/doc.md
@@ -428,9 +428,9 @@ const CheckBoxDemo = () => {
       defaultValue={checkboxgroup2}
       max={3}
       min={1}
-      onChange={(value) => {
-        Toast.show(value)
-      }}
+      onLimit={(type) =>
+        Toast.show(type === 'max' ? '最多选择3项' : '至少选择1项')
+      }
     >
       <Checkbox value="1">
         组合复选框

--- a/src/packages/checkbox/doc.md
+++ b/src/packages/checkbox/doc.md
@@ -35,13 +35,35 @@ const CheckBoxDemo = () => {
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         defaultChecked
       />
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         activeIcon={
           <Checklist className="nut-checkbox-button-icon-checked" />
         }
@@ -51,7 +73,18 @@ const CheckBoxDemo = () => {
         style={{ marginRight: '8px' }}
         shape='button'
         className='test'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         defaultChecked={false}
       />
     </Cell>

--- a/src/packages/checkbox/doc.md
+++ b/src/packages/checkbox/doc.md
@@ -379,7 +379,7 @@ export default CheckBoxDemo;
 
 :::
 
-## checkboxGroup使用，限制最大可选数（2个）
+## checkboxGroup使用，限制最大可选数（3个）, 至少选择数（1个）
 
 :::demo
 
@@ -393,7 +393,8 @@ const CheckBoxDemo = () => {
   return (<>
     <Checkbox.Group
       defaultValue={checkboxgroup2}
-      max={2}
+      max={3}
+      min={1}
       onChange={(value) => {
         Toast.show(value)
       }}
@@ -546,6 +547,7 @@ export default CheckboxGroupOptions;
 | defaultValue | 初始选中项的标识符 | `string` \| `number` | `-` |
 | disabled | 是否禁用选择,将用于其下的全部复选框 | `boolean` | `false` |
 | max | 限制最大可选数 | `number` |  `-` |
+| min | 限制至少选择数 | `number` |  `-` |
 | labelPosition | 文本所在的位置 | `left` \| `right` | `right` |
 | direction | 使用横纵方向 可选值 horizontal、vertical | `string` | `vertical` |
 | options | 配置 options 渲染复选按钮 | `Array<{ label: string value: string disabled?: boolean }>` | `-` |

--- a/src/packages/checkbox/doc.taro.md
+++ b/src/packages/checkbox/doc.taro.md
@@ -35,13 +35,35 @@ const CheckBoxDemo = () => {
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         defaultChecked
       />
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         activeIcon={
           <Checklist className="nut-checkbox-button-icon-checked" />
         }
@@ -51,7 +73,18 @@ const CheckBoxDemo = () => {
         style={{ marginRight: '8px' }}
         shape='button'
         className='test'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         defaultChecked={false}
       />
     </Cell>

--- a/src/packages/checkbox/doc.taro.md
+++ b/src/packages/checkbox/doc.taro.md
@@ -379,7 +379,7 @@ export default CheckBoxDemo;
 
 :::
 
-## checkboxGroup使用，限制最大可选数（2个）
+## checkboxGroup使用，限制最大可选数（3个）, 至少选择数（1个）
 
 :::demo
 
@@ -393,7 +393,8 @@ const CheckBoxDemo = () => {
   return (<>
     <Checkbox.Group
       defaultValue={checkboxgroup2}
-      max={2}
+      max={3}
+      min={1}
       onChange={(value) => {
         Toast.show(value)
       }}
@@ -527,7 +528,7 @@ export default CheckboxGroupOptions;
 | checked | 是否选中 | `boolean` | `false` |
 | defaultChecked | 初始是否选中 | `boolean` | `false` |
 | disabled | 是否禁用选择 | `boolean` | `false` |
-| labelPosition | 文本所在的位置| `left` \| `right` | `string` | `right` |
+| labelPosition | 文本所在的位置 | `left` \| `right` | `right` |
 | icon | 选中前| `ReactNode` | `'CheckNormal'` |
 | activeIcon | 选中后 | `ReactNode` | `'Checked'` |
 | indeterminateIcon | 半选状态| `ReactNode` | `'CheckDisabled'` |
@@ -546,12 +547,13 @@ export default CheckboxGroupOptions;
 | defaultValue | 初始选中项的标识符 | `string` \| `number` | `-` |
 | disabled | 是否禁用选择,将用于其下的全部复选框 | `boolean` | `false` |
 | max | 限制最大可选数 | `number` |  `-` |
-| labelPosition | 文本所在的位置| `left` \| `right` | `string` | `right` |
+| min | 限制至少选择数 | `number` |  `-` |
+| labelPosition | 文本所在的位置 | `left` \| `right` | `right` |
 | direction | 使用横纵方向 可选值 horizontal、vertical | `string` | `vertical` |
-| options | 配置 options 渲染复选按钮 | `Array<{ label: string value: string disabled?: boolean }>`  | `-` |
+| options | 配置 options 渲染复选按钮 | `Array<{ label: string value: string disabled?: boolean }>` | `-` |
 | onChange | 值变化时触发 | `(value: string[]) => void` | `-` |
 
-### Checkbox.Group Ref
+### Ref
 
 | 方法名 | 说明 | 参数 |
 | --- | --- | --- |

--- a/src/packages/checkbox/doc.zh-TW.md
+++ b/src/packages/checkbox/doc.zh-TW.md
@@ -428,9 +428,9 @@ const CheckBoxDemo = () => {
       defaultValue={checkboxgroup2}
       max={3}
       min={1}
-      onChange={(value) => {
-        Toast.show(value)
-      }}
+      onLimit={(type) =>
+        Toast.show(type === 'max' ? '最多選擇3項' : '至少選擇1項')
+      }
     >
       <Checkbox value="1">
         组合复选框

--- a/src/packages/checkbox/doc.zh-TW.md
+++ b/src/packages/checkbox/doc.zh-TW.md
@@ -35,13 +35,35 @@ const CheckBoxDemo = () => {
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         defaultChecked
       />
       <Checkbox
         style={{ marginRight: '8px' }}
         shape='button'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         activeIcon={
           <Checklist className="nut-checkbox-button-icon-checked" />
         }
@@ -51,7 +73,18 @@ const CheckBoxDemo = () => {
         style={{ marginRight: '8px' }}
         shape='button'
         className='test'
-        label='复选框'
+        label={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <div>复选框</div>
+            <div style={{ color: 'gray' }}>描述信息</div>
+          </div>
+        }
         defaultChecked={false}
       />
     </Cell>

--- a/src/packages/checkbox/doc.zh-TW.md
+++ b/src/packages/checkbox/doc.zh-TW.md
@@ -379,7 +379,7 @@ export default CheckBoxDemo;
 
 :::
 
-## checkboxGroup使用，限制最大可选数（2个）
+## checkboxGroup使用，限制最大可选数（3个）, 至少选择数（1个）
 
 :::demo
 
@@ -393,7 +393,8 @@ const CheckBoxDemo = () => {
   return (<>
     <Checkbox.Group
       defaultValue={checkboxgroup2}
-      max={2}
+      max={3}
+      min={1}
       onChange={(value) => {
         Toast.show(value)
       }}
@@ -546,6 +547,7 @@ export default CheckboxGroupOptions;
 | defaultValue | 初始选中项的标识符 | `string` \| `number` | `-` |
 | disabled | 是否禁用选择,将用于其下的全部复选框 | `boolean` | `false` |
 | max | 限制最大可选数 | `number` |  `-` |
+| min | 限制至少选择数 | `number` |  `-` |
 | labelPosition | 文本所在的位置| `left` \| `right` | `string` | `right` |
 | direction | 使用横纵方向 可选值 horizontal、vertical | `string` | `vertical` |
 | options | 配置 options 渲染复选按钮 | `Array<{ label: string value: string disabled?: boolean }>`  | `-` |

--- a/src/packages/checkboxgroup/checkboxgroup.taro.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.taro.tsx
@@ -4,27 +4,32 @@ import { RadioGroupOptionType } from '@/packages/radiogroup/types'
 import { Checkbox } from '../checkbox/checkbox.taro'
 import Context from './context'
 import { usePropsValue } from '@/utils/use-props-value'
-
-export type CheckboxLabelPosition = 'left' | 'right'
-export type CheckboxDirection = 'horizontal' | 'vertical'
+import {
+  CheckboxDirection,
+  CheckboxLabelPosition,
+  CheckboxLimit,
+} from '@/packages/checkboxgroup/types'
 
 export interface CheckboxGroupProps {
   disabled?: boolean
   value?: string[]
   defaultValue?: string[]
   max: number | undefined
-  min?: number | undefined
+  min: number | undefined
   labelPosition: CheckboxLabelPosition
   direction: CheckboxDirection
   options: RadioGroupOptionType[]
   onChange: (value: string[]) => void
+  onLimit: (type: CheckboxLimit) => void
 }
 
 const defaultProps = {
   max: undefined,
+  min: undefined,
   labelPosition: 'right',
   direction: 'vertical',
   onChange: (value: string[]) => {},
+  onLimit: (type: 'max' | 'min') => {},
   options: [],
 } as CheckboxGroupProps
 
@@ -35,8 +40,8 @@ export const CheckboxGroup = React.forwardRef(
       Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
     ref
   ) => {
-    const { children } = { ...defaultProps, ...props }
     const {
+      children,
       className,
       disabled,
       onChange,
@@ -44,11 +49,12 @@ export const CheckboxGroup = React.forwardRef(
       defaultValue,
       max,
       min,
+      onLimit,
       labelPosition,
       direction,
       options,
       ...rest
-    } = props
+    } = { ...defaultProps, ...props }
 
     useImperativeHandle<any, any>(ref, () => ({
       toggle(state: boolean) {
@@ -103,6 +109,7 @@ export const CheckboxGroup = React.forwardRef(
           labelPosition: labelPosition || 'right',
           disabled,
           max,
+          onLimit,
           value: _value,
           check: (value: string) => {
             const combined: string[] = [..._value, value]
@@ -110,7 +117,9 @@ export const CheckboxGroup = React.forwardRef(
           },
           uncheck: (value: string) => {
             const reduced = _value.filter((item) => item !== value)
-            if (min !== undefined && reduced.length < min) return
+            if (min !== undefined && reduced.length < min) {
+              return onLimit?.('min')
+            }
             setValue(reduced)
           },
         }}

--- a/src/packages/checkboxgroup/checkboxgroup.taro.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.taro.tsx
@@ -113,6 +113,11 @@ export const CheckboxGroup = React.forwardRef(
           value: _value,
           check: (value: string) => {
             const combined: string[] = [..._value, value]
+            if (max !== undefined) {
+              if (combined.length > max) {
+                return onLimit?.('max')
+              }
+            }
             setValue(combined)
           },
           uncheck: (value: string) => {

--- a/src/packages/checkboxgroup/checkboxgroup.taro.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.taro.tsx
@@ -13,6 +13,7 @@ export interface CheckboxGroupProps {
   value?: string[]
   defaultValue?: string[]
   max: number | undefined
+  min?: number | undefined
   labelPosition: CheckboxLabelPosition
   direction: CheckboxDirection
   options: RadioGroupOptionType[]
@@ -42,6 +43,7 @@ export const CheckboxGroup = React.forwardRef(
       value,
       defaultValue,
       max,
+      min,
       labelPosition,
       direction,
       options,
@@ -93,7 +95,7 @@ export const CheckboxGroup = React.forwardRef(
           />
         )
       })
-    }, [options, max])
+    }, [options, max, min])
 
     return (
       <Context.Provider
@@ -108,6 +110,7 @@ export const CheckboxGroup = React.forwardRef(
           },
           uncheck: (value: string) => {
             const reduced = _value.filter((item) => item !== value)
+            if (min !== undefined && reduced.length < min) return
             setValue(reduced)
           },
         }}

--- a/src/packages/checkboxgroup/checkboxgroup.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.tsx
@@ -4,27 +4,32 @@ import { RadioGroupOptionType } from '@/packages/radiogroup/types'
 import { Checkbox } from '../checkbox/checkbox'
 import Context from './context'
 import { usePropsValue } from '@/utils/use-props-value'
-
-export type CheckboxLabelPosition = 'left' | 'right'
-export type CheckboxDirection = 'horizontal' | 'vertical'
+import {
+  CheckboxDirection,
+  CheckboxLabelPosition,
+  CheckboxLimit,
+} from '@/packages/checkboxgroup/types'
 
 export interface CheckboxGroupProps {
   disabled?: boolean
   value?: string[]
   defaultValue?: string[]
   max: number | undefined
-  min?: number | undefined
+  min: number | undefined
   labelPosition: CheckboxLabelPosition
   direction: CheckboxDirection
   options: RadioGroupOptionType[]
   onChange: (value: string[]) => void
+  onLimit: (type: CheckboxLimit) => void
 }
 
 const defaultProps = {
   max: undefined,
+  min: undefined,
   labelPosition: 'right',
   direction: 'vertical',
   onChange: (value: string[]) => {},
+  onLimit: (type: 'max' | 'min') => {},
   options: [],
 } as CheckboxGroupProps
 
@@ -35,8 +40,8 @@ export const CheckboxGroup = React.forwardRef(
       Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
     ref
   ) => {
-    const { children } = { ...defaultProps, ...props }
     const {
+      children,
       className,
       disabled,
       onChange,
@@ -44,11 +49,12 @@ export const CheckboxGroup = React.forwardRef(
       defaultValue,
       max,
       min,
+      onLimit,
       labelPosition,
       direction,
       options,
       ...rest
-    } = props
+    } = { ...defaultProps, ...props }
 
     useImperativeHandle<any, any>(ref, () => ({
       toggle(state: boolean) {
@@ -103,6 +109,7 @@ export const CheckboxGroup = React.forwardRef(
           labelPosition: labelPosition || 'right',
           disabled,
           max,
+          onLimit,
           value: _value,
           check: (value: string) => {
             const combined: string[] = [..._value, value]
@@ -110,7 +117,9 @@ export const CheckboxGroup = React.forwardRef(
           },
           uncheck: (value: string) => {
             const reduced = _value.filter((item) => item !== value)
-            if (min !== undefined && reduced.length < min) return
+            if (min !== undefined && reduced.length < min) {
+              return onLimit?.('min')
+            }
             setValue(reduced)
           },
         }}

--- a/src/packages/checkboxgroup/checkboxgroup.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.tsx
@@ -113,6 +113,11 @@ export const CheckboxGroup = React.forwardRef(
           value: _value,
           check: (value: string) => {
             const combined: string[] = [..._value, value]
+            if (max !== undefined) {
+              if (combined.length > max) {
+                return onLimit?.('max')
+              }
+            }
             setValue(combined)
           },
           uncheck: (value: string) => {

--- a/src/packages/checkboxgroup/checkboxgroup.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.tsx
@@ -13,6 +13,7 @@ export interface CheckboxGroupProps {
   value?: string[]
   defaultValue?: string[]
   max: number | undefined
+  min?: number | undefined
   labelPosition: CheckboxLabelPosition
   direction: CheckboxDirection
   options: RadioGroupOptionType[]
@@ -42,6 +43,7 @@ export const CheckboxGroup = React.forwardRef(
       value,
       defaultValue,
       max,
+      min,
       labelPosition,
       direction,
       options,
@@ -93,7 +95,7 @@ export const CheckboxGroup = React.forwardRef(
           />
         )
       })
-    }, [options, max])
+    }, [options, max, min])
 
     return (
       <Context.Provider
@@ -108,6 +110,7 @@ export const CheckboxGroup = React.forwardRef(
           },
           uncheck: (value: string) => {
             const reduced = _value.filter((item) => item !== value)
+            if (min !== undefined && reduced.length < min) return
             setValue(reduced)
           },
         }}

--- a/src/packages/checkboxgroup/context.ts
+++ b/src/packages/checkboxgroup/context.ts
@@ -1,12 +1,14 @@
 import { createContext } from 'react'
+import { CheckboxLimit, CheckboxLabelPosition } from './types'
 
 const CheckboxGroupContext = createContext<{
-  labelPosition: 'left' | 'right'
+  labelPosition: CheckboxLabelPosition
   disabled: boolean | undefined
   value: string[]
   max: number | undefined
   check: (value: string) => void
   uncheck: (value: string) => void
+  onLimit: (type: CheckboxLimit) => void
 } | null>(null)
 
 export default CheckboxGroupContext

--- a/src/packages/checkboxgroup/types.ts
+++ b/src/packages/checkboxgroup/types.ts
@@ -4,3 +4,6 @@ export interface CheckboxGroupOptionType {
   disabled?: boolean
   onChange?: (state: boolean, label: string) => void
 }
+export type CheckboxLimit = 'max' | 'min'
+export type CheckboxLabelPosition = 'left' | 'right'
+export type CheckboxDirection = 'horizontal' | 'vertical'


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

增加 和 max 属性对应的 min 属性，用于限制必须选择的项数量，例如 min=1 ，则至少选择 1 项


