### PR TITLE
feat(dialog): 优化dialog组件，增加 `确认/取消按钮` 属性设置

### DIFF
--- a/src/packages/dialog/config.ts
+++ b/src/packages/dialog/config.ts
@@ -1,6 +1,7 @@
 import { ReactNode, ForwardRefExoticComponent, PropsWithChildren } from 'react'
 import type { MouseEvent } from 'react'
 import { BasicComponent } from '@/utils/typings'
+import type { ButtonProps } from '@/packages/button'
 
 export type DialogConfigType = {
   prefixCls?: string
@@ -16,7 +17,9 @@ export interface DialogBasicProps extends BasicComponent {
   header?: ReactNode
   footer?: ReactNode
   confirmText?: ReactNode
+  confirmButtonProps?: Partial<ButtonProps>
   cancelText?: ReactNode
+  cancelButtonProps?: Partial<ButtonProps>
   overlay?: boolean
   hideConfirmButton?: boolean
   hideCancelButton?: boolean

--- a/src/packages/dialog/demos/h5/demo1.tsx
+++ b/src/packages/dialog/demos/h5/demo1.tsx
@@ -37,6 +37,18 @@ const Demo1 = () => {
         }}
       />
       <Cell
+        title="自定义按钮属性"
+        onClick={() => {
+          Dialog.alert({
+            content: '无标题弹框',
+            confirmText: '确认',
+            confirmButtonProps: { type: 'success', shape: 'square' },
+            cancelText: '取消',
+            cancelButtonProps: { shape: 'square' },
+          })
+        }}
+      />
+      <Cell
         title="底部按钮 垂直布局 使用"
         onClick={() => {
           Dialog.alert({

--- a/src/packages/dialog/demos/taro/demo2.tsx
+++ b/src/packages/dialog/demos/taro/demo2.tsx
@@ -5,6 +5,7 @@ const Demo2 = () => {
   const [visible1, setVisible1] = useState(false)
   const [visible2, setVisible2] = useState(false)
   const [visible3, setVisible3] = useState(false)
+  const [visible4, setVisible4] = useState(false)
   return (
     <>
       <Cell title="基础弹框" onClick={() => setVisible1(true)} />
@@ -37,6 +38,18 @@ const Demo2 = () => {
         lockScroll={false}
         onConfirm={() => setVisible3(false)}
         onCancel={() => setVisible3(false)}
+      >
+        支持函数调用和组件调用两种方式。
+      </Dialog>
+
+      <Cell title="自定义按钮属性" onClick={() => setVisible4(true)} />
+      <Dialog
+        visible={visible4}
+        lockScroll={false}
+        confirmButtonProps={{ type: 'success', shape: 'square' }}
+        cancelButtonProps={{ shape: 'square' }}
+        onConfirm={() => setVisible4(false)}
+        onCancel={() => setVisible4(false)}
       >
         支持函数调用和组件调用两种方式。
       </Dialog>

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -67,7 +67,9 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
       closeOnOverlayClick,
       onOverlayClick,
       confirmText,
+      confirmButtonProps,
       cancelText,
+      cancelButtonProps,
       overlay,
       closeIconPosition,
       closeIcon,
@@ -121,6 +123,7 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
             <Button
               type="default"
               className={`${classPrefix}-footer-cancel`}
+              {...cancelButtonProps}
               onClick={(e) => handleCancel(e)}
             >
               {cancelText || locale.cancel}
@@ -133,8 +136,9 @@ export const BaseDialog: FunctionComponent<Partial<DialogProps>> & {
                 disabled: disableConfirmButton,
               })}
               disabled={disableConfirmButton}
-              onClick={(e) => handleOk(e)}
               loading={loading}
+              {...confirmButtonProps}
+              onClick={(e) => handleOk(e)}
             >
               {confirmText || locale.confirm}
             </Button>

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -46,7 +46,9 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
     disableConfirmButton,
     closeOnOverlayClick,
     confirmText,
+    confirmButtonProps,
     cancelText,
+    cancelButtonProps,
     closeIconPosition,
     closeIcon,
     onClose,
@@ -89,6 +91,7 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
             <Button
               type="default"
               className={`${classPrefix}-footer-cancel`}
+              {...cancelButtonProps}
               onClick={(e) => handleCancel(e)}
             >
               {cancelText || locale.cancel}
@@ -101,8 +104,9 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
                 disabled: disableConfirmButton,
               })}
               disabled={disableConfirmButton}
-              onClick={(e) => handleOk(e)}
               loading={loading}
+              {...confirmButtonProps}
+              onClick={(e) => handleOk(e)}
             >
               {confirmText || locale.confirm}
             </Button>

--- a/src/packages/dialog/doc.en-US.md
+++ b/src/packages/dialog/doc.en-US.md
@@ -91,7 +91,9 @@ import { Dialog } from '@nutui/nutui-react'
 | content | The content of the dialog box is suitable for function calls | `ReactNode` | `-` |
 | footer | Customize the notes, but it will not be displayed in NULL | `ReactNode` | `-` |
 | confirmText | Confirm the button copywriting | `ReactNode` | `Sure` |
+| confirmButtonProps | Confirm button props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | cancelText | Cancellation of buttons | `ReactNode` | `Cancel` |
+| cancelButtonProps | Cancel button props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | overlay | Whether to show a overlay | `boolean` | `true` |
 | hideConfirmButton | Whether to hide the OK button | `boolean` | `false` |
 | hideCancelButton | Whether to hide the cancel button | `boolean` | `false` |

--- a/src/packages/dialog/doc.md
+++ b/src/packages/dialog/doc.md
@@ -91,7 +91,9 @@ import { Dialog } from '@nutui/nutui-react'
 | content | 对话框的内容，适用于函数式调用 | `ReactNode` | `-` |
 | footer | 自定义页脚，传入 null 则不显示 | `ReactNode` | `-` |
 | confirmText | 确认按钮文案 | `ReactNode` | `确定` |
+| confirmButtonProps | 确认按钮 props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | cancelText | 取消按钮文案 | `ReactNode` | `取消` |
+| cancelButtonProps | 取消按钮 props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | overlay | 是否展示遮罩 | `boolean` | `true` |
 | hideConfirmButton | 是否隐藏确定按钮 | `boolean` | `false` |
 | hideCancelButton | 是否隐藏取消按钮 | `boolean` | `false` |

--- a/src/packages/dialog/doc.taro.md
+++ b/src/packages/dialog/doc.taro.md
@@ -91,7 +91,9 @@ import { Dialog } from '@nutui/nutui-react-taro'
 | content | 对话框的内容，适用于函数式调用 | `ReactNode` | `-` |
 | footer | 自定义页脚，传入 null 则不显示 | `ReactNode` | `-` |
 | confirmText | 确认按钮文案 | `ReactNode` | `确定` |
+| confirmButtonProps | 确认按钮 props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | cancelText | 取消按钮文案 | `ReactNode` | `取消` |
+| cancelButtonProps | 取消按钮 props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | overlay | 是否展示遮罩 | `boolean` | `true` |
 | hideConfirmButton | 是否隐藏确定按钮 | `boolean` | `false` |
 | hideCancelButton | 是否隐藏取消按钮 | `boolean` | `false` |

--- a/src/packages/dialog/doc.zh-TW.md
+++ b/src/packages/dialog/doc.zh-TW.md
@@ -91,7 +91,9 @@ import { Dialog } from '@nutui/nutui-react'
 | content | 對話框的內容，適用於函數式調用 | `ReactNode` | `-` |
 | footer | 自定義頁腳，傳入 null 則不顯示 | `ReactNode` | `-` |
 | confirmText | 確認按鈕文案 | `ReactNode` | `確定` |
+| confirmButtonProps | 確認按鈕 props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | cancelText | 取消按鈕文案 | `ReactNode` | `取消` |
+| cancelButtonProps | 取消按鈕 props | [`ButtonProps`](https://nutui.jd.com/h5/react/2x/#/zh-CN/component/button) | `-` |
 | overlay | 是否展示遮罩 | `boolean` | `true` |
 | hideConfirmButton | 是否隱藏確定按鈕 | `boolean` | `false` |
 | hideCancelButton | 是否隱藏取消按鈕 | `boolean` | `false` |


### PR DESCRIPTION
- 对dialog组件新增底部按钮自定义属性

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 组件样式/交互改进

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

增加 `确认/取消按钮` 属性设置。


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
