### PR TITLE
fix(virtuallist): 修复 vitrual list 组件 Taro 下获取窗口高度不正确的问题

### DIFF
--- a/src/packages/virtuallist/virtuallist.taro.tsx
+++ b/src/packages/virtuallist/virtuallist.taro.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -13,7 +14,7 @@ import { Data, PositionType } from './types'
 import { initPositinoCache, updateItemSize } from './utils'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 
-const clientHeight = getSystemInfoSync().windowHeight - 5 || 667
+const defaultContainerHeight = getSystemInfoSync().windowHeight - 5 || 667
 
 export interface VirtualListProps extends BasicComponent {
   list: Array<Data>
@@ -30,7 +31,7 @@ export interface VirtualListProps extends BasicComponent {
 const defaultProps = {
   ...ComponentDefaults,
   list: [] as Array<Data>,
-  containerHeight: clientHeight,
+  containerHeight: defaultContainerHeight,
   itemHeight: 66,
   margin: 10,
   itemEqual: true,
@@ -78,6 +79,11 @@ export const VirtualList: FunctionComponent<Partial<VirtualListProps>> = (
   ])
 
   const [offSetSize, setOffSetSize] = useState<number>(containerHeight || 0)
+
+  const clientHeight = useMemo(
+    () => getSystemInfoSync().windowHeight - 5 || 667,
+    []
+  )
 
   //   初始计算可视区域展示数量
   useEffect(() => {

--- a/src/packages/virtuallist/virtuallist.taro.tsx
+++ b/src/packages/virtuallist/virtuallist.taro.tsx
@@ -14,8 +14,6 @@ import { Data, PositionType } from './types'
 import { initPositinoCache, updateItemSize } from './utils'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 
-const defaultContainerHeight = getSystemInfoSync().windowHeight - 5 || 667
-
 export interface VirtualListProps extends BasicComponent {
   list: Array<Data>
   containerHeight: number
@@ -31,7 +29,6 @@ export interface VirtualListProps extends BasicComponent {
 const defaultProps = {
   ...ComponentDefaults,
   list: [] as Array<Data>,
-  containerHeight: defaultContainerHeight,
   itemHeight: 66,
   margin: 10,
   itemEqual: true,
@@ -51,12 +48,22 @@ export const VirtualList: FunctionComponent<Partial<VirtualListProps>> = (
     key,
     onScroll,
     className,
-    containerHeight,
+    containerHeight: origContainerHeight,
     ...rest
   } = {
     ...defaultProps,
     ...props,
   }
+
+  const clientHeight = useMemo(
+    () => getSystemInfoSync().windowHeight - 5 || 667,
+    []
+  )
+
+  const containerHeight = useMemo(
+    () => origContainerHeight ?? clientHeight,
+    [origContainerHeight, clientHeight]
+  )
 
   const [startOffset, setStartOffset] = useState(0)
   const start = useRef(0)
@@ -79,11 +86,6 @@ export const VirtualList: FunctionComponent<Partial<VirtualListProps>> = (
   ])
 
   const [offSetSize, setOffSetSize] = useState<number>(containerHeight || 0)
-
-  const clientHeight = useMemo(
-    () => getSystemInfoSync().windowHeight - 5 || 667,
-    []
-  )
 
   //   初始计算可视区域展示数量
   useEffect(() => {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

`getSystemInfoSync().windowHeight`  方法返回的值减去了底部 Tabbar 的高度

业务中小程序中非顶级页面不显示底部 Tabbar，而原先的写法中 `clientHeight` 的计算时机是在项目初始化时，所得的值减去了底部 Tabbar 的值。所以在不带有 Tabbar 的非顶级页面下导致 virtualList 内部的 scrollView 高度少了一截。

尝试在组件组件被渲染时再计算 `clientHeight`，使用 `useMemo` 减少不必要的重复调用。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
