### PR TITLE
style(CellGroup): 给`CellGroup`组件新增外边距样式变量，使得使用者可以自由控制该外边距。

### DIFF
--- a/src/packages/cell/doc.en-US.md
+++ b/src/packages/cell/doc.en-US.md
@@ -126,3 +126,4 @@ The component provides the following CSS variables, which can be used to customi
 | \--nutui-cell-group-description-font-size | The description font size of the cell group | `$font-size-small` |
 | \--nutui-cell-group-description-line-height | The description row height of cell group | `16px` |
 | \--nutui-cell-group-background-color | The background color of the cell group | `$white` |
+| \--nutui-cell-group-wrap-margin | The margin of the cell group wrap | `10px 0` |

--- a/src/packages/cell/doc.md
+++ b/src/packages/cell/doc.md
@@ -128,3 +128,4 @@ import { Cell } from '@nutui/nutui-react'
 | \--nutui-cell-group-description-font-size | 单元格分组的描述字体大小 | `$font-size-small` |
 | \--nutui-cell-group-description-line-height | 单元格分组的描述行高 | `16px` |
 | \--nutui-cell-group-background-color | 单元格分组的背景颜色 | `$white` |
+| \--nutui-cell-group-wrap-margin | 单元格分组容器的外边距 | `10px 0` |

--- a/src/packages/cell/doc.taro.md
+++ b/src/packages/cell/doc.taro.md
@@ -127,3 +127,4 @@ import { Cell } from '@nutui/nutui-react-taro'
 | \--nutui-cell-group-description-font-size | 单元格分组的描述字体大小 | `$font-size-small` |
 | \--nutui-cell-group-description-line-height | 单元格分组的描述行高 | `16px` |
 | \--nutui-cell-group-background-color | 单元格分组的背景颜色 | `$white` |
+| \--nutui-cell-group-wrap-margin | 单元格分组容器的外边距 | `10px 0` |

--- a/src/packages/cell/doc.zh-TW.md
+++ b/src/packages/cell/doc.zh-TW.md
@@ -128,3 +128,4 @@ import { Cell } from '@nutui/nutui-react'
 | \--nutui-cell-group-description-font-size | 單元格分組的描述字體大小 | `$font-size-small` |
 | \--nutui-cell-group-description-line-height | 單元格分組的描述行高 | `16px` |
 | \--nutui-cell-group-background-color | 單元格分組的背景顏色 | `$white` |
+| \--nutui-cell-group-wrap-margin | 單元格分組容器的外邊距 | `10px 0` |

--- a/src/packages/cellgroup/cellgroup.scss
+++ b/src/packages/cellgroup/cellgroup.scss
@@ -26,7 +26,7 @@
     border-radius: $cell-border-radius;
     overflow: hidden;
     background-color: $cell-group-background-color;
-    margin: 10px 0;
+    margin: $cell-group-wrap-margin;
 
     .nut-cell {
       margin: 0;

--- a/src/styles/variables-jmapp.scss
+++ b/src/styles/variables-jmapp.scss
@@ -467,6 +467,8 @@ $cell-group-background-color: var(
   $color-background-overlay
 ) !default;
 
+$cell-group-wrap-margin: var(--nutui-cell-group-wrap-margin, 10px 0) !default;
+
 // divider（✅）
 $divider-margin: var(--nutui-divider-margin, 16px 0) !default;
 $divider-text-font-size: var(

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -437,6 +437,7 @@ $cell-group-background-color: var(
   --nutui-cell-group-background-color,
   $color-background-overlay
 ) !default;
+$cell-group-wrap-margin: var(--nutui-cell-group-wrap-margin, 10px 0) !default;
 
 // divider（✅）
 $divider-margin: var(--nutui-divider-margin, 16px 0) !default;


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 组件样式/交互改进


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

给`CellGroup`组件新增外边距样式变量，使得使用者可以自由控制该外边距。
目前我在使用过程中发现这个外边距无法控制，上下始终是10px，而我在使用的时候想要自己设置这个边距，所以新增了一个变量来控制。
![20240422112859](https://github.com/jdf2e/nutui-react/assets/26473919/45201c16-32fa-4043-860e-0b7ec965d087)


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
