### PR TITLE
Button Taro版本新增 button原始类型属性支持 Uploader Taro上传组件按钮原始类型设置为type=button

### DIFF
--- a/src/packages/button/button.taro.tsx
+++ b/src/packages/button/button.taro.tsx
@@ -35,6 +35,7 @@ export interface ButtonProps
   disabled: boolean
   icon: React.ReactNode
   rightIcon: React.ReactNode
+  nativeType: 'submit' | 'reset' | 'button'
   onClick: (e: MouseEvent<HTMLButtonElement>) => void
 }
 
@@ -70,6 +71,7 @@ export const Button = React.forwardRef<HTMLButtonElement, Partial<ButtonProps>>(
       children,
       className,
       style,
+      nativeType,
       onClick,
       ...rest
     } = {
@@ -108,6 +110,7 @@ export const Button = React.forwardRef<HTMLButtonElement, Partial<ButtonProps>>(
       <button
         {...rest}
         ref={ref}
+        type={nativeType}
         className={classNames(
           prefixCls,
           `${prefixCls}-${type}`,

--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -491,12 +491,16 @@ const InternalUploader: ForwardRefRenderFunction<
         <div className="nut-uploader-slot">
           <>
             {children || (
-              <Button size="small" type="primary">
+              <Button nativeType="button" size="small" type="primary">
                 上传文件
               </Button>
             )}
             {Number(maxCount) > fileList.length && (
-              <Button className="nut-uploader-input" onClick={_chooseImage} />
+              <Button
+                nativeType="button"
+                className="nut-uploader-input"
+                onClick={_chooseImage}
+              />
             )}
           </>
         </div>
@@ -526,7 +530,11 @@ const InternalUploader: ForwardRefRenderFunction<
               {uploadIcon}
               <span className="nut-uploader-icon-tip">{uploadLabel}</span>
             </div>
-            <Button className="nut-uploader-input" onClick={_chooseImage} />
+            <Button
+              nativeType="button"
+              className="nut-uploader-input"
+              onClick={_chooseImage}
+            />
           </div>
         )}
     </div>


### PR DESCRIPTION
Uploader按钮类型设置，防止Taro打包的H5版本点击上传按钮触发表单提交

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Form表单 Form.Item加上传组件，会触发表单提交事件 [https://github.com/jdf2e/nutui-react/issues/2186](https://github.com/jdf2e/nutui-react/issues/2186)
Taro版本 Button 无法设置 nativeType 按钮原始类型 submit  reset   button，没有属性 [https://github.com/jdf2e/nutui-react/issues/2193](https://github.com/jdf2e/nutui-react/issues/2193)

### 💡 需求背景和解决方案



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件
