### PR TITLE
chore(tag): css样式变量修复

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1489,7 +1489,7 @@ $tag-success-background-color: var(
 ) !default;
 $tag-danger-background-color: var(
   --nutui-tag-danger-background-color,
-  $color-primary
+  $color-danger
 ) !default;
 $tag-warning-background-color: var(
   --nutui-tag-warning-background-color,


### PR DESCRIPTION
显示上是一样的，但是之前的css变量用的不对
- [x] 日常 bug 修复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 更新了危险标签背景颜色变量，使其与 `$color-danger` 一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->