### PR TITLE
fix(cascader): onPathChange is not a function

### DIFF
--- a/src/packages/cascader/cascader.taro.tsx
+++ b/src/packages/cascader/cascader.taro.tsx
@@ -328,7 +328,7 @@ const InternalCascader: ForwardRefRenderFunction<
         const pathNodes = state.panes.map((item) => item.selectedNode)
         const optionParams = pathNodes.map((item: any) => item.value)
         onChange(optionParams, pathNodes)
-        onPathChange(optionParams, pathNodes)
+        onPathChange?.(optionParams, pathNodes)
         setInnerValue(optionParams)
       }
       setOptionsData(state.panes)
@@ -353,7 +353,7 @@ const InternalCascader: ForwardRefRenderFunction<
       if (!type) {
         const pathNodes = state.panes.map((item) => item.selectedNode)
         const optionParams = pathNodes.map((item: any) => item?.value)
-        onPathChange(optionParams, pathNodes)
+        onPathChange?.(optionParams, pathNodes)
       }
       return
     }

--- a/src/packages/cascader/cascader.tsx
+++ b/src/packages/cascader/cascader.tsx
@@ -327,7 +327,7 @@ const InternalCascader: ForwardRefRenderFunction<
         const pathNodes = state.panes.map((item) => item.selectedNode)
         const optionParams = pathNodes.map((item: any) => item.value)
         onChange(optionParams, pathNodes)
-        onPathChange(optionParams, pathNodes)
+        onPathChange?.(optionParams, pathNodes)
         setInnerValue(optionParams)
       }
       setOptionsData(state.panes)
@@ -352,7 +352,7 @@ const InternalCascader: ForwardRefRenderFunction<
       if (!type) {
         const pathNodes = state.panes.map((item) => item.selectedNode)
         const optionParams = pathNodes.map((item: any) => item?.value)
-        onPathChange(optionParams, pathNodes)
+        onPathChange?.(optionParams, pathNodes)
       }
       return
     }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 更新 `InternalCascader` 组件中的 `onPathChange` 函数调用，使用可选链操作符 (`?.`) 来处理 `onPathChange` 可能未定义的情况，防止调用未定义函数时出现错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->