### PR TITLE
fix(Icon): 适配 rn 和 鸿蒙 

### DIFF
--- a/packages/nutui-harmony/build-profile.json5
+++ b/packages/nutui-harmony/build-profile.json5
@@ -1,6 +1,20 @@
 {
   "app": {
-    "signingConfigs": [],
+    "signingConfigs": [
+      {
+        "name": "default",
+        "type": "HarmonyOS",
+        "material": {
+          "certpath": "/Users/tongen/.ohos/config/default_nutui-harmony_PK697Wu5mnc6ZwkFy1SeSNQa86VdzjbAFwDwqKdj-o0=.cer",
+          "storePassword": "0000001B1D7AA645FFDC09EF80DB9127EE1487532F04045B7C357F80025FC2F69AAB86F59959BFF647D2ED",
+          "keyAlias": "debugKey",
+          "keyPassword": "0000001B3046DD1422DFC16BA1BA8DF23A9D04C17FE2AA1CE5E27F1B3BBD036890625D4F51086AC2A4B3D2",
+          "profile": "/Users/tongen/.ohos/config/default_nutui-harmony_PK697Wu5mnc6ZwkFy1SeSNQa86VdzjbAFwDwqKdj-o0=.p7b",
+          "signAlg": "SHA256withECDSA",
+          "storeFile": "/Users/tongen/.ohos/config/default_nutui-harmony_PK697Wu5mnc6ZwkFy1SeSNQa86VdzjbAFwDwqKdj-o0=.p12"
+        }
+      }
+    ],
     "products": [
       {
         "name": "default",

--- a/packages/nutui-taro-demo-rn/scripts/taro/adapted.js
+++ b/packages/nutui-taro-demo-rn/scripts/taro/adapted.js
@@ -33,4 +33,5 @@ exports = module.exports = [
   'configprovider',
   'input',
   'swipe',
+  'icon',
 ]

--- a/packages/nutui-taro-demo-rn/src/base/pages/icon/index.tsx
+++ b/packages/nutui-taro-demo-rn/src/base/pages/icon/index.tsx
@@ -1,1 +1,2 @@
-export default <>button</>;
+import Demo from '@/packages/icon/demo.taro'
+export default Demo

--- a/src/config.json
+++ b/src/config.json
@@ -105,7 +105,7 @@
           "author": "hanyuxinting"
         },
         {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "name": "Icon",
           "type": "component",
           "cName": "图标",

--- a/src/packages/icon/demo.taro.tsx
+++ b/src/packages/icon/demo.taro.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
 import Taro from '@tarojs/taro'
 import { ScrollView, View } from '@tarojs/components'
-import '@nutui/icons-react-taro/dist/style_iconfont.css'
-import { Cell, Toast } from '@nutui/nutui-react-taro'
+// import '@nutui/icons-react-taro/dist/style_iconfont.css'
+import { Toast } from '@nutui/nutui-react-taro'
 import { useTranslate } from '@/sites/assets/locale/taro'
 import Header from '@/sites/components/header'
 import Demo1 from './demos/taro/demo1'
@@ -73,25 +73,15 @@ const IconDemo = () => {
           }}
         />
         <View className="h2">{translated.svg}</View>
-        <Cell>
-          <Demo1 />
-        </Cell>
+        <Demo1 />
         <View className="h2">{translated['84aa6bce']}</View>
-        <Cell>
-          <Demo2 />
-        </Cell>
+        <Demo2 />
         <View className="h2">{translated.dab8a74f}</View>
-        <Cell>
-          <Demo3 />
-        </Cell>
+        <Demo3 />
         <View className="h2">{translated['52c15454']}</View>
-        <Cell>
-          <Demo4 />
-        </Cell>
+        <Demo4 />
         <View className="h2">{translated['7aeb5407']}</View>
-        <Cell style={{ alignItems: 'center' }}>
-          <Demo5 />
-        </Cell>
+        <Demo5 />
         <Demo6 />
         <Demo7 />
       </ScrollView>

--- a/src/packages/icon/demos/taro/demo1.tsx
+++ b/src/packages/icon/demos/taro/demo1.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
+import { Cell } from '@nutui/nutui-react-taro'
 import { Add, Dongdong, UserAdd } from '@nutui/icons-react-taro'
 
 const Demo1 = () => {
   return (
-    <>
+    <Cell>
       <Add color="red" style={{ marginRight: '10px' }} />
       <UserAdd style={{ marginRight: '10px' }} />
       <Dongdong />
-    </>
+    </Cell>
   )
 }
 export default Demo1

--- a/src/packages/icon/demos/taro/demo2.tsx
+++ b/src/packages/icon/demos/taro/demo2.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
+import { Cell } from '@nutui/nutui-react-taro'
 import { IconFont } from '@nutui/icons-react-taro'
 
 const Demo2 = () => {
   return (
-    <>
+    <Cell>
       <IconFont name="dongdong" style={{ marginRight: '10px' }} />
       <IconFont name="add" style={{ marginRight: '10px' }} />
       <IconFont name="minus" />
-    </>
+    </Cell>
   )
 }
 export default Demo2

--- a/src/packages/icon/demos/taro/demo3.tsx
+++ b/src/packages/icon/demos/taro/demo3.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
+import { Cell } from '@nutui/nutui-react-taro'
 import { IconFont } from '@nutui/icons-react-taro'
 
 const Demo3 = () => {
   return (
-    <>
+    <Cell>
       <IconFont
         size="40"
         name="https://img11.360buyimg.com/imagetools/jfs/t1/137646/13/7132/1648/5f4c748bE43da8ddd/a3f06d51dcae7b60.png"
       />
-    </>
+    </Cell>
   )
 }
 export default Demo3

--- a/src/packages/icon/demos/taro/demo4.tsx
+++ b/src/packages/icon/demos/taro/demo4.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import { Cell } from '@nutui/nutui-react-taro'
 import { IconFont } from '@nutui/icons-react-taro'
 
 const Demo4 = () => {
   return (
-    <>
+    <Cell>
       <IconFont
         name="dongdong"
         color="#FF0F23"
@@ -15,7 +16,7 @@ const Demo4 = () => {
         style={{ marginRight: '10px' }}
       />
       <IconFont name="dongdong" color="#ffd700" />
-    </>
+    </Cell>
   )
 }
 

--- a/src/packages/icon/demos/taro/demo5.tsx
+++ b/src/packages/icon/demos/taro/demo5.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
+import { Cell } from '@nutui/nutui-react-taro'
 import { IconFont } from '@nutui/icons-react-taro'
 
 const Demo5 = () => {
   return (
-    <>
+    <Cell style={{ alignItems: 'center' }}>
       <IconFont name="dongdong" size="16" style={{ marginRight: '10px' }} />
       <IconFont name="dongdong" size="20" style={{ marginRight: '10px' }} />
       <IconFont name="dongdong" size="24" />
-    </>
+    </Cell>
   )
 }
 


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为 HarmonyOS 添加了签名配置。

- **改进**
  - 更新了 Icon 组件的版本，从 2.0.0 升级到 3.0.0。
  - 在 Taro Demo 中增加了 `icon` 组件的导出。

- **重构**
  - 重新导出 Icon 页面中的 Demo 组件。
  - 在多个 Icon 的 Demo 示例中，将根片段替换为 `Cell` 组件，优化了界面布局和结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->