### PR TITLE
fix(datepicker): 修复 datepicker 类型为hour-minutes/time时选中值无法回显的问题

### DIFF
--- a/src/packages/datepicker/datepicker.taro.tsx
+++ b/src/packages/datepicker/datepicker.taro.tsx
@@ -215,6 +215,14 @@ export const DatePicker: FunctionComponent<
     }
   }
 
+  const compareDateChange = (currentDate: number, newDate: Date | null) => {
+    const isEqual = new Date(currentDate)?.getTime() === newDate?.getTime()
+    newDate &&
+      isDate(newDate) &&
+      !isEqual &&
+      setSelectedDate(formatValue(newDate as Date))
+  }
+
   const handlePickerChange = (
     selectedOptions: PickerOption[],
     selectedValue: (number | string)[],
@@ -267,11 +275,24 @@ export const DatePicker: FunctionComponent<
         date = new Date(year, month, day, Number(formatDate[3]))
       }
 
-      const isEqual = new Date(selectedDate)?.getTime() === date?.getTime()
-      date &&
-        isDate(date) &&
-        !isEqual &&
-        setSelectedDate(formatValue(date as Date))
+      compareDateChange(selectedDate, date)
+    } else {
+      // 'hour-minutes' 'time'
+      const [hour, minute, seconds] = selectedValue
+      const currentDate = new Date(selectedDate)
+      const year = currentDate.getFullYear()
+      const month = currentDate.getMonth()
+      const day = currentDate.getDate()
+
+      const date = new Date(
+        year,
+        month,
+        day,
+        Number(hour),
+        Number(minute),
+        rangeType === 'time' ? Number(seconds) : 0
+      )
+      compareDateChange(selectedDate, date)
     }
     props.onChange && props.onChange(selectedOptions, selectedValue, index)
   }

--- a/src/packages/datepicker/datepicker.tsx
+++ b/src/packages/datepicker/datepicker.tsx
@@ -215,6 +215,14 @@ export const DatePicker: FunctionComponent<
     }
   }
 
+  const compareDateChange = (currentDate: number, newDate: Date | null) => {
+    const isEqual = new Date(currentDate)?.getTime() === newDate?.getTime()
+    newDate &&
+      isDate(newDate) &&
+      !isEqual &&
+      setSelectedDate(formatValue(newDate as Date))
+  }
+
   const handlePickerChange = (
     selectedOptions: PickerOption[],
     selectedValue: (number | string)[],
@@ -266,12 +274,24 @@ export const DatePicker: FunctionComponent<
       } else if (rangeType === 'datehour') {
         date = new Date(year, month, day, Number(formatDate[3]))
       }
+      compareDateChange(selectedDate, date)
+    } else {
+      // 'hour-minutes' 'time'
+      const [hour, minute, seconds] = selectedValue
+      const currentDate = new Date(selectedDate)
+      const year = currentDate.getFullYear()
+      const month = currentDate.getMonth()
+      const day = currentDate.getDate()
 
-      const isEqual = new Date(selectedDate)?.getTime() === date?.getTime()
-      date &&
-        isDate(date) &&
-        !isEqual &&
-        setSelectedDate(formatValue(date as Date))
+      const date = new Date(
+        year,
+        month,
+        day,
+        Number(hour),
+        Number(minute),
+        rangeType === 'time' ? Number(seconds) : 0
+      )
+      compareDateChange(selectedDate, date)
     }
     props.onChange && props.onChange(selectedOptions, selectedValue, index)
   }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->
问题描述：
v2.5.0下的datepicker组件当类型为hour-minutes/time时选中值无法回显；
https://github.com/jdf2e/nutui-react/assets/53027240/0b78410d-0d93-4c7e-b78e-47cd07b5a783

解决方案：查看对应代码发现这两种类型在picker change的时候并没有做对应的处理，在picker change的时候想要知道的是时分秒的变化因此拿当前的日期拼凑成date与原有的date比较若不同则更新值（taro和h5都有处理）；

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
