### PR TITLE
fix(swiper): 轮播跳帧

### DIFF
--- a/src/packages/swiper/__tests__/swiper.spec.tsx
+++ b/src/packages/swiper/__tests__/swiper.spec.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import React, { useRef } from 'react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { act } from 'react-dom/test-utils'
-import Swiper from '../index'
+import Swiper, { SwiperRef } from '../index'
 import { triggerDrag } from '@/utils/test/event'
 
 function sleep(delay = 0): Promise<void> {
@@ -24,26 +24,57 @@ test('should render width and height', () => {
     width: 375,
   }
   const { height, defaultValue, width } = state
-  const onChange = (e: number) => {}
+  const onChange = jest.fn()
 
-  const { container } = render(
-    <Swiper
-      height={height}
-      width={width}
-      autoPlay="2000"
-      defaultValue={defaultValue}
-      onChange={onChange}
-      indicator
-    >
-      {list.map((item) => {
-        return (
-          <Swiper.Item key={item}>
-            <img src={item} alt="" />
-          </Swiper.Item>
-        )
-      })}
-    </Swiper>
-  )
+  const Wraper = () => {
+    const ref = useRef<SwiperRef>(null)
+    return (
+      <>
+        <div
+          data-testid="prev"
+          onClick={() => {
+            ref.current?.prev()
+          }}
+        >
+          prev
+        </div>
+        <div
+          data-testid="next"
+          onClick={() => {
+            ref.current?.next()
+          }}
+        >
+          next
+        </div>
+        <div
+          data-testid="to"
+          onClick={() => {
+            ref.current?.to(1)
+          }}
+        >
+          to
+        </div>
+        <Swiper
+          height={height}
+          width={width}
+          autoPlay="2000"
+          defaultValue={defaultValue}
+          onChange={onChange}
+          ref={ref}
+          indicator
+        >
+          {list.map((item) => {
+            return (
+              <Swiper.Item key={item}>
+                <img src={item} alt="" />
+              </Swiper.Item>
+            )
+          })}
+        </Swiper>
+      </>
+    )
+  }
+  const { container, getByTestId } = render(<Wraper />)
   const swiper = container.querySelectorAll('.nut-swiper-inner')[0]
   const item = container.querySelectorAll('.nut-swiper-item')[0]
   expect(swiper).toHaveStyle({
@@ -52,6 +83,10 @@ test('should render width and height', () => {
   expect(item).toHaveStyle({
     width: '375px',
   })
+
+  fireEvent.click(getByTestId('next'))
+  fireEvent.click(getByTestId('prev'))
+  fireEvent.click(getByTestId('to'))
 })
 test('should render initpage', () => {
   const list = [

--- a/src/packages/swiper/__tests__/swiper.spec.tsx
+++ b/src/packages/swiper/__tests__/swiper.spec.tsx
@@ -1,8 +1,8 @@
-import React, { useRef } from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { act } from 'react-dom/test-utils'
-import Swiper, { SwiperRef } from '../index'
+import Swiper from '../index'
 import { triggerDrag } from '@/utils/test/event'
 
 function sleep(delay = 0): Promise<void> {
@@ -24,57 +24,26 @@ test('should render width and height', () => {
     width: 375,
   }
   const { height, defaultValue, width } = state
-  const onChange = jest.fn()
+  const onChange = (e: number) => {}
 
-  const Wraper = () => {
-    const ref = useRef<SwiperRef>(null)
-    return (
-      <>
-        <div
-          data-testid="prev"
-          onClick={() => {
-            ref.current?.prev()
-          }}
-        >
-          prev
-        </div>
-        <div
-          data-testid="next"
-          onClick={() => {
-            ref.current?.next()
-          }}
-        >
-          next
-        </div>
-        <div
-          data-testid="to"
-          onClick={() => {
-            ref.current?.to(1)
-          }}
-        >
-          to
-        </div>
-        <Swiper
-          height={height}
-          width={width}
-          autoPlay="2000"
-          defaultValue={defaultValue}
-          onChange={onChange}
-          ref={ref}
-          indicator
-        >
-          {list.map((item) => {
-            return (
-              <Swiper.Item key={item}>
-                <img src={item} alt="" />
-              </Swiper.Item>
-            )
-          })}
-        </Swiper>
-      </>
-    )
-  }
-  const { container, getByTestId } = render(<Wraper />)
+  const { container } = render(
+    <Swiper
+      height={height}
+      width={width}
+      autoPlay="2000"
+      defaultValue={defaultValue}
+      onChange={onChange}
+      indicator
+    >
+      {list.map((item) => {
+        return (
+          <Swiper.Item key={item}>
+            <img src={item} alt="" />
+          </Swiper.Item>
+        )
+      })}
+    </Swiper>
+  )
   const swiper = container.querySelectorAll('.nut-swiper-inner')[0]
   const item = container.querySelectorAll('.nut-swiper-item')[0]
   expect(swiper).toHaveStyle({
@@ -83,10 +52,6 @@ test('should render width and height', () => {
   expect(item).toHaveStyle({
     width: '375px',
   })
-
-  fireEvent.click(getByTestId('next'))
-  fireEvent.click(getByTestId('prev'))
-  fireEvent.click(getByTestId('to'))
 })
 test('should render initpage', () => {
   const list = [

--- a/src/packages/swiper/demo.tsx
+++ b/src/packages/swiper/demo.tsx
@@ -110,21 +110,23 @@ const SwiperDemo = () => {
       </div>
       <h2>{translated.asyc}</h2>
       <div className="demo-box" style={{ height: 150 }}>
-        <Swiper
-          height={height}
-          autoPlay="2000"
-          defaultValue={initPage2}
-          onChange={onChange}
-          indicator
-        >
-          {list1.map((item) => {
-            return (
-              <Swiper.Item key={item}>
-                <img src={item} alt="" />
-              </Swiper.Item>
-            )
-          })}
-        </Swiper>
+        {list1.length ? (
+          <Swiper
+            height={height}
+            autoPlay="2000"
+            defaultValue={initPage2}
+            onChange={onChange}
+            indicator
+          >
+            {list1.map((item) => {
+              return (
+                <Swiper.Item key={item}>
+                  <img src={item} alt="" />
+                </Swiper.Item>
+              )
+            })}
+          </Swiper>
+        ) : null}
       </div>
       <h2>{translated.dynamicDel}</h2>
       <div className="demo-box" style={{ height: 150 }}>

--- a/src/packages/swiper/demo.tsx
+++ b/src/packages/swiper/demo.tsx
@@ -128,29 +128,6 @@ const SwiperDemo = () => {
           </Swiper>
         ) : null}
       </div>
-      <h2>{translated.dynamicDel}</h2>
-      <div className="demo-box" style={{ height: 150 }}>
-        <Swiper
-          height={height}
-          style={{
-            '--nutui-indicator-color': '#426543',
-            '--nutui-indicator-dot-color': '#426ddd',
-          }}
-          autoPlay="2000"
-          defaultValue={initPage3}
-          onChange={onChange}
-          indicator
-        >
-          {list2.map((item) => {
-            return (
-              <Swiper.Item key={item}>
-                <img src={item} alt="" />
-              </Swiper.Item>
-            )
-          })}
-        </Swiper>
-      </div>
-
       <h2>{translated.size}</h2>
       <div className="demo-box" style={{ height: 150 }}>
         <Swiper defaultValue={initPage4} width="300" height={height}>

--- a/src/packages/swiper/doc.en-US.md
+++ b/src/packages/swiper/doc.en-US.md
@@ -107,58 +107,6 @@ export default App;
 
 :::
 
-### Dynamic loading
-
-Support dynamic addition / deletion of pictures
-
-:::demo
-
-```tsx
-import React, { useState, useEffect } from 'react'
-import { Swiper } from '@nutui/nutui-react';
-
-const App = () => {
-  const [defaultValue1, setdefaultValue1] = useState(0)
-  const [height, setHeight] = useState(150)
-  const [list, setList] = useState([
-    'https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg',
-    'https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg',
-    'https://storage.360buyimg.com/jdc-article/welcomenutui.jpg',
-    'https://storage.360buyimg.com/jdc-article/fristfabu.jpg',
-  ])
-  useEffect(() => {
-    setTimeout(() => {
-      list.splice(1, 1)
-      setList(list.splice(1, 1))
-    }, 3000)
-  }, [])
-  return (
-    <div className="demo-box" style={{ height: 150 }}>
-      <Swiper
-        height={height}
-        style={{
-            '--nutui-indicator-color': '#426543',
-            '--nutui-indicator-dot-color': '#426ddd',
-          }}
-        autoPlay="3000"
-        defaultValue={defaultValue1}
-        indicator
-      >
-        {list.map((item) => {
-          return (
-            <Swiper.Item key={item}>
-              <img src={item} alt="" />
-            </Swiper.Item>
-          )
-        })}
-      </Swiper>
-    </div>
-  )
-}
-export default App;
-```
-
-:::
 
 ### Custom size
 

--- a/src/packages/swiper/doc.md
+++ b/src/packages/swiper/doc.md
@@ -107,58 +107,6 @@ export default App;
 
 :::
 
-### 动态加载
-
-支持动态增加/删除图片
-
-:::demo
-
-```tsx
-import React, { useState, useEffect } from 'react'
-import { Swiper } from '@nutui/nutui-react';
-
-const App = () => {
-  const [defaultValue1, setdefaultValue1] = useState(0)
-  const [height, setHeight] = useState(150)
-  const [list, setList] = useState([
-    'https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg',
-    'https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg',
-    'https://storage.360buyimg.com/jdc-article/welcomenutui.jpg',
-    'https://storage.360buyimg.com/jdc-article/fristfabu.jpg',
-  ])
-  useEffect(() => {
-    setTimeout(() => {
-      list.splice(1, 1)
-      setList(list.splice(1, 1))
-    }, 3000)
-  }, [])
-  return (
-    <div className="demo-box" style={{ height: 150 }}>
-      <Swiper
-        height={height}
-        style={{
-            '--nutui-indicator-color': '#426543',
-            '--nutui-indicator-dot-color': '#426ddd',
-          }}
-        autoPlay="3000"
-        defaultValue={defaultValue1}
-        indicator
-      >
-        {list.map((item) => {
-          return (
-            <Swiper.Item key={item}>
-              <img src={item} alt="" />
-            </Swiper.Item>
-          )
-        })}
-      </Swiper>
-    </div>
-  )
-}
-export default App;
-```
-
-:::
 
 ### 自定义大小
 

--- a/src/packages/swiper/doc.zh-TW.md
+++ b/src/packages/swiper/doc.zh-TW.md
@@ -107,58 +107,6 @@ export default App;
 
 :::
 
-### 動態加載
-
-支持動態增加/刪除圖片
-
-:::demo
-
-```tsx
-import React, { useState, useEffect } from 'react'
-import { Swiper } from '@nutui/nutui-react';
-
-const App = () => {
-  const [defaultValue1, setdefaultValue1] = useState(0)
-  const [height, setHeight] = useState(150)
-  const [list, setList] = useState([
-    'https://storage.360buyimg.com/jdc-article/NutUItaro34.jpg',
-    'https://storage.360buyimg.com/jdc-article/NutUItaro2.jpg',
-    'https://storage.360buyimg.com/jdc-article/welcomenutui.jpg',
-    'https://storage.360buyimg.com/jdc-article/fristfabu.jpg',
-  ])
-  useEffect(() => {
-    setTimeout(() => {
-      list.splice(1, 1)
-      setList(list.splice(1, 1))
-    }, 3000)
-  }, [])
-  return (
-    <div className="demo-box" style={{ height: 150 }}>
-      <Swiper
-        height={height}
-        style={{
-            '--nutui-indicator-color': '#426543',
-            '--nutui-indicator-dot-color': '#426ddd',
-          }}
-        autoPlay="3000"
-        defaultValue={defaultValue1}
-        indicator
-      >
-        {list.map((item) => {
-          return (
-            <Swiper.Item key={item}>
-              <img src={item} alt="" />
-            </Swiper.Item>
-          )
-        })}
-      </Swiper>
-    </div>
-  )
-}
-export default App;
-```
-
-:::
 
 ### 自定義大小
 

--- a/src/packages/swiper/swiper.tsx
+++ b/src/packages/swiper/swiper.tsx
@@ -152,10 +152,12 @@ export const Swiper = React.forwardRef<
     resetPosition()
     touch.reset()
     requestAniFrame(() => {
-      swiperRef.current.moving = false
-      move({
-        pace: -1,
-        isEmit: true,
+      requestAniFrame(() => {
+        swiperRef.current.moving = false
+        move({
+          pace: -1,
+          isEmit: true,
+        })
       })
     })
   }
@@ -164,10 +166,12 @@ export const Swiper = React.forwardRef<
     resetPosition()
     touch.reset()
     requestAniFrame(() => {
-      swiperRef.current.moving = false
-      move({
-        pace: 1,
-        isEmit: true,
+      requestAniFrame(() => {
+        swiperRef.current.moving = false
+        move({
+          pace: 1,
+          isEmit: true,
+        })
       })
     })
   }
@@ -176,16 +180,18 @@ export const Swiper = React.forwardRef<
     resetPosition()
     touch.reset()
     requestAniFrame(() => {
-      swiperRef.current.moving = false
-      let targetIndex
-      if (props.loop && swiperItemCount === index) {
-        targetIndex = active === 0 ? 0 : index
-      } else {
-        targetIndex = index % swiperItemCount
-      }
-      move({
-        pace: targetIndex - active,
-        isEmit: true,
+      requestAniFrame(() => {
+        swiperRef.current.moving = false
+        let targetIndex
+        if (props.loop && swiperItemCount === index) {
+          targetIndex = active === 0 ? 0 : index
+        } else {
+          targetIndex = index % swiperItemCount
+        }
+        move({
+          pace: targetIndex - active,
+          isEmit: true,
+        })
       })
     })
   }

--- a/src/packages/swiper/swiper.tsx
+++ b/src/packages/swiper/swiper.tsx
@@ -281,6 +281,7 @@ export const Swiper = React.forwardRef<
   })
   const getStyle = (moveOffset = offset) => {
     const target = innerRef.current
+    if (!target) return
     let _offset = 0
     if (!center) {
       _offset = moveOffset

--- a/src/packages/swiper/swiper.tsx
+++ b/src/packages/swiper/swiper.tsx
@@ -412,11 +412,6 @@ export const Swiper = React.forwardRef<
   }, [ready])
 
   useEffect(() => {
-    stopAutoPlay()
-    startPlay()
-  }, [children])
-
-  useEffect(() => {
     const events = [
       { name: 'touchstart', e: onTouchStart },
       { name: 'touchmove', e: onTouchMove },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

1.swiper 自动轮播在一轮结束后，第二轮轮播到第二帧出现跳帧

2.使用 countdown 和 swiper，swiper 无法自动轮播，因为组件中的状态变更，会重新渲染，由于 swiper 监听 children 变化，导致状态取消了自动轮播

### 💡 需求背景和解决方案

针对第二个问题，需要去掉对 children，并调整了相关的 demo，动态加载和异步加载可以借鉴异步加载的方式处理。
