### PR TITLE
fix: menuitem 的 value 更新后，数据无法更新

### DIFF
--- a/src/packages/menuitem/menuitem.tsx
+++ b/src/packages/menuitem/menuitem.tsx
@@ -75,6 +75,14 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     setShowPopup(showPopup)
   }, [showPopup])
   useEffect(() => {
+    setValue(value)
+    options?.map((option) => {
+      if (option.value === value) {
+        setTitle(option.text)
+      }
+    })
+  }, [value])
+  useEffect(() => {
     getParentOffset()
   }, [_showPopup])
 


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？


- [x] 日常 bug 修复

### 🔗 相关 Issue

```tsx
  const [applystatus, setApplystatus] = useState(4)
  const [applyDateScopeType, setApplyDateScopeType] = useState(1)
  const [isApplyFailStatus, setIsApplyFailStatus] = useState(false)
  const statusList = [
    { text: '全部', value: 0 },
    { text: '成功', value: 4 },
    { text: '失败', value: 3 },
    { text: '待出库返还', value: 6 },
  ]
  const currYear = new Date().getFullYear()
  const recordTimeList = [
    { text: '近三个月', value: 1 },
    { text: '今年', value: 2 },
    { text: `${currYear - 1}年`, value: 3 },
    { text: `${currYear - 2}年`, value: 4 },
  ]
  const failRecordTimeList = [
    { text: '近三个月', value: 1 },
    { text: '今年', value: 2 },
  ]
const onStatusMenuChange = (val: { text: string; value: number }) => {
    if (val.value) {
      setApplystatus(val.value)
    } else setApplystatus('')
    if (val.value == 3) {
      setApplyDateScopeType(1)
      setIsApplyFailStatus(true)
    } else setIsApplyFailStatus(false)
  }
  const onTimeMenuChange = (val: { text: string; value: number }) => {
    setApplyDateScopeType(val.value)

  }

	<Menu>
          <MenuItem options={statusList} value={applystatus} onChange={onStatusMenuChange} key={1} />
          <MenuItem
            options={isApplyFailStatus ? failRecordTimeList : recordTimeList}
            value={applyDateScopeType}
            onChange={onTimeMenuChange}
            key={2}
          />
        </Menu>
```

在成功菜单中选择了 年份，切换到 失败菜单，应该更新失败菜单后面对应的选项。

### 💡 需求背景和解决方案

需要根据 value 重新设置内部状态

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
