### PR TITLE
fix(infiniteloading): 解决infiniteloading触发点击操作后再滑动时，滑动操作异常的问题

### DIFF
--- a/src/packages/infiniteloading/infiniteloading.taro.tsx
+++ b/src/packages/infiniteloading/infiniteloading.taro.tsx
@@ -151,6 +151,7 @@ export const InfiniteLoading: FunctionComponent<
     if (distance.current < refreshMaxH.current) {
       distance.current = 0
       setTopDisScoll(0)
+      isTouching.current = false
     } else {
       await onRefresh?.()
       refreshDone()

--- a/src/packages/infiniteloading/infiniteloading.tsx
+++ b/src/packages/infiniteloading/infiniteloading.tsx
@@ -160,6 +160,7 @@ export const InfiniteLoading: FunctionComponent<
     if (distance.current < refreshMaxH.current) {
       distance.current = 0
       getRefreshTop().style.height = `${distance.current}px`
+      isTouching.current = false
     } else {
       await onRefresh?.()
       refreshDone()


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
下拉加载组件启用时，在页面顶部点击某个元素后，触发了touchstart、touchend事件，但是touchend中if条件内未将isTouching.current重置为false，导致再次滑动页面时，滑动距离的计算还是基于之前点击的元素来计算的，导致滑动距离计算异常，带来了异常的滑动体验，详见以下视频
操作顺序：
1、点击顶部用户信息的文字
2、滑动下面的内容，从下往上滑，但是看到的效果却是触发了下拉刷新


https://github.com/jdf2e/nutui-react/assets/18415185/f0571bf0-981f-4b54-a879-231bf2be6063



<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
