### PR TITLE
fix(uploader): 京东小程序中可上传时可选择图片和视频

### DIFF
--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -252,8 +252,8 @@ const InternalUploader: ForwardRefRenderFunction<
         document.body.appendChild(obj)
       }
     }
-    if (getEnv() === 'WEAPP' && chooseMedia) {
-      // chooseMedia 目前只支持微信小程序原生，其余端全部使用 chooseImage API
+    if ((getEnv() === 'WEAPP' || getEnv() === 'JD') && chooseMedia) {
+      // 其余端全部使用 chooseImage API
       chooseMedia({
         /** 最多可以选择的文件个数 */
         count: multiple ? (maxCount as number) * 1 - fileList.length : 1,


### PR DESCRIPTION

### 🤔 这个变动的性质是？
- [ ✅ ] 功能增强
### 🔗 相关 Issue

### 💡 需求背景和解决方案
需求背景：

1. 京东小程序中需要支持一个按钮上传图片或者视频，现有uploader组件只能选择相册中的图片
2. 京东小程序中的chooseMedia支持同时选择图片或视频，但uploader组件中没有支持

解决方案：

对京东小程序端的chooseMedia进行支持

使用方法
mediaType={['image', 'video','mix']}


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ✅ ] 文档已补充或无须补充
- [ ✅] 代码演示已提供或无须提供
- [ ✅ ] TypeScript 定义已补充或无须补充
- [ ✅ ] fork仓库代码是否为最新避免文件冲突
- [ ✅ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了媒体选择功能，现在在微信小程序和京东环境中提供更好的支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->