### PR TITLE
feat: Input组件的onFocus方法入参增加键盘高度

### DIFF
--- a/src/packages/input/doc.md
+++ b/src/packages/input/doc.md
@@ -148,7 +148,7 @@ import { Input } from '@nutui/nutui-react';
 | formatTrigger | 格式化函数触发的时机，可选值为 `onChange`、`onBlur` | `string` | `-` |
 | onChange | 输入框内容变化时触发 | `(value: string) => void` | `-` |
 | onBlur | 失去焦点后触发 | `(value: string) => void` | `-` |
-| onFocus | 获得焦点后触发 | `(value: string) => void` | `-` |
+| onFocus | 获得焦点后触发 | `(value: string, height?: number) => void` | `-` |
 | onClear | 点击清空按钮时触发 | `(value: string) => void` | `-` |
 | onClick | 点击 input 容器触发 | `(value: MouseEvent<HTMLDivElement>) => void` | `-` |
 

--- a/src/packages/input/input.taro.tsx
+++ b/src/packages/input/input.taro.tsx
@@ -41,7 +41,7 @@ export interface InputProps extends BasicComponent {
   formatter?: (value: string) => void
   onChange?: (value: string) => void
   onBlur?: (value: string) => void
-  onFocus?: (value: string) => void
+  onFocus?: (value: string, height?: number) => void
   onClear?: (value: string) => void
   onClick?: (e: ITouchEvent) => void
 }
@@ -173,7 +173,8 @@ export const Input = forwardRef(
         const val: any = (event.target as any).value
         onFocus && onFocus(val)
       } else {
-        onFocus?.(value)
+        const height = (event.detail || {}).height
+        onFocus?.(value, height)
       }
       setActive(true)
     }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. taro提供的[Input组件](https://taro-docs.jd.com/docs/components/forms/input)，onFocus事件入参包括键盘高度：

  >  输入框聚焦时触发，event.detail = { value, height }，height 为键盘高度

### 💡 需求背景和解决方案

<!--

1. 需求背景：和Taro的Input组件的onFocus入参保持一致
2. 解决方案：在Input的入参中增加height字段

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件