### PR TITLE
fix(searchbar): 修复 clear 时未触发 change 的问题

### DIFF
--- a/src/packages/searchbar/__tests__/searchbar.spec.tsx
+++ b/src/packages/searchbar/__tests__/searchbar.spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import Searchbar from '@/packages/searchbar'
+import SearchBar from '@/packages/searchbar'
 
 test('basic usage', () => {
-  const { container } = render(<Searchbar placeholder="请输入文字" />)
+  const { container } = render(<SearchBar placeholder="请输入文字" />)
   expect(container.querySelector('.nut-searchbar-input')).toHaveAttribute(
     'placeholder',
     '请输入文字'
@@ -12,7 +12,7 @@ test('basic usage', () => {
 })
 
 test('should limit maxlength of input value when using maxlength prop', () => {
-  const { container } = render(<Searchbar shape="round" maxLength={5} />)
+  const { container } = render(<SearchBar shape="round" maxLength={5} />)
   expect(container.querySelector('.nut-searchbar-input')).toHaveAttribute(
     'maxlength',
     '5'
@@ -23,9 +23,22 @@ test('should limit maxlength of input value when using maxlength prop', () => {
 })
 
 test('Search box text settings', () => {
-  const { container } = render(<Searchbar left="文本" right="确定" />)
+  const { container } = render(<SearchBar left="文本" right="确定" />)
   expect(container.querySelector('.nut-searchbar-left')?.innerHTML).toBe('文本')
   expect(container.querySelector('.nut-searchbar-right')?.innerHTML).toBe(
     '确定'
   )
+})
+
+test('Search clear & change', () => {
+  const change = vi.fn()
+  const { container } = render(
+    <SearchBar value="123" onChange={change} maxLength={10} />
+  )
+  const input = container.querySelector('.nut-searchbar-input')
+  expect(input?.getAttribute('value')).toBe('123')
+  const clear = container.querySelector('.nut-searchbar-clear')
+  fireEvent.click(clear as Element)
+  expect(change).toBeCalledWith('')
+  expect(input?.getAttribute('value')).toBe('')
 })

--- a/src/packages/searchbar/demos/h5/demo7.tsx
+++ b/src/packages/searchbar/demos/h5/demo7.tsx
@@ -3,17 +3,9 @@ import { SearchBar } from '../../searchbar'
 
 const Demo7 = () => {
   const [value, setValue] = useState('')
-  const change = (val: string, e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(val)
-  }
   return (
     <>
-      <SearchBar
-        onChange={(val: string, e: React.ChangeEvent<HTMLInputElement>) =>
-          change(val, e)
-        }
-        maxLength={10}
-      />
+      <SearchBar onChange={(val: string) => setValue(val)} maxLength={10} />
       <div
         style={{
           height: '40px',

--- a/src/packages/searchbar/demos/taro/demo7.tsx
+++ b/src/packages/searchbar/demos/taro/demo7.tsx
@@ -3,17 +3,9 @@ import { SearchBar } from '@nutui/nutui-react-taro'
 
 const Demo7 = () => {
   const [value, setValue] = useState('')
-  const change = (val: string, e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(val)
-  }
   return (
     <>
-      <SearchBar
-        onChange={(val: string, e: React.ChangeEvent<HTMLInputElement>) =>
-          change(val, e)
-        }
-        maxLength={10}
-      />
+      <SearchBar onChange={(val: string) => setValue(val)} maxLength={10} />
       <div
         style={{
           height: '40px',

--- a/src/packages/searchbar/searchbar.taro.tsx
+++ b/src/packages/searchbar/searchbar.taro.tsx
@@ -29,7 +29,7 @@ export interface SearchBarProps extends BasicComponent {
   /**  确定搜索时触发	 */
   onSearch?: (val: string) => void
   /** 输入框内容变化时触发	 */
-  onChange?: (value: string, event: ChangeEvent<HTMLInputElement>) => void
+  onChange?: (value: string, event?: ChangeEvent<HTMLInputElement>) => void
   /** 输入框获得焦点时触发	 */
   onFocus?: (value: string, event: FocusEvent<HTMLInputElement>) => void
   /** 输入框失去焦点时触发	 */
@@ -190,6 +190,7 @@ export const SearchBar: FunctionComponent<
     }
     setValue('')
     forceFocus()
+    onChange && onChange?.('')
     onClear && onClear(event)
   }
   const onKeypress = (e: any) => {

--- a/src/packages/searchbar/searchbar.tsx
+++ b/src/packages/searchbar/searchbar.tsx
@@ -29,7 +29,7 @@ export interface SearchBarProps extends BasicComponent {
   /**  确定搜索时触发	 */
   onSearch?: (val: string) => void
   /** 输入框内容变化时触发	 */
-  onChange?: (value: string, event: ChangeEvent<HTMLInputElement>) => void
+  onChange?: (value: string, event?: ChangeEvent<HTMLInputElement>) => void
   /** 输入框获得焦点时触发	 */
   onFocus?: (value: string, event: FocusEvent<HTMLInputElement>) => void
   /** 输入框失去焦点时触发	 */
@@ -193,6 +193,7 @@ export const SearchBar: FunctionComponent<
       return
     }
     setValue('')
+    onChange && onChange?.('')
     onClear && onClear(event)
     forceFocus()
   }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - `Searchbar` 组件重命名为 `SearchBar`，并更新了相应的测试用例。
  - 增加了搜索清除和更改功能的测试用例。

- **改进**
  - 简化了 `SearchBar` 组件的 `onChange` 事件处理程序。
  - `onChange` 函数签名更新为可接受可选的 `event` 参数，并在某些条件下调用 `onChange('')`。

- **修复**
  - 移除了 `Demo7` 组件中的 `change` 函数，直接使用简化的箭头函数更新 `value` 状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->