### PR TITLE
fix(badge): 修复value传入0时显示不正确的问题

### DIFF
--- a/src/packages/badge/badge.taro.tsx
+++ b/src/packages/badge/badge.taro.tsx
@@ -31,7 +31,7 @@ export const Badge: FunctionComponent<Partial<BadgeProps>> = (props) => {
   const classes = classNames(classPrefix, className)
 
   function content() {
-    if (dot || typeof value === 'object') return null
+    if (dot || typeof value === 'object' || value === 0) return null
     if (typeof value === 'number' && typeof max === 'number') {
       return max < value ? `${max}+` : `${value}`
     }

--- a/src/packages/badge/badge.tsx
+++ b/src/packages/badge/badge.tsx
@@ -31,7 +31,7 @@ export const Badge: FunctionComponent<Partial<BadgeProps>> = (props) => {
   const classes = classNames(classPrefix, className)
 
   function content() {
-    if (dot || typeof value === 'object') return null
+    if (dot || typeof value === 'object' || value === 0) return null
     if (typeof value === 'number' && typeof max === 'number') {
       return max < value ? `${max}+` : `${value}`
     }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
目前Badge组件value传入0时会在下方显示一个0，预期应为不显示徽标
![微信图片_20240311182732](https://github.com/jdf2e/nutui-react/assets/58927554/287469a3-fa12-412a-a6fd-5b56c9346774)


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
