### PR TITLE
fix(Dialog): 修复小程序中content内容无法滚动的问题

### DIFF
--- a/src/packages/dialog/content.taro.tsx
+++ b/src/packages/dialog/content.taro.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, ReactNode, HTMLAttributes } from 'react'
 import classNames from 'classnames'
-import { ITouchEvent } from '@tarojs/components'
+import { ITouchEvent, ScrollView } from '@tarojs/components'
 import { BasicComponent } from '@/utils/typings'
 
 interface ContentProps extends BasicComponent {
@@ -63,9 +63,9 @@ export const Content: FunctionComponent<
         style={{ display: visible ? 'flex' : 'none' }}
       >
         {renderHeader()}
-        <div className={`${classPrefix}-content`}>
+        <ScrollView scrollY className={`${classPrefix}-content`}>
           <>{children}</>
-        </div>
+        </ScrollView>
         {renderFooter()}
       </div>
     </div>

--- a/src/packages/dialog/doc.taro.md
+++ b/src/packages/dialog/doc.taro.md
@@ -100,7 +100,7 @@ import { Dialog } from '@nutui/nutui-react-taro'
 | closeIconPosition | 关闭按钮位置 | `top-left` \| `top-right` \| `bottom` | `top-right` |
 | closeOnOverlayClick | 点击蒙层是否关闭对话框 | `boolean` | `true` |
 | footerDirection | 使用横纵方向 可选值 horizontal、vertical | `string` | `horizontal` |
-| lockScroll | 背景是否锁定 | `boolean` | `false` |
+| lockScroll | 背景是否锁定 | `boolean` | `true` |
 | beforeCancel | 取消前回调，点击取消时触发 | `() => boolean` | `-` |
 | beforeClose | 关闭前回调 | `() => boolean` | `-` |
 | onConfirm | 确定按钮回调 | `(e?: MouseEvent) => Promise \| void` | `-` |


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
由于最外层View设置了catchMove并且默认为true，Dialog组件中content内容溢出后无法滚动。
```typescript
<Dialog title="自定义内容区域">
     <div>
         {'文字内容文字内容文字内容文字内容文字内容文字内容文字内容文字内容'.repeat(100)}
      </div>
</Dialog>
```
before:
![before](https://github.com/jdf2e/nutui-react/assets/58927554/cede1c00-1674-4e6c-b4a0-c1fad8296a3c)
after:
![after](https://github.com/jdf2e/nutui-react/assets/58927554/2c62b7ff-91f1-4140-bb5e-c9f81f933bc9)


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件
