### PR TITLE
fix(CellGroup): 去掉CellGroup组件未单独使用的style属性的参数结构

### DIFF
--- a/src/packages/cellgroup/cellgroup.taro.tsx
+++ b/src/packages/cellgroup/cellgroup.taro.tsx
@@ -23,7 +23,7 @@ const classPrefix = 'nut-cell-group'
 export const CellGroup: FunctionComponent<Partial<CellGroupProps>> = (
   props
 ) => {
-  const { children, className, style, title, description, divider, ...rest } = {
+  const { children, className, title, description, divider, ...rest } = {
     ...defaultProps,
     ...props,
   }

--- a/src/packages/cellgroup/cellgroup.tsx
+++ b/src/packages/cellgroup/cellgroup.tsx
@@ -23,7 +23,7 @@ const classPrefix = 'nut-cell-group'
 export const CellGroup: FunctionComponent<Partial<CellGroupProps>> = (
   props
 ) => {
-  const { children, className, style, title, description, divider, ...rest } = {
+  const { children, className, title, description, divider, ...rest } = {
     ...defaultProps,
     ...props,
   }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

解决cellgroup组件在未单独对style属性做处理的情况，在参数结构是结构了style属性，后面又没有使用，导致设置cellgroup组件的style属性失效的问题。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
