### PR TITLE
fix: 移除 defaultProps

### DIFF
--- a/src/packages/animatingnumbers/countup.taro.tsx
+++ b/src/packages/animatingnumbers/countup.taro.tsx
@@ -141,5 +141,4 @@ export const CountUp: FunctionComponent<Partial<CountUpProps>> = (props) => {
   )
 }
 
-CountUp.defaultProps = defaultProps
 CountUp.displayName = 'NutCountUp'

--- a/src/packages/animatingnumbers/countup.tsx
+++ b/src/packages/animatingnumbers/countup.tsx
@@ -122,5 +122,4 @@ export const CountUp: FunctionComponent<Partial<CountUpProps>> = (props) => {
   )
 }
 
-CountUp.defaultProps = defaultProps
 CountUp.displayName = 'NutCountUp'

--- a/src/packages/audio/audio.taro.tsx
+++ b/src/packages/audio/audio.taro.tsx
@@ -267,5 +267,4 @@ export const Audio: FunctionComponent<
   )
 }
 
-Audio.defaultProps = defaultProps
 Audio.displayName = 'NutAudio'

--- a/src/packages/audio/audio.tsx
+++ b/src/packages/audio/audio.tsx
@@ -290,5 +290,4 @@ export const Audio: FunctionComponent<
   )
 }
 
-Audio.defaultProps = defaultProps
 Audio.displayName = 'NutAudio'

--- a/src/packages/checkboxgroup/checkboxgroup.taro.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.taro.tsx
@@ -151,5 +151,4 @@ export const CheckboxGroup = React.forwardRef(
   }
 )
 
-CheckboxGroup.defaultProps = defaultProps
 CheckboxGroup.displayName = 'NutCheckboxGroup'

--- a/src/packages/checkboxgroup/checkboxgroup.tsx
+++ b/src/packages/checkboxgroup/checkboxgroup.tsx
@@ -151,5 +151,4 @@ export const CheckboxGroup = React.forwardRef(
   }
 )
 
-CheckboxGroup.defaultProps = defaultProps
 CheckboxGroup.displayName = 'NutCheckboxGroup'

--- a/src/packages/datepicker/datepicker.taro.tsx
+++ b/src/packages/datepicker/datepicker.taro.tsx
@@ -428,5 +428,4 @@ export const DatePicker: FunctionComponent<
   )
 }
 
-DatePicker.defaultProps = defaultProps
 DatePicker.displayName = 'NutDatePicker'

--- a/src/packages/datepicker/datepicker.tsx
+++ b/src/packages/datepicker/datepicker.tsx
@@ -423,5 +423,4 @@ export const DatePicker: FunctionComponent<
   )
 }
 
-DatePicker.defaultProps = defaultProps
 DatePicker.displayName = 'NutDatePicker'

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -225,7 +225,6 @@ export function close(selector: string) {
   customEvents.trigger(path, { status: false })
 }
 
-BaseDialog.defaultProps = defaultProps
 BaseDialog.displayName = 'NutDialog'
 BaseDialog.open = open
 BaseDialog.close = close

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -161,5 +161,4 @@ Dialog.confirm = (props: DialogConfirmProps): DialogReturnProps => {
   }
 })
 
-Dialog.defaultProps = defaultProps
 Dialog.displayName = 'NutDialog'

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -64,8 +64,8 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
 
     const handleCancel = (e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()
-      if (!beforeCancel?.()) return
-      if (!beforeClose?.()) return
+      if (beforeCancel && !beforeCancel?.()) return
+      if (beforeClose && !beforeClose?.()) return
       onClose?.()
       onCancel?.()
     }
@@ -115,8 +115,8 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<DialogProps>> = (
   const renderCloseIcon = () => {
     if (!closeIcon) return null
     const handleCancel = () => {
-      if (!beforeCancel?.()) return
-      if (!beforeClose?.()) return
+      if (beforeCancel && !beforeCancel?.()) return
+      if (beforeClose && !beforeClose?.()) return
       onClose?.()
       onCancel?.()
     }

--- a/src/packages/notify/notify.taro.tsx
+++ b/src/packages/notify/notify.taro.tsx
@@ -130,7 +130,6 @@ export function close(selector: string) {
   customEvents.trigger(path, false)
 }
 
-Notify.defaultProps = defaultProps
 Notify.displayName = 'NutNotify'
 Notify.open = open
 Notify.close = close

--- a/src/packages/pulltorefresh/pulltorefresh.taro.tsx
+++ b/src/packages/pulltorefresh/pulltorefresh.taro.tsx
@@ -180,5 +180,4 @@ export const PullToRefresh: FunctionComponent<Partial<PullToRefreshProps>> = (
   )
 }
 
-PullToRefresh.defaultProps = defaultProps
 PullToRefresh.displayName = 'NutPullToRefresh'

--- a/src/packages/pulltorefresh/pulltorefresh.tsx
+++ b/src/packages/pulltorefresh/pulltorefresh.tsx
@@ -226,5 +226,4 @@ export const PullToRefresh: FunctionComponent<Partial<PullToRefreshProps>> = (
   )
 }
 
-PullToRefresh.defaultProps = defaultProps
 PullToRefresh.displayName = 'NutPullToRefresh'

--- a/src/packages/radio/radio.taro.tsx
+++ b/src/packages/radio/radio.taro.tsx
@@ -172,6 +172,5 @@ export const Radio: FunctionComponent<
   )
 }
 
-Radio.defaultProps = defaultProps
 Radio.displayName = 'NutRadio'
 Radio.Group = RadioGroup

--- a/src/packages/radio/radio.tsx
+++ b/src/packages/radio/radio.tsx
@@ -168,6 +168,5 @@ export const Radio: FunctionComponent<
   )
 }
 
-Radio.defaultProps = defaultProps
 Radio.displayName = 'NutRadio'
 Radio.Group = RadioGroup

--- a/src/packages/radiogroup/radiogroup.taro.tsx
+++ b/src/packages/radiogroup/radiogroup.taro.tsx
@@ -106,5 +106,4 @@ export const RadioGroup = React.forwardRef(
   }
 )
 
-RadioGroup.defaultProps = defaultProps
 RadioGroup.displayName = 'NutRadioGroup'

--- a/src/packages/radiogroup/radiogroup.tsx
+++ b/src/packages/radiogroup/radiogroup.tsx
@@ -106,5 +106,4 @@ export const RadioGroup = React.forwardRef(
   }
 )
 
-RadioGroup.defaultProps = defaultProps
 RadioGroup.displayName = 'NutRadioGroup'

--- a/src/packages/swipe/swipe.taro.tsx
+++ b/src/packages/swipe/swipe.taro.tsx
@@ -275,5 +275,4 @@ export const Swipe = forwardRef<
   )
 })
 
-Swipe.defaultProps = defaultProps
 Swipe.displayName = 'NutSwipe'

--- a/src/packages/swipe/swipe.tsx
+++ b/src/packages/swipe/swipe.tsx
@@ -270,5 +270,4 @@ export const Swipe = forwardRef<
   )
 })
 
-Swipe.defaultProps = defaultProps
 Swipe.displayName = 'NutSwipe'

--- a/src/packages/swiper/swiper.taro.tsx
+++ b/src/packages/swiper/swiper.taro.tsx
@@ -141,7 +141,7 @@ export const Swiper = forwardRef((props: Partial<SwiperProps>, ref) => {
           indicatorDots={false}
           onChange={(e) => {
             handleOnChange(e)
-            props.onChange?.(e)
+            onChange?.(e)
           }}
           style={{
             width: !width ? '100%' : pxCheck(width),
@@ -167,5 +167,4 @@ export const Swiper = forwardRef((props: Partial<SwiperProps>, ref) => {
   )
 })
 
-Swiper.defaultProps = defaultProps
 Swiper.displayName = 'NutSwiper'

--- a/src/packages/swiper/swiper.tsx
+++ b/src/packages/swiper/swiper.tsx
@@ -57,6 +57,8 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
       duration,
       style,
       className,
+      slideSize,
+      onChange,
     } = { ...defaultProps, ...props }
     const isVertical = direction === 'vertical'
     const count = useMemo(() => {
@@ -67,7 +69,7 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
       return c
     }, [children])
     const getSlideSize = () => {
-      if (props.slideSize) return props.slideSize
+      if (slideSize) return slideSize
       if (stageRef.current) {
         if (isVertical) return stageRef.current.offsetHeight
         return stageRef.current.offsetWidth
@@ -135,8 +137,7 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
     function boundIndex(current: number) {
       const min = 0
       const max = count - 1
-      if (current === max && !loop && props.slideSize) {
-        const slideSize = props.slideSize
+      if (current === max && !loop && slideSize) {
         const swiperSize = getSwiperSize()
         const ratio = (swiperSize - slideSize) / slideSize
         return bound(current, min, max - ratio)
@@ -151,7 +152,7 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
         targetIndex = cycleIndex < 0 ? cycleIndex + count : cycleIndex
       }
       setCurrent(targetIndex)
-      props.onChange?.(targetIndex)
+      onChange?.(targetIndex)
 
       if (effect) {
         updateTransform(transforms, setTransforms, effect, targetIndex)
@@ -315,5 +316,4 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
     )
   }
 )
-Swiper.defaultProps = defaultProps
 Swiper.displayName = 'NutSwiper'

--- a/src/packages/swiperitem/swiperitem.taro.tsx
+++ b/src/packages/swiperitem/swiperitem.taro.tsx
@@ -17,5 +17,4 @@ export const SwiperItem: FunctionComponent<Partial<SwiperItemProps>> = (
   const { children, ...rest } = props
   return <>{children}</>
 }
-SwiperItem.defaultProps = defaultProps
 SwiperItem.displayName = 'NutSwiperItem'

--- a/src/packages/swiperitem/swiperitem.tsx
+++ b/src/packages/swiperitem/swiperitem.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { BasicComponent } from '@/utils/typings'
 
 export interface SwiperItemProps extends BasicComponent {
+  // eslint-disable-next-line react/no-unused-prop-types
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 }
 
@@ -12,14 +13,13 @@ const defaultProps = {
 
 export const SwiperItem = (props: SwiperItemProps) => {
   const classPrefix = 'nut-swiper-item'
-  const { className, style, children } = { ...defaultProps, ...props }
+  const { className, style, children, onClick } = { ...defaultProps, ...props }
   const classes = classNames(classPrefix, className)
 
   return (
-    <div className={classes} onClick={props.onClick} style={style}>
+    <div className={classes} onClick={onClick} style={style}>
       {children}
     </div>
   )
 }
-SwiperItem.defaultProps = defaultProps
 SwiperItem.displayName = 'NutSwiperItem'

--- a/src/packages/toast/toast.taro.tsx
+++ b/src/packages/toast/toast.taro.tsx
@@ -222,7 +222,6 @@ export function hide(selector: string) {
   customEvents.trigger(path, { status: false })
 }
 
-Toast.defaultProps = defaultProps
 Toast.displayName = 'NutToast'
 Toast.show = show
 Toast.hide = hide


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 移除 defaultProps 
2. dialog 组件通过单元测试

将触发onClose/onCancel的逻辑进行调整：
只有当传入beforOnClose或beforOnCancel时才会判断该函数的返回结果 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
	- 将多个组件的 `displayName` 更新为以 'Nut' 开头的名称，以提高组件命名一致性。例如，`CountUp` 更新为 `NutCountUp`。
- **修复**
	- 在 `Dialog` 组件中，修复了 `beforeCancel` 和 `beforeClose` 函数的存在性检查，以确保在调用这些函数之前进行验证。
	- 解决了 `Swiper` 组件中 `onChange` 处理程序的潜在问题，简化了事件处理逻辑。
- **代码优化**
	- 移除了多个组件的 `defaultProps` 声明，优化了组件的初始化行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->