### PR TITLE
fix(dialog): 关闭按钮默认在底部，24px白色图标

### DIFF
--- a/src/packages/dialog/demos/h5/demo6.tsx
+++ b/src/packages/dialog/demos/h5/demo6.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { Cell, Dialog } from '@nutui/nutui-react'
-import { Close } from '@nutui/icons-react'
 
 const Demo6 = () => {
   const [visible1, setVisible1] = useState(false)
@@ -18,6 +17,10 @@ const Demo6 = () => {
         title="顶部带关闭按钮"
         visible={visible1}
         closeIcon
+        closeIconPosition="top-right"
+        style={{
+          '--nutui-dialog-close-color': '#8c8c8c',
+        }}
         onConfirm={() => setVisible1(false)}
         onCancel={() => setVisible1(false)}
       >
@@ -33,13 +36,9 @@ const Demo6 = () => {
         className="test-dialog"
         title="底部带关闭按钮"
         visible={visible2}
-        closeIcon={<Close width="24px" height="24px" />}
-        closeIconPosition="bottom"
         onConfirm={() => setVisible2(false)}
         onCancel={() => setVisible2(false)}
-        style={{
-          '--nutui-dialog-close-color': '#FFFFFF',
-        }}
+        closeIcon
       >
         支持函数调用和组件调用两种方式。
       </Dialog>

--- a/src/packages/dialog/demos/taro/demo6.tsx
+++ b/src/packages/dialog/demos/taro/demo6.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { Cell, Dialog } from '@nutui/nutui-react-taro'
-import { Close } from '@nutui/icons-react-taro'
 
 const Demo6 = () => {
   const [visible1, setVisible1] = useState(false)
@@ -18,6 +17,10 @@ const Demo6 = () => {
         title="顶部带关闭按钮"
         visible={visible1}
         closeIcon
+        closeIconPosition="top-right"
+        style={{
+          '--nutui-dialog-close-color': '#8c8c8c',
+        }}
         onConfirm={() => setVisible1(false)}
         onCancel={() => setVisible1(false)}
       >
@@ -33,13 +36,9 @@ const Demo6 = () => {
         className="test-dialog"
         title="底部带关闭按钮"
         visible={visible2}
-        closeIcon={<Close width="24px" height="24px" />}
-        closeIconPosition="bottom"
         onConfirm={() => setVisible2(false)}
         onCancel={() => setVisible2(false)}
-        style={{
-          '--nutui-dialog-close-color': '#FFFFFF',
-        }}
+        closeIcon
       >
         支持函数调用和组件调用两种方式。
       </Dialog>

--- a/src/packages/dialog/dialog.scss
+++ b/src/packages/dialog/dialog.scss
@@ -44,6 +44,11 @@
     align-items: center;
     top: $dialog-close-top;
     color: $dialog-close-color;
+    .nut-icon {
+      font-size: 24px;
+      height: 24px;
+      width: 24px;
+    }
 
     &-top-right {
       right: $dialog-close-right;

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -158,7 +158,7 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
     })
     return (
       <View className={closeClasses} onClick={handleCancel}>
-        {React.isValidElement(closeIcon) ? closeIcon : <Close size={24} />}
+        {React.isValidElement(closeIcon) ? closeIcon : <Close />}
       </View>
     )
   }

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -33,7 +33,7 @@ const defaultProps = {
   disableConfirmButton: false,
   footerDirection: 'horizontal',
   lockScroll: true,
-  closeIconPosition: 'top-right',
+  closeIconPosition: 'bottom',
   closeIcon: false,
   beforeCancel: () => true,
   beforeClose: () => true,
@@ -158,7 +158,7 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
     })
     return (
       <View className={closeClasses} onClick={handleCancel}>
-        {React.isValidElement(closeIcon) ? closeIcon : <Close />}
+        {React.isValidElement(closeIcon) ? closeIcon : <Close size={24} />}
       </View>
     )
   }

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -26,7 +26,7 @@ const defaultProps = {
   disableConfirmButton: false,
   footerDirection: 'horizontal',
   lockScroll: true,
-  closeIconPosition: 'top-right',
+  closeIconPosition: 'bottom',
   closeIcon: false,
   beforeCancel: () => true,
   beforeClose: () => true,
@@ -126,7 +126,11 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
     })
     return (
       <div className={closeClasses} onClick={handleCancel}>
-        {React.isValidElement(closeIcon) ? closeIcon : <Close />}
+        {React.isValidElement(closeIcon) ? (
+          closeIcon
+        ) : (
+          <Close height={24} width={24} />
+        )}
       </div>
     )
   }

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -126,11 +126,7 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
     })
     return (
       <div className={closeClasses} onClick={handleCancel}>
-        {React.isValidElement(closeIcon) ? (
-          closeIcon
-        ) : (
-          <Close height={24} width={24} />
-        )}
+        {React.isValidElement(closeIcon) ? closeIcon : <Close />}
       </div>
     )
   }

--- a/src/styles/variables-jmapp.scss
+++ b/src/styles/variables-jmapp.scss
@@ -1323,7 +1323,7 @@ $dialog-vertical-footer-ok-margin-top: var(
   --nutui-dialog-vertical-footer-ok-margin-top,
   5px
 ) !default;
-$dialog-close-color: var(--nutui-dialog-close-color, #8c8c8c) !default;
+$dialog-close-color: var(--nutui-dialog-close-color, #ffffff) !default;
 $dialog-close-width: var(--nutui-dialog-close-width, 18px) !default;
 $dialog-close-height: var(--nutui-dialog-close-height, 18px) !default;
 $dialog-close-top: var(--nutui-dialog-close-top, 16px) !default;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1276,7 +1276,7 @@ $dialog-vertical-footer-ok-margin-top: var(
   --nutui-dialog-vertical-footer-ok-margin-top,
   5px
 ) !default;
-$dialog-close-color: var(--nutui-dialog-close-color, #8c8c8c) !default;
+$dialog-close-color: var(--nutui-dialog-close-color, #ffffff) !default;
 $dialog-close-width: var(--nutui-dialog-close-width, 18px) !default;
 $dialog-close-height: var(--nutui-dialog-close-height, 18px) !default;
 $dialog-close-top: var(--nutui-dialog-close-top, 16px) !default;


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
