### PR TITLE
fix(input): placeholder 无法设置空字符串

### DIFF
--- a/src/packages/input/input.taro.tsx
+++ b/src/packages/input/input.taro.tsx
@@ -28,7 +28,7 @@ export interface InputProps extends BasicComponent {
   name: string
   defaultValue?: string
   value?: string
-  placeholder: string
+  placeholder?: string
   align: InputAlign
   disabled: boolean
   readOnly: boolean
@@ -50,7 +50,7 @@ const defaultProps = {
   ...ComponentDefaults,
   type: 'text',
   name: '',
-  placeholder: '',
+  placeholder: undefined,
   confirmType: 'done',
   align: 'left',
   required: false,
@@ -232,7 +232,9 @@ export const Input = forwardRef(
           type={inputType(type) as any}
           password={type === 'password'}
           maxlength={maxLength}
-          placeholder={placeholder || locale.placeholder}
+          placeholder={
+            placeholder === undefined ? locale.placeholder : placeholder
+          }
           disabled={disabled || readOnly}
           value={value}
           focus={autoFocus}

--- a/src/packages/input/input.tsx
+++ b/src/packages/input/input.tsx
@@ -23,7 +23,7 @@ export interface InputProps extends BasicComponent {
   name: string
   defaultValue?: string
   value?: string
-  placeholder: string
+  placeholder?: string
   align: InputAlign
   disabled: boolean
   readOnly: boolean
@@ -45,7 +45,7 @@ const defaultProps = {
   ...ComponentDefaults,
   type: 'text',
   name: '',
-  placeholder: '',
+  placeholder: undefined,
   confirmType: 'done',
   align: 'left',
   required: false,
@@ -213,7 +213,9 @@ export const Input = forwardRef(
           }}
           type={inputType(type)}
           maxLength={maxLength}
-          placeholder={placeholder || locale.placeholder}
+          placeholder={
+            placeholder === undefined ? locale.placeholder : placeholder
+          }
           disabled={disabled}
           readOnly={readOnly}
           value={value}


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了输入组件的 `placeholder` 属性，现在该属性为可选项。
  - 当 `placeholder` 未定义时，将使用默认的本地化占位符。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->