### PR TITLE
fix(tabs): 修复tabs异步设置titles滚动失效（#2351）

### DIFF
--- a/src/packages/tabs/tabs.tsx
+++ b/src/packages/tabs/tabs.tsx
@@ -101,10 +101,12 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
   const scrollIntoView = (index: number, immediate?: boolean) => {
     const nav = navRef.current
     const titleItem = titleItemsRef.current
-    if (!nav || !titleItem || !titleItem[index]) {
+    const titlesLength = titles.current.length
+    const itemLength = titleItemsRef.current.length
+    if (!nav || !titleItem || !titleItem[itemLength - titlesLength + index]) {
       return
     }
-    const title = titleItem[index]
+    const title = titleItem[itemLength - titlesLength + index]
 
     let to = 0
     if (direction === 'vertical') {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [X] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/2351

### 💡 需求背景和解决方案

问题背景：
在已有代码中，对于每个tabs里的titles，遍历渲染的时候会把item组件的 ref push到 titleItemsRef.current 中，这个current一直随着点击切换 tab 或 tab 的 titles 变化而累加，最终这个 current 会有很大的存储。
并且移动tab到视区中心的代码只从 index 获取此元素。所以在 tab 的titles先是较少（假设只有3个），后续变多（假设为8）时，假设要移动到第5个时，titleItemsRef.current 的第5个索引并没有这个元素，因此会滚动失效。

修复方案：
取 titleItemsRef.current 的最后/最新的内容，并获取最新的 titles 元素，从而使滚动正常。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] fork仓库代码是否为最新避免文件冲突
- [X] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **缺陷修复**
  - 更新了 `Tabs` 组件中 `scrollIntoView` 函数的逻辑，以正确计算需要滚动到视野内的标题项索引。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->