### PR TITLE
fix(ellipsis): 修复设置行数超过内容高度时只显示一行内容的问题

### DIFF
--- a/src/packages/ellipsis/ellipsis.taro.tsx
+++ b/src/packages/ellipsis/ellipsis.taro.tsx
@@ -60,6 +60,7 @@ export const Ellipsis: FunctionComponent<
   const maxHeight = useRef(0) // 当行的最大高度
   const [exceeded, setExceeded] = useState(false)
   const [expanded, setExpanded] = useState(false)
+  const [cacled, setCacled] = useState(false)
   const ellipsis = useRef<EllipsisValue>({
     leading: '',
     tailing: '',
@@ -71,7 +72,7 @@ export const Ellipsis: FunctionComponent<
   const lineH = useRef(0) // 当行的最大高度
   const originHeight = useRef(0) // 原始高度
   const refRandomId = useRef(Math.random().toString(36).slice(-8))
-  const widthRef: any = useRef('auto')
+  const widthRef = useRef('auto')
   const widthBase = useRef([14, 10, 7, 8.4, 10]) // 中、英(大)、英(小)、数字、其他字符的基础宽度
   const symbolTextWidth = useRef(widthBase.current[0] * 0.7921)
   const chineseReg = /^[\u4e00-\u9fa5]+$/ // 汉字
@@ -91,6 +92,10 @@ export const Ellipsis: FunctionComponent<
       getSymbolInfo()
       getReference()
     })
+
+    return () => {
+      setCacled(false)
+    }
   }, [content])
 
   // 获取省略号宽度
@@ -157,6 +162,7 @@ export const Ellipsis: FunctionComponent<
     const refe = await getRectByTaro(rootContain.current)
     if (refe.height <= maxHeight.current) {
       setExceeded(false)
+      setCacled(true)
     } else {
       const rowNum = Math.floor(
         content.length / (originHeight.current / lineH.current - 1)
@@ -306,7 +312,8 @@ export const Ellipsis: FunctionComponent<
                 width: `${
                   !Number.isNaN(Number(width)) ? `${width}px` : 'auto'
                 }`,
-                height: '20px',
+                minHeight: '20px',
+                height: cacled ? 'auto' : '20px',
                 overflow: 'hidden',
               }}
             >
@@ -369,7 +376,7 @@ export const Ellipsis: FunctionComponent<
         className="nut-ellipsis-copy"
         ref={rootContain}
         id={`rootContain${refRandomId.current}`}
-        style={{ width: `${widthRef}` }}
+        style={{ width: `${widthRef.current}` }}
       >
         <View>{contentCopy}</View>
       </View>


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[https://github.com/jdf2e/nutui-react/issues/2008](https://github.com/jdf2e/nutui-react/issues/2008)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
设置行数超过内容高度的时候，exceeded === false，之前为了尽可能平滑高度容器写死了20px，所以导致只显示了一行内容。
目前解决方案为计算出是否exceeded前容器高度还是一样20px，计算完成后设置容器高度为'auto'。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
