### PR TITLE
chore(dev): development mode, remove duplicate CSS stylesheets

### DIFF
--- a/src/sites/mobile/Links.scss
+++ b/src/sites/mobile/Links.scss
@@ -1,4 +1,4 @@
-@import '@/sites/assets/styles/reset.scss';
+//@import '@/sites/assets/styles/reset.scss';
 .index {
   height: 100%;
   width: 100%;

--- a/src/sites/mobile/Links.tsx
+++ b/src/sites/mobile/Links.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import './Links.scss'
+import '../assets/styles/reset.scss'
 import { Link } from 'react-router-dom'
 import { ArrowRight } from '@nutui/icons-react'
 import pkg from '../../config.json'

--- a/src/sites/mobile/main.tsx
+++ b/src/sites/mobile/main.tsx
@@ -3,6 +3,9 @@ import * as ReactDOM from 'react-dom/client'
 import App from './App'
 import '@nutui/touch-emulator' // 适配 h5 示例桌面端预览
 import { isMobile } from '@/sites/assets/util'
+
+import(`../../styles/font${__PROJECTID__}/iconfont.css`)
+import(`../../styles/theme${__PROJECTID__ || '-default'}.scss`)
 import('../../packages/nutui.react.scss')
 
 const rootElement = document.querySelector('#app')

--- a/src/styles/variables-jmapp.scss
+++ b/src/styles/variables-jmapp.scss
@@ -1386,6 +1386,10 @@ $radiogroup-radio-margin: var(
   --nutui-radiogroup-radio-margin,
   0 20px 5px 0
 ) !default;
+$radiogroup-radio-margin-bottom: var(
+  --nutui-radiogroup-radio-margin,
+  5px
+) !default;
 $radiogroup-radio-label-margin: var(
   --nutui-radiogroup-radio-label-margin,
   0 5px 0 5px

--- a/vite.config.build.site.ts
+++ b/vite.config.build.site.ts
@@ -5,10 +5,10 @@ import atImport from 'postcss-import'
 import config from './package.json'
 
 const { resolve } = path
-let fileStr = `@import "@/styles/variables.scss";@import '@/styles/theme-default.scss';\n`
+let fileStr = `@import "@/styles/variables.scss";\n`
 const projectID = process.env.VITE_APP_PROJECT_ID
 if (projectID) {
-  fileStr = `@import '@/styles/variables-${projectID}.scss';@import '@/styles/theme-${projectID}.scss';\n`
+  fileStr = `@import '@/styles/variables-${projectID}.scss';\n`
 }
 
 // https://vitejs.dev/config/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
     reactRefresh(),
     {
       name: 'test',
+      apply: 'serve',
       async load(id) {
         if (id.endsWith('.scss')) {
           // 移除 @import 语句


### PR DESCRIPTION
### 🤔 这个变动的性质是？


- [x] 站点、文档改进
- [x] 演示代码改进

### 🔗 相关 Issue

在开发环境下，由于使用 scss 的 additionalData，会导致 additionalData 重复插入页面，增加样式在控制台的调试。

### 💡 需求背景和解决方案

将 additionalData 由 js 导入，去除主题变量的重复插入。

通过 vite 插件，在 reslove 阶段移除 import 的 scss 文件。


