### PR TITLE
fix: 修复image宽高处理函数,调整swipe版本号

### DIFF
--- a/packages/nutui-taro-demo-rn/scripts/taro/adapted.js
+++ b/packages/nutui-taro-demo-rn/scripts/taro/adapted.js
@@ -33,5 +33,4 @@ exports = module.exports = [
   'configprovider',
   'input',
   'swipe',
-  'icon',
 ]

--- a/src/config.json
+++ b/src/config.json
@@ -861,7 +861,7 @@
           "author": "swag~jun"
         },
         {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "name": "Swipe",
           "type": "component",
           "cName": "滑动手势",

--- a/src/packages/image/image.taro.tsx
+++ b/src/packages/image/image.taro.tsx
@@ -14,7 +14,6 @@ import {
 import { Image as ImageIcon, ImageError } from '@nutui/icons-react-taro'
 import classNames from 'classnames'
 import { BaseEventOrig } from '@tarojs/components/types/common'
-import { pxCheck } from '@/utils/px-check'
 import { harmonyAndRn } from '@/utils/platform-taro'
 
 export interface ImageProps extends Omit<TImageProps, 'style'> {
@@ -49,6 +48,10 @@ export const Image: FunctionComponent<Partial<ImageProps>> = (props) => {
   } = { ...defaultProps, ...props }
   const [innerLoading, setInnerLoading] = useState(true)
   const [isError, setIsError] = useState(false)
+
+  const pxCheck = (value: string | number): string => {
+    return Number.isNaN(Number(value)) ? String(value) : `${value}px`
+  }
 
   // 图片加载
   const handleLoad = (e: BaseEventOrig<TImageProps.onLoadEventDetail>) => {
@@ -85,7 +88,11 @@ export const Image: FunctionComponent<Partial<ImageProps>> = (props) => {
     overflow: radius !== undefined && radius !== null ? 'hidden' : '',
     borderRadius:
       // eslint-disable-next-line no-nested-ternary
-      radius != null ? (Taro.getEnv() === 'RN' ? radius : pxCheck(radius)) : '',
+      radius !== undefined && radius != null
+        ? Taro.getEnv() === 'RN'
+          ? radius
+          : pxCheck(radius)
+        : '',
   }
 
   const imgStyle: any = {
@@ -127,7 +134,7 @@ export const Image: FunctionComponent<Partial<ImageProps>> = (props) => {
     <View className={classNames(classPrefix, className)} style={containerStyle}>
       <TImage
         {...rest}
-        className={`${classPrefix}-default ${className}-image`}
+        className={`${classPrefix}-default ${className ? `${className}-image` : ''}`}
         style={imgStyle}
         src={src}
         onLoad={(e) => handleLoad(e)}

--- a/src/packages/image/image.tsx
+++ b/src/packages/image/image.tsx
@@ -9,7 +9,6 @@ import React, {
 import { Image as ImageIcon, ImageError } from '@nutui/icons-react'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
-import { pxCheck } from '@/utils/px-check'
 
 export interface ImageProps extends BasicComponent {
   src: string
@@ -82,6 +81,9 @@ export const Image: FunctionComponent<
   const [isError, setIsError] = useState(false)
   const [complete, setComplete] = useState(false)
   const imgRef = useRef<HTMLImageElement>(null)
+  const pxCheck = (value: string | number): string => {
+    return Number.isNaN(Number(value)) ? String(value) : `${value}px`
+  }
 
   useEffect(() => {
     if (imgRef.current && imgRef.current.complete && !lazy) {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了 `Swipe` 组件版本号至 3.0.0。
  
- **重构**
  - 移除了 `icon` 模块的导出。
  - 在 `Image` 组件中本地定义并使用 `pxCheck` 函数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->