### PR TITLE
chore(image): 官网taro的demo显示与h5不一致

### DIFF
--- a/src/packages/image/demos/h5/demo2.tsx
+++ b/src/packages/image/demos/h5/demo2.tsx
@@ -16,7 +16,7 @@ const Demo2 = () => {
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
         {fits.map((i) => {
           return (
-            <div key={i} style={{ width: 100 }}>
+            <div key={i} style={{ width: 98 }}>
               <Image src={src} width="80" height="80" fit={i} />
               <div style={imageText}>{i}</div>
             </div>

--- a/src/packages/image/demos/h5/demo3.tsx
+++ b/src/packages/image/demos/h5/demo3.tsx
@@ -16,7 +16,7 @@ const Demo3 = () => {
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
         {positions.map((i) => {
           return (
-            <div key={i} style={{ width: 100 }}>
+            <div key={i} style={{ width: 98 }}>
               <Image
                 src={src}
                 width="80"

--- a/src/packages/image/demos/h5/demo4.tsx
+++ b/src/packages/image/demos/h5/demo4.tsx
@@ -13,15 +13,15 @@ const Demo4 = () => {
   return (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image src={src} width="80" height="80" fit="contain" radius="50%" />
           <div style={imageText}>contain</div>
         </div>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image src={src} width="80" height="80" fit="cover" radius="50%" />
           <div style={imageText}>cover</div>
         </div>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image src={src} width="80" height="80" fit="cover" radius="10" />
           <div style={imageText}>cover</div>
         </div>

--- a/src/packages/image/demos/taro/demo2.tsx
+++ b/src/packages/image/demos/taro/demo2.tsx
@@ -7,7 +7,7 @@ const Demo2 = () => {
   return (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image
             src={src}
             mode="aspectFit"
@@ -16,7 +16,7 @@ const Demo2 = () => {
             radius="50%"
           />
         </div>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image
             src={src}
             mode="scaleToFill"
@@ -25,7 +25,7 @@ const Demo2 = () => {
             radius="50%"
           />
         </div>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image
             src={src}
             mode="scaleToFill"

--- a/src/packages/image/demos/taro/demo3.tsx
+++ b/src/packages/image/demos/taro/demo3.tsx
@@ -13,11 +13,11 @@ const Demo3 = () => {
   return (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image width="80" height="80" />
           <View style={imageText}>默认</View>
         </div>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image
             width="80"
             height="80"

--- a/src/packages/image/demos/taro/demo4.tsx
+++ b/src/packages/image/demos/taro/demo4.tsx
@@ -13,11 +13,11 @@ const Demo4 = () => {
   return (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image src="https://x" width="80" height="80" />
           <View style={imageText}>默认</View>
         </div>
-        <div style={{ width: 100 }}>
+        <div style={{ width: 98 }}>
           <Image src="https://x" width="80" height="80" error={<Failure />} />
           <View style={imageText}>自定义</View>
         </div>


### PR DESCRIPTION
突然发现之前调整的demo在官网显示和h5不一致，是由机器宽度有区别导致【360和375】，微调了demo的宽度，使其一致。https://nutui.jd.com/taro/react/2x/#/zh-CN/component/image
![截屏2024-05-11 18 07 38](https://github.com/jdf2e/nutui-react/assets/99181718/12010d29-86d0-4057-8e17-39b50cebf328)



- [x] 站点、文档改进

