### PR TITLE
fix(popover): 置于滚动容器中，popover 需要跟随滚动，修复选中项的样式

### DIFF
--- a/src/packages/popover/__tests__/popover.spec.tsx
+++ b/src/packages/popover/__tests__/popover.spec.tsx
@@ -120,6 +120,37 @@ test('render popover position33', async () => {
   expect(content).toHaveAttribute('style', 'top: calc(50% - 20px);')
 })
 
+test('render position fixed ', async () => {
+  const { container } = render(
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 10,
+        right: -10,
+        zIndex: 1000,
+      }}
+    >
+      <Popover
+        className="demo-popover"
+        visible
+        list={itemList}
+        location="top"
+        offset={[12, 20]}
+        style={{ marginRight: '30px' }}
+      >
+        <Button data-testid="a" type="primary" shape="square">
+          position: fixed
+        </Button>
+      </Popover>
+    </div>
+  )
+  const content = document.querySelectorAll(
+    '.nut-popover-arrow'
+  )[0] as HTMLElement
+  fireEvent.click(document.documentElement)
+  expect(content).toBeTruthy()
+})
+
 test('should emit onchoose event when clicking the action', async () => {
   const choose = jest.fn()
   const { container } = render(

--- a/src/packages/popover/__tests__/popover.spec.tsx
+++ b/src/packages/popover/__tests__/popover.spec.tsx
@@ -44,7 +44,7 @@ test('render popover content', async () => {
       </Button>
     </Popover>
   )
-  const content = container.querySelectorAll('.nut-popover-content')[0]
+  const content = document.querySelectorAll('.nut-popover-content')[0]
   expect(content.className).toContain(
     'nut-popup-default nut-popover-content nut-popover-content-bottom'
   )
@@ -58,7 +58,7 @@ test('render popover position', async () => {
       </Button>
     </Popover>
   )
-  const content = container.querySelectorAll('.nut-popover-content')[0]
+  const content = document.querySelectorAll('.nut-popover-content')[0]
   expect(content.className).toContain(
     'nut-popup-default nut-popover-content nut-popover-content-bottom-start'
   )
@@ -72,7 +72,7 @@ test('render popover position2', async () => {
       </Button>
     </Popover>
   )
-  const content = container.querySelectorAll(
+  const content = document.querySelectorAll(
     '.nut-popover-arrow'
   )[0] as HTMLElement
   expect(content).toHaveAttribute('style', 'left: 36px;')
@@ -86,7 +86,7 @@ test('render popover position22', async () => {
       </Button>
     </Popover>
   )
-  const content = container.querySelectorAll(
+  const content = document.querySelectorAll(
     '.nut-popover-arrow'
   )[0] as HTMLElement
   expect(content).toHaveAttribute('style', 'left: calc(50% + 20px);')
@@ -100,7 +100,7 @@ test('render popover position3', async () => {
       </Button>
     </Popover>
   )
-  const content = container.querySelectorAll(
+  const content = document.querySelectorAll(
     '.nut-popover-arrow'
   )[0] as HTMLElement
   expect(content).toHaveAttribute('style', 'top: -4px;')
@@ -114,7 +114,7 @@ test('render popover position33', async () => {
       </Button>
     </Popover>
   )
-  const content = container.querySelectorAll(
+  const content = document.querySelectorAll(
     '.nut-popover-arrow'
   )[0] as HTMLElement
   expect(content).toHaveAttribute('style', 'top: calc(50% - 20px);')
@@ -129,7 +129,7 @@ test('should emit onchoose event when clicking the action', async () => {
       </Button>
     </Popover>
   )
-  const contentItem = container.querySelectorAll('.nut-popover-menu-item')[0]
+  const contentItem = document.querySelectorAll('.nut-popover-menu-item')[0]
   fireEvent.click(contentItem)
   await waitFor(() => expect(choose.mock.calls[0][0].name).toEqual('option1'))
   await waitFor(() => expect(choose.mock.calls[0][1]).toBe(0))
@@ -144,7 +144,7 @@ test('should not emit select event when the action is disabled', async () => {
       </Button>
     </Popover>
   )
-  const contentItem = container.querySelectorAll('.nut-popover-menu-item')[0]
+  const contentItem = document.querySelectorAll('.nut-popover-menu-item')[0]
   fireEvent.click(contentItem)
 
   await waitFor(() => expect(choose).not.toBeCalled())

--- a/src/packages/popover/__tests__/popover.spec.tsx
+++ b/src/packages/popover/__tests__/popover.spec.tsx
@@ -121,15 +121,18 @@ test('render popover position33', async () => {
 })
 
 test('render position fixed ', async () => {
-  const { container } = render(
+  const close = jest.fn()
+  const click = jest.fn()
+  const { container, getByTestId } = render(
     <div
       style={{
-        position: 'fixed',
-        bottom: 10,
-        right: -10,
-        zIndex: 1000,
+        height: '200px',
+        overflowY: 'scroll',
+        position: 'relative',
       }}
+      data-testid="aa"
     >
+      <div style={{ height: '100px' }} />
       <Popover
         className="demo-popover"
         visible
@@ -137,6 +140,8 @@ test('render position fixed ', async () => {
         location="top"
         offset={[12, 20]}
         style={{ marginRight: '30px' }}
+        onClick={click}
+        onClose={close}
       >
         <Button data-testid="a" type="primary" shape="square">
           position: fixed
@@ -144,11 +149,17 @@ test('render position fixed ', async () => {
       </Popover>
     </div>
   )
-  const content = document.querySelectorAll(
-    '.nut-popover-arrow'
-  )[0] as HTMLElement
-  fireEvent.click(document.documentElement)
-  expect(content).toBeTruthy()
+  const item = document.querySelectorAll('.nut-popover-menu-item-name')
+  fireEvent.click(item[0])
+  expect(click).toBeCalled()
+  expect(close).toBeCalled()
+  fireEvent.click(getByTestId('a'))
+  await waitFor(() => {
+    fireEvent.scroll(getByTestId('aa'), { target: { scrollTop: 10 } })
+
+    const item1 = document.querySelectorAll('.nut-popover-menu-item-name')
+    expect(item1.length).toBe(3)
+  })
 })
 
 test('should emit onchoose event when clicking the action', async () => {

--- a/src/packages/popover/demo.scss
+++ b/src/packages/popover/demo.scss
@@ -1,7 +1,5 @@
-.demo {
-  .nut-popover-content {
-    width: 120px;
-  }
+.nut-popover-content {
+  width: 120px;
 }
 
 .customClass {

--- a/src/packages/popover/demo.scss
+++ b/src/packages/popover/demo.scss
@@ -1,4 +1,4 @@
-.nut-popover-content {
+.demo-popover .nut-popover-content {
   width: 120px;
 }
 

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -441,7 +441,8 @@ const PopoverDemo = () => {
         <div
           style={{
             position: 'fixed',
-            bottom: 0,
+            bottom: 10,
+            right: -10,
             zIndex: 1000,
           }}
         >

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -233,6 +233,7 @@ const PopoverDemo = () => {
     setCustomTarget(!customTarget)
   }
   const [visiblePopover, setVisiblePopover] = useState(false)
+  const [visiblePopover1, setVisiblePopover1] = useState(false)
   const list = [
     {
       key: 'key1',
@@ -250,6 +251,36 @@ const PopoverDemo = () => {
   return (
     <>
       <div className="demo">
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 0,
+            zIndex: 1,
+          }}
+        >
+          <Popover
+            visible={visiblePopover}
+            list={list}
+            location="top"
+            style={{ marginRight: '30px' }}
+            closeOnOutsideClick={false}
+            onClick={() => {
+              visiblePopover
+                ? setVisiblePopover(false)
+                : setVisiblePopover(true)
+            }}
+            onOpen={() => {
+              console.log('打开菜单时触发')
+            }}
+            onClose={() => {
+              console.log('关闭菜单时触发')
+            }}
+          >
+            <Button type="primary" shape="square">
+              Popover基础用法
+            </Button>
+          </Popover>
+        </div>
         <h2>{translated.title}</h2>
         <Popover
           visible={basic}
@@ -276,19 +307,20 @@ const PopoverDemo = () => {
           style={{
             height: '200px',
             overflowY: 'scroll',
+            position: 'relative',
           }}
         >
           <div style={{ height: '100px' }} />
           <Popover
-            visible={visiblePopover}
+            visible={visiblePopover1}
             list={list}
             location="top"
             closeOnOutsideClick={false}
             style={{ marginRight: '30px' }}
             onClick={() => {
               visiblePopover
-                ? setVisiblePopover(false)
-                : setVisiblePopover(true)
+                ? setVisiblePopover1(false)
+                : setVisiblePopover1(true)
             }}
           >
             <Button id="test" type="primary" shape="square">
@@ -434,6 +466,7 @@ const PopoverDemo = () => {
             {translated.contentColor}
           </Button>
         </Popover>
+        <div style={{ height: '100px' }} />
       </div>
     </>
   )

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -358,9 +358,7 @@ const PopoverDemo = () => {
                 )
               })}
             </div>
-          ) : (
-            ''
-          )}
+          ) : null}
         </Popover>
 
         <h2>{translated.title3}</h2>

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -17,6 +17,7 @@ import './demo.scss'
 interface T {
   [props: string]: string
 }
+
 interface List {
   key?: string
   name: string
@@ -231,7 +232,21 @@ const PopoverDemo = () => {
   const clickCustomHandle = () => {
     setCustomTarget(!customTarget)
   }
-
+  const [visiblePopover, setVisiblePopover] = useState(false)
+  const list = [
+    {
+      key: 'key1',
+      name: 'option1',
+    },
+    {
+      key: 'key2',
+      name: 'option2',
+    },
+    {
+      key: 'key3',
+      name: 'option3',
+    },
+  ]
   return (
     <>
       <div className="demo">
@@ -255,6 +270,32 @@ const PopoverDemo = () => {
             {translated.title}
           </Button>
         </Popover>
+        <h2>{translated.title}</h2>
+
+        <div
+          style={{
+            height: '200px',
+            overflowY: 'scroll',
+          }}
+        >
+          <div style={{ height: '100px' }} />
+          <Popover
+            visible={visiblePopover}
+            list={list}
+            location="top"
+            style={{ marginRight: '30px' }}
+            onClick={() => {
+              visiblePopover
+                ? setVisiblePopover(false)
+                : setVisiblePopover(true)
+            }}
+          >
+            <Button id="test" type="primary" shape="square">
+              置于可滚动容器中
+            </Button>
+          </Popover>
+          <div style={{ height: '100px' }} />
+        </div>
 
         <h2>{translated.title1}</h2>
         <Popover

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -48,6 +48,7 @@ const PopoverDemo = () => {
       content: '自定义内容',
       contentColor: '自定义颜色',
       showMoreDirection: '点击查看更多方向',
+      scroll: '置于可滚动容器中',
     },
     'en-US': {
       title: 'Basic Usage',
@@ -61,6 +62,7 @@ const PopoverDemo = () => {
       content: 'Custom Content',
       contentColor: 'Custom Color',
       showMoreDirection: 'click show more direction',
+      scroll: 'In scrollable contain',
     },
     'zh-TW': {
       title: '基礎用法',
@@ -74,6 +76,7 @@ const PopoverDemo = () => {
       content: '自定義內容',
       contentColor: '自定義顏色',
       showMoreDirection: '點擊查看更多方向',
+      scroll: '置於可滾動容器中',
     },
   })
   const selfContentStyle = {
@@ -251,36 +254,6 @@ const PopoverDemo = () => {
   return (
     <>
       <div className="demo">
-        <div
-          style={{
-            position: 'fixed',
-            bottom: 0,
-            zIndex: 1,
-          }}
-        >
-          <Popover
-            visible={visiblePopover}
-            list={list}
-            location="top"
-            style={{ marginRight: '30px' }}
-            closeOnOutsideClick={false}
-            onClick={() => {
-              visiblePopover
-                ? setVisiblePopover(false)
-                : setVisiblePopover(true)
-            }}
-            onOpen={() => {
-              console.log('打开菜单时触发')
-            }}
-            onClose={() => {
-              console.log('关闭菜单时触发')
-            }}
-          >
-            <Button type="primary" shape="square">
-              Popover基础用法
-            </Button>
-          </Popover>
-        </div>
         <h2>{translated.title}</h2>
         <Popover
           visible={basic}
@@ -290,45 +263,11 @@ const PopoverDemo = () => {
           onClick={() => {
             basic ? setBasic(false) : setBasic(true)
           }}
-          onOpen={() => {
-            console.log('打开菜单时触发')
-          }}
-          onClose={() => {
-            console.log('关闭菜单时触发')
-          }}
         >
           <Button type="primary" shape="square">
             {translated.title}
           </Button>
         </Popover>
-        <h2>{translated.title}</h2>
-
-        <div
-          style={{
-            height: '200px',
-            overflowY: 'scroll',
-            position: 'relative',
-          }}
-        >
-          <div style={{ height: '100px' }} />
-          <Popover
-            visible={visiblePopover1}
-            list={list}
-            location="top"
-            closeOnOutsideClick={false}
-            style={{ marginRight: '30px' }}
-            onClick={() => {
-              visiblePopover
-                ? setVisiblePopover1(false)
-                : setVisiblePopover1(true)
-            }}
-          >
-            <Button id="test" type="primary" shape="square">
-              置于可滚动容器中
-            </Button>
-          </Popover>
-          <div style={{ height: '100px' }} />
-        </div>
 
         <h2>{translated.title1}</h2>
         <Popover
@@ -466,6 +405,60 @@ const PopoverDemo = () => {
             {translated.contentColor}
           </Button>
         </Popover>
+
+        <h2>{translated.scroll}</h2>
+        <div
+          style={{
+            height: '200px',
+            overflowY: 'scroll',
+            position: 'relative',
+          }}
+        >
+          <div style={{ height: '100px' }} />
+          <Popover
+            visible={visiblePopover1}
+            list={list}
+            location="top"
+            closeOnOutsideClick={false}
+            style={{ marginRight: '30px' }}
+            onClick={() => {
+              visiblePopover
+                ? setVisiblePopover1(false)
+                : setVisiblePopover1(true)
+            }}
+          >
+            <Button id="test" type="primary" shape="square">
+              {translated.scroll}
+            </Button>
+          </Popover>
+          <div style={{ height: '100px' }} />
+        </div>
+
+        <h2>{translated.fixed}</h2>
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 0,
+            zIndex: 1,
+          }}
+        >
+          <Popover
+            visible={visiblePopover}
+            list={list}
+            location="top"
+            style={{ marginRight: '30px' }}
+            closeOnOutsideClick={false}
+            onClick={() => {
+              visiblePopover
+                ? setVisiblePopover(false)
+                : setVisiblePopover(true)
+            }}
+          >
+            <Button type="primary" shape="square">
+              position: fixed
+            </Button>
+          </Popover>
+        </div>
         <div style={{ height: '100px' }} />
       </div>
     </>

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -283,6 +283,7 @@ const PopoverDemo = () => {
             visible={visiblePopover}
             list={list}
             location="top"
+            closeOnOutsideClick={false}
             style={{ marginRight: '30px' }}
             onClick={() => {
               visiblePopover

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -271,6 +271,7 @@ const PopoverDemo = () => {
 
         <h2>{translated.title1}</h2>
         <Popover
+          className="demo-popover"
           visible={showIcon}
           location="bottom-start"
           onClick={() => {
@@ -374,6 +375,7 @@ const PopoverDemo = () => {
 
         <h2>{translated.title4}</h2>
         <Popover
+          className="demo-popover"
           visible={customTarget}
           targetId="popid"
           list={iconItemList}
@@ -416,6 +418,7 @@ const PopoverDemo = () => {
         >
           <div style={{ height: '100px' }} />
           <Popover
+            className="demo-popover"
             visible={visiblePopover1}
             list={list}
             location="top"
@@ -439,10 +442,11 @@ const PopoverDemo = () => {
           style={{
             position: 'fixed',
             bottom: 0,
-            zIndex: 1,
+            zIndex: 1000,
           }}
         >
           <Popover
+            className="demo-popover"
             visible={visiblePopover}
             list={list}
             location="top"

--- a/src/packages/popover/demo.tsx
+++ b/src/packages/popover/demo.tsx
@@ -49,6 +49,7 @@ const PopoverDemo = () => {
       contentColor: '自定义颜色',
       showMoreDirection: '点击查看更多方向',
       scroll: '置于可滚动容器中',
+      fixed: '容器设置 position: fixed',
     },
     'en-US': {
       title: 'Basic Usage',
@@ -63,6 +64,7 @@ const PopoverDemo = () => {
       contentColor: 'Custom Color',
       showMoreDirection: 'click show more direction',
       scroll: 'In scrollable contain',
+      fixed: 'position: fixed',
     },
     'zh-TW': {
       title: '基礎用法',
@@ -77,6 +79,7 @@ const PopoverDemo = () => {
       contentColor: '自定義顏色',
       showMoreDirection: '點擊查看更多方向',
       scroll: '置於可滾動容器中',
+      fixed: '容器設置 position: fixed',
     },
   })
   const selfContentStyle = {

--- a/src/packages/popover/doc.en-US.md
+++ b/src/packages/popover/doc.en-US.md
@@ -488,6 +488,126 @@ export default App
 
 :::
 
+### In scrollable container
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from 'react'
+import { Popover, Button } from '@nutui/nutui-react'
+
+const App = () => {
+  const [visible, setVisible] = useState(false)
+  const itemList = [
+    {
+      key: 'key1',
+      name: 'option1',
+    },
+    {
+      key: 'key2',
+      name: 'option2',
+    },
+    {
+      key: 'key3',
+      name: 'option3',
+    },
+  ]
+  return (
+    <>
+      <div
+        style={{
+          height: '200px',
+          overflowY: 'scroll',
+          position: 'relative',
+        }}
+      >
+        <div style={{ height: '100px' }} />
+        <Popover
+          visible={visible}
+          list={itemList}
+          location='top'
+          closeOnOutsideClick={false}
+          style={{ marginRight: '30px' }}
+          onClick={() => {
+            visble
+              ? setVisible(false)
+              : setVisible(true)
+          }}
+        >
+          <Button id='test' type='primary' shape='square'>
+            In scrollable container
+          </Button>
+        </Popover>
+        <div style={{ height: '100px' }} />
+      </div>
+    </>
+  )
+}
+
+export default App
+```
+
+:::
+
+### Container setting position: fixed
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from 'react'
+import { Popover, Button } from '@nutui/nutui-react'
+
+const App = () => {
+  const [visible, setVisible] = useState(false)
+  const list = [
+    {
+      key: 'key1',
+      name: 'option1',
+    },
+    {
+      key: 'key2',
+      name: 'option2',
+    },
+    {
+      key: 'key3',
+      name: 'option3',
+    },
+  ]
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          zIndex: 1,
+        }}
+      >
+        <Popover
+          visible={visible}
+          list={list}
+          location="top"
+          style={{ marginRight: '30px' }}
+          closeOnOutsideClick={false}
+          onClick={() => {
+            visible
+              ? setVisible(false)
+              : setVisible(true)
+          }}
+        >
+          <Button type="primary" shape="square">
+            position: fixed
+          </Button>
+        </Popover>
+      </div>
+    </>
+  )
+}
+
+export default App
+```
+
+:::
+
 ## Popover
 
 ### Props

--- a/src/packages/popover/doc.md
+++ b/src/packages/popover/doc.md
@@ -493,6 +493,126 @@ export default App
 
 :::
 
+### 置于可滚动容器中
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from 'react'
+import { Popover, Button } from '@nutui/nutui-react'
+
+const App = () => {
+  const [visible, setVisible] = useState(false)
+  const itemList = [
+    {
+      key: 'key1',
+      name: 'option1',
+    },
+    {
+      key: 'key2',
+      name: 'option2',
+    },
+    {
+      key: 'key3',
+      name: 'option3',
+    },
+  ]
+  return (
+    <>
+      <div
+        style={{
+          height: '200px',
+          overflowY: 'scroll',
+          position: 'relative',
+        }}
+      >
+        <div style={{ height: '100px' }} />
+        <Popover
+          visible={visible}
+          list={itemList}
+          location='top'
+          closeOnOutsideClick={false}
+          style={{ marginRight: '30px' }}
+          onClick={() => {
+            visble
+              ? setVisible(false)
+              : setVisible(true)
+          }}
+        >
+          <Button id='test' type='primary' shape='square'>
+            置于可滚动容器中
+          </Button>
+        </Popover>
+        <div style={{ height: '100px' }} />
+      </div>
+    </>
+  )
+}
+
+export default App
+```
+
+:::
+
+### 容器设置 position: fixed
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from 'react'
+import { Popover, Button } from '@nutui/nutui-react'
+
+const App = () => {
+  const [visible, setVisible] = useState(false)
+  const list = [
+    {
+      key: 'key1',
+      name: 'option1',
+    },
+    {
+      key: 'key2',
+      name: 'option2',
+    },
+    {
+      key: 'key3',
+      name: 'option3',
+    },
+  ]
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          zIndex: 1,
+        }}
+      >
+        <Popover
+          visible={visible}
+          list={list}
+          location="top"
+          style={{ marginRight: '30px' }}
+          closeOnOutsideClick={false}
+          onClick={() => {
+            visible
+              ? setVisible(false)
+              : setVisible(true)
+          }}
+        >
+          <Button type="primary" shape="square">
+            position: fixed
+          </Button>
+        </Popover>
+      </div>
+    </>
+  )
+}
+
+export default App
+```
+
+:::
+
 ## Popover
 
 ### Props

--- a/src/packages/popover/doc.zh-TW.md
+++ b/src/packages/popover/doc.zh-TW.md
@@ -493,6 +493,126 @@ export default App
 
 :::
 
+### 置於可滾動容器中
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from 'react'
+import { Popover, Button } from '@nutui/nutui-react'
+
+const App = () => {
+  const [visible, setVisible] = useState(false)
+  const itemList = [
+    {
+      key: 'key1',
+      name: 'option1',
+    },
+    {
+      key: 'key2',
+      name: 'option2',
+    },
+    {
+      key: 'key3',
+      name: 'option3',
+    },
+  ]
+  return (
+    <>
+      <div
+        style={{
+          height: '200px',
+          overflowY: 'scroll',
+          position: 'relative',
+        }}
+      >
+        <div style={{ height: '100px' }} />
+        <Popover
+          visible={visible}
+          list={itemList}
+          location='top'
+          closeOnOutsideClick={false}
+          style={{ marginRight: '30px' }}
+          onClick={() => {
+            visble
+              ? setVisible(false)
+              : setVisible(true)
+          }}
+        >
+          <Button id='test' type='primary' shape='square'>
+            置於可滾動容器中
+          </Button>
+        </Popover>
+        <div style={{ height: '100px' }} />
+      </div>
+    </>
+  )
+}
+
+export default App
+```
+
+:::
+
+### 容器設置 position: fixed
+
+:::demo
+
+```tsx
+import React, { useState, useRef } from 'react'
+import { Popover, Button } from '@nutui/nutui-react'
+
+const App = () => {
+  const [visible, setVisible] = useState(false)
+  const list = [
+    {
+      key: 'key1',
+      name: 'option1',
+    },
+    {
+      key: 'key2',
+      name: 'option2',
+    },
+    {
+      key: 'key3',
+      name: 'option3',
+    },
+  ]
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          zIndex: 1,
+        }}
+      >
+        <Popover
+          visible={visible}
+          list={list}
+          location="top"
+          style={{ marginRight: '30px' }}
+          closeOnOutsideClick={false}
+          onClick={() => {
+            visible
+              ? setVisible(false)
+              : setVisible(true)
+          }}
+        >
+          <Button type="primary" shape="square">
+            position: fixed
+          </Button>
+        </Popover>
+      </div>
+    </>
+  )
+}
+
+export default App
+```
+
+:::
+
 ## Popover
 
 ### Props

--- a/src/packages/popover/popover.scss
+++ b/src/packages/popover/popover.scss
@@ -97,7 +97,7 @@
       border-bottom: 1px solid $popover-divider-color;
 
       &:last-child {
-        margin-bottom: 2px;
+        margin-bottom: 0px;
         border-bottom: none;
       }
 

--- a/src/packages/popover/popover.tsx
+++ b/src/packages/popover/popover.tsx
@@ -118,7 +118,7 @@ export const Popover: FunctionComponent<
     if (visible) {
       setTimeout(() => {
         getContentWidth()
-      }, 10)
+      }, 0)
     }
   }, [visible, location])
 
@@ -127,9 +127,9 @@ export const Popover: FunctionComponent<
   })
   useEffect(() => {
     if (visible) {
-      scrollableParents.forEach((parent) =>
+      scrollableParents.forEach((parent) => {
         parent.addEventListener('scroll', update.current, { passive: true })
-      )
+      })
     } else {
       scrollableParents.forEach((parent) =>
         parent.removeEventListener('scroll', update.current)
@@ -140,9 +140,7 @@ export const Popover: FunctionComponent<
   let element: Element | null = null
   let targetSet = []
   if (canUseDom && targetId) {
-    console.log(targetId)
     element = document.querySelector(`#${targetId}`) as Element
-    console.log(element?.getBoundingClientRect().top)
     targetSet = [element, popoverContentRef.current]
   } else {
     targetSet = [popoverRef.current, popoverContentRef.current]
@@ -169,6 +167,7 @@ export const Popover: FunctionComponent<
         ? (document.querySelector(`#${targetId}`) as Element)
         : (popoverRef.current as Element)
     )
+    console.log(rect.top, document.documentElement.scrollTop)
     setRootPosition({
       width: rect.width,
       height: rect.height,
@@ -196,7 +195,6 @@ export const Popover: FunctionComponent<
   const getRootPosition = () => {
     const styles: CSSProperties = {}
     if (!rootPosition) return {}
-
     const contentWidth = popoverContentRef.current?.clientWidth as number
     const contentHeight = popoverContentRef.current?.clientHeight as number
     const { width, height, left, top, right } = rootPosition

--- a/src/packages/popover/popover.tsx
+++ b/src/packages/popover/popover.tsx
@@ -3,6 +3,7 @@ import React, {
   FunctionComponent,
   ReactPortal,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -119,7 +120,7 @@ export const Popover: FunctionComponent<
     if (visible) {
       setTimeout(() => {
         getContentWidth()
-      }, 10)
+      })
     }
   }, [visible])
 
@@ -144,30 +145,29 @@ export const Popover: FunctionComponent<
     closeOnOutsideClick
   )
 
-  const scrollableParents = getAllScrollableParents(
-    (element || popoverRef.current) as Element
-  )
-  const update = () => {
+  const scrollableParents = useMemo(() => {
+    return getAllScrollableParents((element || popoverRef.current) as Element)
+  }, [element, popoverRef.current])
+  const update = (e: any) => {
+    console.log(e.target.scrollTop)
     getContentWidth()
   }
 
   useEffect(() => {
     scrollableParents.forEach((parent) =>
-      parent.addEventListener('scroll', update, false)
+      parent.addEventListener('scroll', update, { passive: true })
     )
     return () => {
       scrollableParents.forEach((parent) =>
         parent.removeEventListener('scroll', update)
       )
     }
-  })
-
+  }, [scrollableParents])
+  const cElement = useMemo(() => {
+    if (targetId) return document.querySelector(`#${targetId}`) as Element
+  }, [targetId])
   const getContentWidth = () => {
-    const rect = getRect(
-      targetId
-        ? (document.querySelector(`#${targetId}`) as Element)
-        : (popoverRef.current as Element)
-    )
+    const rect = getRect(targetId ? cElement : (popoverRef.current as Element))
     setRootPosition({
       width: rect.width,
       height: rect.height,

--- a/src/packages/popover/popover.tsx
+++ b/src/packages/popover/popover.tsx
@@ -1,17 +1,20 @@
 import React, {
   CSSProperties,
   FunctionComponent,
+  ReactPortal,
   useEffect,
   useRef,
   useState,
 } from 'react'
 import classNames from 'classnames'
+import { createPortal } from 'react-dom'
 import Popup from '@/packages/popup'
 import { PopupProps } from '@/packages/popup/popup'
 import { getRect } from '@/utils/use-client-rect'
 import { ComponentDefaults } from '@/utils/typings'
 import useClickAway from '@/utils/use-click-away'
 import { canUseDom } from '@/utils/can-use-dom'
+import { getAllScrollableParents } from '@/utils/get-scroll-parent'
 
 export type PopoverLocation =
   | 'bottom'
@@ -113,26 +116,27 @@ export const Popover: FunctionComponent<
 
   useEffect(() => {
     setShowPopup(visible)
-
+    console.log(visible)
     if (visible) {
       setTimeout(() => {
         getContentWidth()
-      }, 0)
+      }, 10)
     }
   }, [visible])
-  let element
-  if (canUseDom) {
-    element = targetId && document.querySelector(`#${targetId}`)
+
+  let element: Element | null = null
+  let targetSet = []
+  if (canUseDom && targetId) {
+    element = document.querySelector(`#${targetId}`) as Element
+    targetSet = [popoverContentRef.current, element]
+  } else {
+    targetSet = [popoverRef.current, popoverContentRef.current]
   }
-  const targetSet = [
-    targetId ? element : popoverRef.current,
-    popoverContentRef.current,
-  ]
 
   useClickAway(
     () => {
-      props.onClick && props.onClick()
-      onClose && onClose()
+      props.onClick?.()
+      onClose?.()
     },
     targetSet as Element[],
     'touchstart',
@@ -141,37 +145,39 @@ export const Popover: FunctionComponent<
     closeOnOutsideClick
   )
 
-  const getContentWidth = () => {
-    let rect = getRect(popoverRef.current as Element)
-    const scrollDis = document.documentElement.scrollTop || window.scrollY
-    if (targetId) {
-      setTimeout(() => {
-        rect = getRect(document.querySelector(`#${targetId}`) as Element)
-        setRootPosition({
-          width: rect.width,
-          height: rect.height,
-          left: rect.left,
-          top: rect.top + scrollDis,
-          right: rect.right,
-        })
-        if (popoverContentRef.current) {
-          setElWidth(popoverContentRef.current.clientWidth)
-          setElHeight(popoverContentRef.current.clientHeight)
-        }
-      }, 0)
-    } else {
-      setRootPosition({
-        width: rect.width,
-        height: rect.height,
-        left: rect.left,
-        top: rect.top + scrollDis,
-        right: rect.right,
-      })
-      if (popoverContentRef.current) {
-        setElWidth(popoverContentRef.current.clientWidth)
-        setElHeight(popoverContentRef.current.clientHeight)
-      }
+  const scrollableParents = getAllScrollableParents(
+    (element || popoverRef.current) as Element
+  )
+  const update = () => {
+    getContentWidth()
+  }
+
+  useEffect(() => {
+    scrollableParents.forEach((parent) =>
+      parent.addEventListener('scroll', update, false)
+    )
+    return () => {
+      scrollableParents.forEach((parent) =>
+        parent.removeEventListener('scroll', update)
+      )
     }
+  })
+
+  const getContentWidth = () => {
+    const rect = getRect(
+      targetId
+        ? (document.querySelector(`#${targetId}`) as Element)
+        : (popoverRef.current as Element)
+    )
+    setRootPosition({
+      width: rect.width,
+      height: rect.height,
+      left: rect.left,
+      top:
+        rect.top +
+        Math.max(document.documentElement.scrollTop, document.body.scrollTop),
+      right: rect.right,
+    })
   }
 
   const classes = classNames(
@@ -183,17 +189,16 @@ export const Popover: FunctionComponent<
 
   const popoverArrow = () => {
     const prefixCls = 'nut-popover-arrow'
-    const loca = location
-    const direction = loca.split('-')[0]
-    return `${prefixCls} ${prefixCls}-${direction} ${prefixCls}-${loca}`
+    const direction = location.split('-')[0]
+    return `${prefixCls} ${prefixCls}-${direction} ${prefixCls}-${location}`
   }
 
   const getRootPosition = () => {
     const styles: CSSProperties = {}
     if (!rootPosition) return {}
 
-    const contentWidth = elWidth
-    const contentHeight = elHeight
+    const contentWidth = popoverContentRef.current?.clientWidth as number
+    const contentHeight = popoverContentRef.current?.clientHeight as number
     const { width, height, left, top, right } = rootPosition
     const direction = location.split('-')[0]
     const skew = location.split('-')[1]
@@ -203,7 +208,7 @@ export const Popover: FunctionComponent<
       cross += +offset[1]
       parallel += +offset[0]
     }
-
+    console.log('rootPosition', direction, rootPosition)
     if (width) {
       if (['bottom', 'top'].includes(direction)) {
         const h =
@@ -237,10 +242,11 @@ export const Popover: FunctionComponent<
         }
       }
     }
+    console.log(styles)
     return styles
   }
 
-  const popoverArrowStyle = () => {
+  const arrowStyle = () => {
     const styles: CSSProperties = {}
     const direction = location.split('-')[0]
     const skew = location.split('-')[1]
@@ -276,11 +282,11 @@ export const Popover: FunctionComponent<
 
   const handleSelect = (item: List, index: number) => {
     if (!item.disabled) {
-      onSelect && onSelect(item, index)
+      onSelect?.(item, index)
     }
     if (closeOnActionClick) {
-      props.onClick && props.onClick()
-      onClose && onClose()
+      props.onClick?.()
+      onClose?.()
     }
   }
   return (
@@ -290,11 +296,11 @@ export const Popover: FunctionComponent<
           className="nut-popover-wrapper"
           ref={popoverRef}
           onClick={() => {
-            props.onClick && props.onClick()
+            props.onClick?.()
             if (!visible) {
-              onOpen && onOpen()
+              onOpen?.()
             } else {
-              onClose && onClose()
+              onClose?.()
             }
           }}
           style={style}
@@ -302,52 +308,63 @@ export const Popover: FunctionComponent<
           {Array.isArray(children) ? children[0] : children}
         </div>
       )}
-      <div className={classes} style={getRootPosition()}>
-        <Popup
-          className={`nut-popover-content nut-popover-content-${location}`}
-          visible={showPopup}
-          overlay={overlay}
-          position="default"
-          {...rest}
-        >
-          <div className="nut-popover-content-group" ref={popoverContentRef}>
-            {showArrow && (
-              <div className={popoverArrow()} style={popoverArrowStyle()} />
-            )}
-            {Array.isArray(children) ? children[1] : ''}
-            {list.map((item, index) => {
-              return (
-                <div
-                  className={classNames(
-                    {
-                      'nut-popover-menu-item': true,
-                      'nut-popover-menu-disabled': item.disabled,
-                    },
-                    item.className
-                  )}
-                  key={item.key || index}
-                  onClick={() => handleSelect(item, index)}
-                >
-                  {item.icon ? (
-                    <div className="nut-popover-menu-item-icon">
-                      {item.icon}
-                    </div>
-                  ) : null}
-                  <div className="nut-popover-menu-item-name">{item.name}</div>
-                  {item.action && item.action.icon ? (
+      {
+        createPortal(
+          <div className={classes} style={getRootPosition()}>
+            <Popup
+              className={`nut-popover-content nut-popover-content-${location}`}
+              visible={showPopup}
+              overlay={overlay}
+              position="default"
+              lockScroll={false}
+              {...rest}
+            >
+              <div
+                className="nut-popover-content-group"
+                ref={popoverContentRef}
+              >
+                {showArrow && (
+                  <div className={popoverArrow()} style={arrowStyle()} />
+                )}
+                {Array.isArray(children) ? children[1] : null}
+                {list.map((item, index) => {
+                  return (
                     <div
-                      className="nut-popover-menu-item-action-icon"
-                      onClick={(e) => item.action?.onClick?.(e)}
+                      className={classNames(
+                        {
+                          'nut-popover-menu-item': true,
+                          'nut-popover-menu-disabled': item.disabled,
+                        },
+                        item.className
+                      )}
+                      key={item.key || index}
+                      onClick={() => handleSelect(item, index)}
                     >
-                      {item.action.icon}
+                      {item.icon ? (
+                        <div className="nut-popover-menu-item-icon">
+                          {item.icon}
+                        </div>
+                      ) : null}
+                      <div className="nut-popover-menu-item-name">
+                        {item.name}
+                      </div>
+                      {item.action && item.action.icon ? (
+                        <div
+                          className="nut-popover-menu-item-action-icon"
+                          onClick={(e) => item.action?.onClick?.(e)}
+                        >
+                          {item.action.icon}
+                        </div>
+                      ) : null}
                     </div>
-                  ) : null}
-                </div>
-              )
-            })}
-          </div>
-        </Popup>
-      </div>
+                  )
+                })}
+              </div>
+            </Popup>
+          </div>,
+          document.body
+        ) as ReactPortal
+      }
     </>
   )
 }

--- a/src/packages/popover/popover.tsx
+++ b/src/packages/popover/popover.tsx
@@ -116,7 +116,6 @@ export const Popover: FunctionComponent<
 
   useEffect(() => {
     setShowPopup(visible)
-    console.log(visible)
     if (visible) {
       setTimeout(() => {
         getContentWidth()
@@ -208,7 +207,6 @@ export const Popover: FunctionComponent<
       cross += +offset[1]
       parallel += +offset[0]
     }
-    console.log('rootPosition', direction, rootPosition)
     if (width) {
       if (['bottom', 'top'].includes(direction)) {
         const h =
@@ -242,7 +240,6 @@ export const Popover: FunctionComponent<
         }
       }
     }
-    console.log(styles)
     return styles
   }
 

--- a/src/packages/popover/popover.tsx
+++ b/src/packages/popover/popover.tsx
@@ -167,7 +167,6 @@ export const Popover: FunctionComponent<
         ? (document.querySelector(`#${targetId}`) as Element)
         : (popoverRef.current as Element)
     )
-    console.log(rect.top, document.documentElement.scrollTop)
     setRootPosition({
       width: rect.width,
       height: rect.height,

--- a/src/packages/tour/__test__/tour.spec.tsx
+++ b/src/packages/tour/__test__/tour.spec.tsx
@@ -54,10 +54,8 @@ test('base render', () => {
   const { container } = render(
     <Tour visible list={steps} type="tile" location="bottom-end" />
   )
-  expect(container.querySelector('.nut-popover')).toBeTruthy()
-  expect(
-    container.querySelector('.nut-popover-content-bottom-end')
-  ).toBeTruthy()
+  expect(document.querySelector('.nut-popover')).toBeTruthy()
+  expect(document.querySelector('.nut-popover-content-bottom-end')).toBeTruthy()
 })
 
 test('custom style', () => {
@@ -102,7 +100,7 @@ test('custom offset', () => {
       offset={[8, 8]}
     />
   )
-  const tourArrow = container.querySelectorAll('.nut-popover-arrow')[0]
+  const tourArrow = document.querySelectorAll('.nut-popover-arrow')[0]
   expect(tourArrow).toHaveStyle({ right: '52px' })
 })
 
@@ -127,7 +125,7 @@ test('slot render', () => {
       </div>
     </Tour>
   )
-  const tourArrow = container.querySelectorAll('.nut-popover-content-group')[0]
+  const tourArrow = document.querySelectorAll('.nut-popover-content-group')[0]
   expect(tourArrow).toHaveTextContent('nutui 4.x 即将发布，敬请期待')
 })
 
@@ -139,14 +137,14 @@ test('steps render', async () => {
   const { container } = render(
     <Tour visible list={steps4} location="bottom-end" />
   )
-  const btn = container.querySelectorAll(
+  const btn = document.querySelectorAll(
     '.nut-tour-content-bottom-operate-btn'
   )[0]
   expect(btn).toBeTruthy()
   fireEvent.click(btn)
 
   await waitFor(() => {
-    const btn2 = container.querySelectorAll(
+    const btn2 = document.querySelectorAll(
       '.nut-tour-content-bottom-operate-btn'
     )
     expect(btn2.length).toBe(2)

--- a/src/utils/get-scroll-parent.ts
+++ b/src/utils/get-scroll-parent.ts
@@ -32,3 +32,25 @@ export function getScrollParent(
   }
   return root
 }
+
+export function getAllScrollableParents(
+  element: Element | null,
+  scrollableParents: Element[] = []
+): Element[] {
+  if (!element) {
+    return scrollableParents
+  }
+
+  // 检查元素是否具有滚动条
+  const isScrollable =
+    element.scrollHeight > element.clientHeight ||
+    element.scrollWidth > element.clientWidth
+
+  if (isScrollable) {
+    // 如果当前元素具有滚动条，则将其添加到数组中
+    scrollableParents.push(element)
+  }
+
+  // 递归检查父元素
+  return getAllScrollableParents(element.parentElement, scrollableParents)
+}

--- a/src/utils/get-scroll-parent.ts
+++ b/src/utils/get-scroll-parent.ts
@@ -48,7 +48,12 @@ export function getAllScrollableParents(
 
   if (isScrollable) {
     // 如果当前元素具有滚动条，则将其添加到数组中
-    scrollableParents.push(element)
+    if (element.nodeName === 'HTML') {
+      // @ts-ignore
+      scrollableParents.push(document)
+    } else {
+      scrollableParents.push(element)
+    }
   }
 
   // 递归检查父元素


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue


### 💡 需求背景和解决方案

```html
<div
          style={{
            height: '200px',
            overflowY: 'scroll',
          }}
        >
          <div style={{ height: '100px' }} />
          <Popover
            visible={visiblePopover}
            list={list}
            location="top"
            style={{ marginRight: '30px' }}
            onClick={() => {
              visiblePopover
                ? setVisiblePopover(false)
                : setVisiblePopover(true)
            }}
          >
            <Button id="test" type="primary" shape="square">
              置于可滚动容器中
            </Button>
          </Popover>
          <div style={{ height: '100px' }} />
        </div>
```

在上面例子中，popover不能随之滚动。可参考 bug 录屏如下：


https://github.com/jdf2e/nutui-react/assets/12181600/40205b97-dd6c-4b49-8366-c78db136ef40



修复后



https://github.com/jdf2e/nutui-react/assets/12181600/d6270a1e-8a56-4e80-b29b-1f3900b4363d

