### PR TITLE
fix(actionsheet): 关闭弹窗后内容显示在页面，优化 popup 相关属性传递

### DIFF
--- a/src/packages/actionsheet/actionsheet.taro.tsx
+++ b/src/packages/actionsheet/actionsheet.taro.tsx
@@ -56,6 +56,7 @@ export const ActionSheet: FunctionComponent<
 
   return (
     <Popup
+      {...rest}
       round
       visible={visible}
       position="bottom"

--- a/src/packages/actionsheet/actionsheet.tsx
+++ b/src/packages/actionsheet/actionsheet.tsx
@@ -56,6 +56,7 @@ export const ActionSheet: FunctionComponent<
 
   return (
     <Popup
+      {...rest}
       round
       visible={visible}
       position="bottom"
@@ -66,7 +67,7 @@ export const ActionSheet: FunctionComponent<
         onCancel && onCancel()
       }}
     >
-      <div className={`${className}`} style={style} {...rest}>
+      <div className={`${className}`} style={style}>
         {options.length ? (
           <div className={`${classPrefix}-list`}>
             {options.map((item, index) => {

--- a/src/packages/popup/popup.scss
+++ b/src/packages/popup/popup.scss
@@ -307,7 +307,9 @@
     &-right-exit-done,
     &-top-exit-done,
     &-bottom-exit-done {
-      display: none;
+      &.nut-popup {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

无。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


https://github.com/jdf2e/nutui-react/assets/9999765/eb31d823-5a26-4a1b-9d5c-3e230f7700d0

#### 问题原因

项目打包后 CSS 顺序混乱，`.nut-actionsheet` 权重高于 `.nut-popup-slide-bottom-exit-done`，在 src/packages/popup/popup.scss 中加重退出时样式权重。

按照 TypeScript 提供的类型，可以使用 Popup 的 `destroyOnClose` 属性规避这个问题，但是 `ActionSheet` 内部传递属性有点小问题，Taro 代码没有使用 `rest` 对象，React 代码放的地方不合适（这部分需要 Review 一下）。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
