### PR TITLE
feat(dialog): support confirm button loading effect

### DIFF
--- a/src/packages/dialog/__test__/dialog.spec.tsx
+++ b/src/packages/dialog/__test__/dialog.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Dialog } from '../dialog'
 
@@ -117,4 +117,25 @@ test('dialog close icon  position adjustment', async () => {
   fireEvent.click(closeBtn)
   expect(onClose).toBeCalled()
   expect(onCancel).toBeCalled()
+})
+
+test('should display loading when onConfirm returns a promise', async () => {
+  const mockOnConfirm = jest.fn(
+    () =>
+      new Promise((resolve) => {
+        setTimeout(resolve, 1000)
+      })
+  )
+  const { container } = render(<Dialog visible onConfirm={mockOnConfirm} />)
+
+  const footerOkEle = container.querySelector('.nut-dialog-footer-ok')!
+  fireEvent.click(footerOkEle)
+
+  expect(footerOkEle).toHaveClass('nut-button-loading')
+
+  await waitFor(() => {
+    expect(footerOkEle).not.toHaveClass('nut-button-loading')
+  })
+
+  expect(mockOnConfirm).toHaveBeenCalled()
 })

--- a/src/packages/dialog/config.ts
+++ b/src/packages/dialog/config.ts
@@ -29,7 +29,7 @@ export interface DialogBasicProps extends BasicComponent {
   beforeClose?: () => boolean
   beforeCancel?: () => boolean
   onClose?: () => void
-  onConfirm?: (e?: MouseEvent<HTMLButtonElement>) => Promise<void> | void
+  onConfirm?: (e?: MouseEvent<HTMLButtonElement>) => PromiseLike<any> | void
   onCancel?: () => void
   onClick?: () => void
   onOverlayClick?: () => void

--- a/src/packages/dialog/config.ts
+++ b/src/packages/dialog/config.ts
@@ -29,7 +29,7 @@ export interface DialogBasicProps extends BasicComponent {
   beforeClose?: () => boolean
   beforeCancel?: () => boolean
   onClose?: () => void
-  onConfirm?: (e?: MouseEvent<HTMLButtonElement>) => Promise<() => void> | void
+  onConfirm?: (e?: MouseEvent<HTMLButtonElement>) => Promise<void> | void
   onCancel?: () => void
   onClick?: () => void
   onOverlayClick?: () => void

--- a/src/packages/dialog/confirm.tsx
+++ b/src/packages/dialog/confirm.tsx
@@ -51,7 +51,7 @@ const confirm = (
     const ret = _onConfirm?.()
     if (ret && ret.then) {
       renderFunction(dialogConfig)
-      ret.then(
+      return ret.then(
         () => {
           onCancel(true)
         },

--- a/src/packages/dialog/demo.taro.tsx
+++ b/src/packages/dialog/demo.taro.tsx
@@ -25,6 +25,7 @@ interface T {
   customClose: string
   customContent: string
   customContentText: string
+  confirmLoading: string
 }
 
 const DialogDemo = () => {
@@ -50,6 +51,7 @@ const DialogDemo = () => {
       customContent: '自定义内容区域',
       customContentText:
         '文字内容文字内容文字内容文字内容文字内容文字内容文字内容文字内容',
+      confirmLoading: '确认按钮loading效果',
     },
     'en-US': {
       basic: 'Basic Usage',
@@ -73,6 +75,7 @@ const DialogDemo = () => {
       customContent: 'Customize the content area',
       customContentText:
         'Text content text content text content text content text content text content text content text content text content.',
+      confirmLoading: 'Confirm button loading effect',
     },
   })
 
@@ -87,6 +90,7 @@ const DialogDemo = () => {
   const [visible9, setVisible9] = useState(false)
   const [visible10, setVisible10] = useState(false)
   const [visible11, setVisible11] = useState(false)
+  const [visible12, setVisible12] = useState(false)
 
   return (
     <>
@@ -276,6 +280,34 @@ const DialogDemo = () => {
               {translated.customContent}
             </div>
           </>
+        </Dialog>
+        <Cell
+          title={translated.confirmLoading}
+          onClick={() => {
+            setVisible12(true)
+          }}
+        />
+        <Dialog
+          className="test-dialog"
+          title={translated.confirmLoading}
+          visible={visible12}
+          onConfirm={async () => {
+            const wait = () => {
+              return new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve(0)
+                }, 3000)
+              })
+            }
+            await wait()
+            setVisible12(false)
+          }}
+          onCancel={() => setVisible12(false)}
+          style={{
+            '--nutui-dialog-close-color': '#FFFFFF',
+          }}
+        >
+          {translated.content}
         </Dialog>
       </div>
     </>

--- a/src/packages/dialog/demo.tsx
+++ b/src/packages/dialog/demo.tsx
@@ -26,6 +26,7 @@ interface T {
   customClose: string
   customContent: string
   customContentText: string
+  confirmLoading: string
 }
 
 const DialogDemo = () => {
@@ -52,6 +53,7 @@ const DialogDemo = () => {
       customContent: '自定义内容区域',
       customContentText:
         '文字内容文字内容文字内容文字内容文字内容文字内容文字内容文字内容.',
+      confirmLoading: '确认按钮loading效果',
     },
     'en-US': {
       funUse: 'Function use',
@@ -76,6 +78,7 @@ const DialogDemo = () => {
       customContent: 'Customize the content area',
       customContentText:
         'Text content text content text content text content text content text content text content text content text content.',
+      confirmLoading: 'Confirm button loading effect',
     },
   })
 
@@ -89,6 +92,7 @@ const DialogDemo = () => {
   const [visible8, setVisible8] = useState(false)
   const [visible9, setVisible9] = useState(false)
   const [visible10, setVisible10] = useState(false)
+  const [visible11, setVisible11] = useState(false)
 
   return (
     <>
@@ -348,6 +352,34 @@ const DialogDemo = () => {
               {translated.customContent}
             </div>
           </>
+        </Dialog>
+        <Cell
+          title={translated.confirmLoading}
+          onClick={() => {
+            setVisible11(true)
+          }}
+        />
+        <Dialog
+          className="test-dialog"
+          title={translated.confirmLoading}
+          visible={visible11}
+          onConfirm={async () => {
+            const wait = () => {
+              return new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve(0)
+                }, 3000)
+              })
+            }
+            await wait()
+            setVisible11(false)
+          }}
+          onCancel={() => setVisible11(false)}
+          style={{
+            '--nutui-dialog-close-color': '#FFFFFF',
+          }}
+        >
+          {translated.content}
         </Dialog>
       </div>
     </>

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useState } from 'react'
 import type { MouseEvent } from 'react'
 import classNames from 'classnames'
 import { CSSTransition } from 'react-transition-group'
@@ -46,6 +46,7 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
 } = (props) => {
   const classPrefix = 'nut-dialog'
   const { locale } = useConfig()
+  const [loading, setLoading] = useState(false)
 
   const {
     params: {
@@ -101,10 +102,16 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
       onCancel?.()
     }
 
-    const handleOk = (e: MouseEvent<HTMLButtonElement>) => {
+    const handleOk = async (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()
-      onClose?.()
-      onConfirm?.(e)
+      setLoading(true)
+      try {
+        await onConfirm?.(e)
+        setLoading(false)
+        onClose?.()
+      } catch {
+        setLoading(false)
+      }
     }
 
     return (
@@ -127,6 +134,7 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
               })}
               disabled={disableConfirmButton}
               onClick={(e) => handleOk(e)}
+              loading={loading}
             >
               {confirmText || locale.confirm}
             </Button>

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefRenderFunction, forwardRef } from 'react'
+import React, { ForwardRefRenderFunction, forwardRef, useState } from 'react'
 import type { MouseEvent } from 'react'
 import classNames from 'classnames'
 import { Close } from '@nutui/icons-react'
@@ -57,6 +57,7 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
     ...restProps
   } = props
   const classPrefix = 'nut-dialog'
+  const [loading, setLoading] = useState(false)
 
   const renderFooter = () => {
     if (footer === null) return ''
@@ -69,10 +70,16 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
       onCancel?.()
     }
 
-    const handleOk = (e: MouseEvent<HTMLButtonElement>) => {
+    const handleOk = async (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()
-      onClose?.()
-      onConfirm?.(e)
+      setLoading(true)
+      try {
+        await onConfirm?.(e)
+        setLoading(false)
+        onClose?.()
+      } catch {
+        setLoading(false)
+      }
     }
 
     return (
@@ -95,6 +102,7 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
               })}
               disabled={disableConfirmButton}
               onClick={(e) => handleOk(e)}
+              loading={loading}
             >
               {confirmText || locale.confirm}
             </Button>

--- a/src/packages/dialog/doc.en-US.md
+++ b/src/packages/dialog/doc.en-US.md
@@ -225,6 +225,28 @@ const App = () => {
             </div>
           </>
         </Dialog>
+        <Dialog
+          className="test-dialog"
+          title="Confirm button loading effect"
+          visible={visible10}
+          onConfirm={async () => {
+            const wait = () => {
+              return new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve(0)
+                }, 3000)
+              })
+            }
+            await wait()
+            setVisible10(false)
+          }}
+          onCancel={() => setVisible10(false)}
+          style={{
+            '--nutui-dialog-close-color': '#FFFFFF',
+          }}
+        >
+          {translated.content}
+        </Dialog>
     </>
   )
 }

--- a/src/packages/dialog/doc.md
+++ b/src/packages/dialog/doc.md
@@ -251,6 +251,28 @@ const App = () => {
             </div>
           </>
         </Dialog>
+        <Dialog
+          className="test-dialog"
+          title="确认按钮loading效果"
+          visible={visible10}
+          onConfirm={async () => {
+            const wait = () => {
+              return new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve(0)
+                }, 3000)
+              })
+            }
+            await wait()
+            setVisible10(false)
+          }}
+          onCancel={() => setVisible10(false)}
+          style={{
+            '--nutui-dialog-close-color': '#FFFFFF',
+          }}
+        >
+          {translated.content}
+        </Dialog>
     </>
   )
 }

--- a/src/packages/dialog/doc.taro.md
+++ b/src/packages/dialog/doc.taro.md
@@ -238,6 +238,28 @@ const App = () => {
             </div>
           </>
         </Dialog>
+        <Dialog
+          className="test-dialog"
+          title="确认按钮loading效果"
+          visible={visible10}
+          onConfirm={async () => {
+            const wait = () => {
+              return new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve(0)
+                }, 3000)
+              })
+            }
+            await wait()
+            setVisible10(false)
+          }}
+          onCancel={() => setVisible10(false)}
+          style={{
+            '--nutui-dialog-close-color': '#FFFFFF',
+          }}
+        >
+          {translated.content}
+        </Dialog>
     </>
   )
 }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[https://github.com/jdf2e/nutui-react/issues/1202](https://github.com/jdf2e/nutui-react/issues/1202)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Dialog确定按钮通常进行请求接口操作，此时增加loading效果可以提高交互体验。
类似antd PopConfirm组件那样，onConfirm支持传入一个Promise函数，在Promise pendding时显示loading效果。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
