### PR TITLE
fix(tabs): 修复 tab 过多时滚动定位不准确的问题

### DIFF
--- a/src/packages/navbar/demos/h5/demo3.tsx
+++ b/src/packages/navbar/demos/h5/demo3.tsx
@@ -24,7 +24,6 @@ const Demo3 = () => {
               setTab1value(paneKey)
             }}
             style={{
-              '--nutui-tabs-titles-padding': 0,
               '--nutui-tabs-titles-gap': 0,
             }}
           >

--- a/src/packages/navbar/demos/taro/demo3.tsx
+++ b/src/packages/navbar/demos/taro/demo3.tsx
@@ -33,7 +33,6 @@ const Demo3 = () => {
               setTab1value(paneKey)
             }}
             style={{
-              '--nutui-tabs-titles-padding': 0,
               '--nutui-tabs-titles-gap': 0,
             }}
           >

--- a/src/packages/tabs/demo.taro.tsx
+++ b/src/packages/tabs/demo.taro.tsx
@@ -82,7 +82,7 @@ const TabsDemo = () => {
   return (
     <>
       <Header />
-      <div className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''} full `}>
+      <div className={`demo ${Taro.getEnv() === 'WEB' ? 'web  full' : ''}`}>
         <h2>{translated.basic}</h2>
         <Demo1 />
         <h2>{translated.title1}</h2>

--- a/src/packages/tabs/doc.en-US.md
+++ b/src/packages/tabs/doc.en-US.md
@@ -241,7 +241,6 @@ The component provides the following CSS variables, which can be used to customi
 | --- | --- | --- |
 | \--nutui-tabs-titles-height | height of titles in horizontal direction | `44px` |
 | \--nutui-tabs-titles-background-color | Tab title background color | `$color-background` |
-| \--nutui-tabs-titles-padding | Tab title padding | `0 16px` |
 | \--nutui-tabs-title-gap | Tab title margin | `0px` |
 | \--nutui-tabs-titles-font-size | Tab title font size | `$font-size-base` |
 | \--nutui-tabs-titles-item-min-width | Minimum width of horizontal titles | `50px` |

--- a/src/packages/tabs/doc.md
+++ b/src/packages/tabs/doc.md
@@ -241,7 +241,6 @@ import { Tabs } from '@nutui/nutui-react';
 | --- | --- | --- |
 | \--nutui-tabs-titles-height | 水平方向标题的高度 | `44px` |
 | \--nutui-tabs-titles-background-color | Tab 标题的背景色 | `$color-background` |
-| \--nutui-tabs-titles-padding | Tab 标题的内边距 | `0 16px` |
 | \--nutui-tabs-title-gap | Tab 标题的左右 margin | `0px` |
 | \--nutui-tabs-titles-font-size | Tab 标题的字号 | `$font-size-base` |
 | \--nutui-tabs-titles-item-min-width | 水平方向标题的最小宽度 | `50px` |

--- a/src/packages/tabs/doc.taro.md
+++ b/src/packages/tabs/doc.taro.md
@@ -239,7 +239,6 @@ import { Tabs } from '@nutui/nutui-react-taro';
 | --- | --- | --- |
 | \--nutui-tabs-titles-height | 水平方向标题的高度 | `44px` |
 | \--nutui-tabs-titles-background-color | Tab 标题的背景色 | `$color-background` |
-| \--nutui-tabs-titles-padding | Tab 标题的内边距 | `0 16px` |
 | \--nutui-tabs-title-gap | Tab 标题的左右 margin | `0px` |
 | \--nutui-tabs-titles-font-size | Tab 标题的字号 | `$font-size-base` |
 | \--nutui-tabs-titles-item-min-width | 水平方向标题的最小宽度 | `50px` |

--- a/src/packages/tabs/doc.zh-TW.md
+++ b/src/packages/tabs/doc.zh-TW.md
@@ -239,7 +239,6 @@ import { Tabs } from '@nutui/nutui-react';
 | --- | --- | --- |
 | \--nutui-tabs-titles-height | 水平方向標題的高度 | `44px` |
 | \--nutui-tabs-titles-background-color | Tab 標題的背景色 | `$color-background` |
-| \--nutui-tabs-titles-padding | Tab 標題的內邊距 | `0 16px` |
 | \--nutui-tabs-title-gap | Tab 標題的左右 margin | `0px` |
 | \--nutui-tabs-titles-font-size | Tab 標題的字號 | `$font-size-base` |
 | \--nutui-tabs-titles-item-min-width | 水平方向標題的最小寬度 | `50px` |

--- a/src/packages/tabs/tabs.scss
+++ b/src/packages/tabs/tabs.scss
@@ -151,7 +151,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 8px;
+        padding: 0 8px;
       }
     }
     .nut-tabs-titles-item-active {

--- a/src/packages/tabs/tabs.scss
+++ b/src/packages/tabs/tabs.scss
@@ -9,7 +9,6 @@
   display: flex;
   box-sizing: border-box;
   height: $tabs-titles-height;
-  padding: $tabs-titles-padding;
   user-select: none;
   overflow: hidden;
   background: $tabs-titles-background-color;
@@ -30,14 +29,14 @@
   &-left {
     justify-content: flex-start;
     .nut-tabs-titles-item {
-      padding: 0 10px;
+      padding: 0 22px;
     }
   }
 
   &-right {
     justify-content: flex-end;
     .nut-tabs-titles-item {
-      padding: 0 10px;
+      padding: 0 22px;
     }
   }
 
@@ -52,7 +51,7 @@
     align-items: center;
     justify-content: center;
     flex: 1 0 auto;
-    margin: 0 $tabs-titles-gap;
+    padding: 0 $tabs-titles-gap;
     height: $tabs-titles-height;
     line-height: $tabs-titles-height;
     min-width: $tabs-titles-item-min-width;
@@ -119,14 +118,6 @@
     &-disabled {
       color: $color-text-disabled;
     }
-
-    &:first-child {
-      margin-left: 0;
-    }
-
-    &:last-child {
-      margin-right: 0;
-    }
   }
 
   &-simple {
@@ -141,7 +132,7 @@
     background-color: $color-default-light;
 
     .nut-tabs-titles-item {
-      margin: 0;
+      padding: 0;
 
       &-active {
         font-weight: $font-weight-bold;
@@ -153,10 +144,18 @@
 
   &-button {
     .nut-tabs-titles-item {
-      &-active {
+      padding: 0 10px;
+      .nut-tabs-titles-item-text {
+        flex: 1;
         height: 28px;
-        margin-top: 8px;
-        margin-bottom: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 8px;
+      }
+    }
+    .nut-tabs-titles-item-active {
+      .nut-tabs-titles-item-text {
         background: $color-default-light;
         color: $color-text;
         border-radius: $tabs-tab-button-border-radius;
@@ -173,7 +172,7 @@
     border-bottom: 1px solid $color-border;
 
     .nut-tabs-titles-item {
-      margin: 0;
+      padding: 0;
       position: relative;
 
       &::after {
@@ -204,10 +203,6 @@
       left: auto;
       right: 50%;
       transform: translate(50%, 0);
-    }
-    &:first-child {
-      margin-left: 0;
-      margin-right: 0;
     }
   }
   &-divider {

--- a/src/packages/tabs/tabs.taro.tsx
+++ b/src/packages/tabs/tabs.taro.tsx
@@ -199,22 +199,14 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
 
         let to = 0
         if (props.direction === 'vertical') {
-          const DEFAULT_PADDING = 11
           const top = titleRects
             .slice(0, index)
-            .reduce(
-              (prev: number, curr: RectItem) => prev + curr.height,
-              DEFAULT_PADDING
-            )
+            .reduce((prev: number, curr: RectItem) => prev + curr.height, 0)
           to = top - (navRectRef.current.height - titleRect.height) / 2
         } else {
-          const DEFAULT_PADDING = 0
           const left = titleRects
             .slice(0, index)
-            .reduce(
-              (prev: number, curr: RectItem) => prev + curr.width,
-              DEFAULT_PADDING
-            )
+            .reduce((prev: number, curr: RectItem) => prev + curr.width, 0)
           to = left - (navRectRef.current.width - titleRect.width) / 2
           to = rtl ? -to : to
         }

--- a/src/packages/tabs/tabs.taro.tsx
+++ b/src/packages/tabs/tabs.taro.tsx
@@ -208,7 +208,7 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
             )
           to = top - (navRectRef.current.height - titleRect.height) / 2
         } else {
-          const DEFAULT_PADDING = 20
+          const DEFAULT_PADDING = 0
           const left = titleRects
             .slice(0, index)
             .reduce(

--- a/src/styles/variables-jmapp.scss
+++ b/src/styles/variables-jmapp.scss
@@ -1683,7 +1683,6 @@ $tabs-titles-background-color: var(
   --nutui-tabs-titles-background-color,
   $white
 ) !default;
-$tabs-titles-padding: var(--nutui-tabs-titles-padding, 0 16px) !default;
 $tabs-titles-gap: var(--nutui-tabs-titles-gap, 12px) !default;
 $tabs-titles-font-size: var(
   --nutui-tabs-titles-font-size,

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1641,7 +1641,6 @@ $tabs-titles-background-color: var(
   --nutui-tabs-titles-background-color,
   $color-background
 ) !default;
-$tabs-titles-padding: var(--nutui-tabs-titles-padding, 0 16px) !default;
 $tabs-titles-gap: var(--nutui-tabs-titles-gap, 12px) !default;
 $tabs-titles-font-size: var(
   --nutui-tabs-titles-font-size,


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

存在的问题：
标题栏滚动时需要计算每一个标题的宽度，获取到的 `nut-tabs-titles-item` 元素的宽度 `rect.width` 中不包含它的 margin 值，计算数据偏小。因此 tab 数量越多，误差越大，后面的 tab 滚动定位不准确。

https://github.com/jdf2e/nutui-react/blob/b7be8ca5d8929b0dff47536167aaa87fd4992b1f/src/packages/tabs/tabs.taro.tsx#L211-L219

修改方式：
将 `nut-tabs-titles-item` 元素的 margin 修改为 padding，此时获取到的宽度是精确的。
在此基础上修改了其他的样式以保证整体展示效果不发生变化。

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [x] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
