### PR TITLE
修改picker组件issue

### DIFF
--- a/src/packages/picker/picker.tsx
+++ b/src/packages/picker/picker.tsx
@@ -98,7 +98,7 @@ const InternalPicker: ForwardRefRenderFunction<
     defaultValue: [...defaultValue],
     finalValue: [...defaultValue],
     onChange: (val: (string | number)[]) => {
-      props.onConfirm?.(setSelectedOptions(), val)
+      !val && props.onConfirm?.(setSelectedOptions(), val)
     },
   })
   const [innerVisible, setInnerVisible] = usePropsValue<boolean>({

--- a/src/packages/picker/picker.tsx
+++ b/src/packages/picker/picker.tsx
@@ -197,7 +197,11 @@ const InternalPicker: ForwardRefRenderFunction<
   }
 
   useEffect(() => {
-    setInnerValue(innerValue !== selectedValue ? selectedValue : innerValue)
+    // 此hook的作用是‘如果内部选中值与用户选中值不同则把内部值置用户选中值’保证用户打开选项时选中的是选择的值。
+    // 但是当用户并没有进行确认选择，则不需要进行修改innerValue，否则会出现 issue#2290的问题
+    if (innerValue !== selectedValue && selectedValue.length > 0) {
+      setInnerValue(selectedValue)
+    }
   }, [innerVisible, selectedValue])
 
   useEffect(() => {

--- a/src/packages/picker/picker.tsx
+++ b/src/packages/picker/picker.tsx
@@ -206,11 +206,6 @@ const InternalPicker: ForwardRefRenderFunction<
     }
   }, [options, innerVisible])
 
-  // 选中值进行修改
-  useEffect(() => {
-    onChange && onChange(setSelectedOptions(), innerValue, columnIndex)
-  }, [innerValue, columnsList])
-
   const setSelectedOptions = () => {
     const options: PickerOption[] = []
     let currOptions = []
@@ -251,6 +246,8 @@ const InternalPicker: ForwardRefRenderFunction<
           ]
           setInnerValue(combineResult)
           setColumnsList(normalListData(combineResult) as PickerOption[][])
+
+          onChange && onChange(setSelectedOptions(), combineResult, columnIndex)
         } else {
           setInnerValue((data: (number | string)[]) => {
             const cdata: (number | string)[] = [...data]
@@ -260,6 +257,7 @@ const InternalPicker: ForwardRefRenderFunction<
             )
               ? columnOptions.value
               : ''
+            onChange && onChange(setSelectedOptions(), cdata, columnIndex)
             return cdata
           })
         }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [√ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
1. form下的picker在第一次不选择选项，直接取消选择后再次点击picker，出现第一项被选中的问题https://github.com/jdf2e/nutui-react/issues/2290
2. Picker 和 FormItem 搭配使用时，ref.open() 会触发 Picker 的 onClose
https://github.com/jdf2e/nutui-react/issues/2312

### 💡 需求背景和解决方案

背景：线上issue
解决方案：通过修改源代码的方式对issue进行修改，不破坏原逻辑，对性能没有影响

<!--
1. 要解决的具体问题。
4. 列出最终的 API 实现和用法。
5. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√  ] 文档已补充或无须补充
- [ √ ] 代码演示已提供或无须提供
- [ √ ] TypeScript 定义已补充或无须补充
- [ √ ] fork仓库代码是否为最新避免文件冲突
- [√  ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 更新了选择器组件的`onChange`事件处理逻辑，以确保在确认选择时行为正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->