### PR TITLE
fix: 修复Windows系统下 npm scripts: generate:themes 因为复制的目标文件路径替换失败导致 后续bu…

### DIFF
--- a/scripts/generate-themes.js
+++ b/scripts/generate-themes.js
@@ -12,11 +12,18 @@ let tasks = []
 const componentsScss = glob.sync('./src/packages/**/*.scss', { dotRelative: true })
 componentsScss.map((cs) => {
   if (cs.indexOf('demo.scss') > -1) return
+
+  let destDir = path.normalize(cs);
+  // for Windows path: .\src\packages\**\*.scss
+  destDir = destDir.replace(path.normalize('.\\src\\'), '')
+  // for mac osx
+  destDir = destDir.replace('src/', '')
+
   tasks.push(
     fs
       .copy(
         path.resolve(__dirname, `.${cs}`),
-        path.resolve(__dirname, `../dist`, `${cs.replace('./src/', '')}`)
+        path.resolve(__dirname, `../dist`, destDir)
       )
       .catch((error) => { })
   )


### PR DESCRIPTION
npm scripts：generate:themes 指令的相关脚本出错


<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/2314
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修正了文件路径处理问题，确保在不同操作系统上正确复制文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->