### PR TITLE
fix(elevator): 解决部分安卓手机右侧导航高亮偏差问题

### DIFF
--- a/src/packages/elevator/elevator.tsx
+++ b/src/packages/elevator/elevator.tsx
@@ -177,7 +177,8 @@ export const Elevator: FunctionComponent<
       calculateHeight()
     }
     const target = e.target as Element
-    const { scrollTop } = target
+    let { scrollTop } = target
+    scrollTop = Math.ceil(scrollTop)
     state.current.scrollY = scrollTop
     setScrollY(scrollTop)
     for (let i = 0; i < listHeight.length - 1; i++) {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？


- [x] 日常 bug 修复


### 🔗 相关 Issue

部分安卓机型下，索引列高亮偏移

### 💡 需求背景和解决方案

部分安卓机型下返回的 scrollTop 存在精度问题，通过 Math.ceil 尝试解决.
点击实际滑动的距离是65，但是安卓获取到的64.90xxxxxx


