### PR TITLE
fix(picker): 函数调用之前检查 locale 是否已经定义

### DIFF
--- a/src/packages/picker/picker.taro.tsx
+++ b/src/packages/picker/picker.taro.tsx
@@ -324,7 +324,7 @@ const InternalPicker: ForwardRefRenderFunction<
             setInnerVisible(false)
           }}
         >
-          {locale.cancel}
+          {locale?.cancel}
         </span>
         <div className={`${classPrefix}-title`}>{title || ''}</div>
         <span

--- a/src/packages/picker/picker.tsx
+++ b/src/packages/picker/picker.tsx
@@ -296,7 +296,7 @@ const InternalPicker: ForwardRefRenderFunction<
             setInnerVisible(false)
           }}
         >
-          {locale.cancel}
+          {locale?.cancel}
         </span>
         <div className={`${classPrefix}-title`}>{title || ''}</div>
         <span


### PR DESCRIPTION

- [x] 日常 bug 修复



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 在选择器组件中，使用可选链（`?.`）来安全访问 `locale` 对象的 `cancel` 属性，解决了当 `locale` 可能为 `null` 或 `undefined` 时导致的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->