### PR TITLE
fix(layout): 使用 utils 中的 px 转换函数

### DIFF
--- a/src/packages/layout/demos/taro/demo1.tsx
+++ b/src/packages/layout/demos/taro/demo1.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react'
 import { Row, Col } from '@nutui/nutui-react-taro'
-import { pxTransform } from '@tarojs/taro'
 import { View } from '@tarojs/components'
+import pxTransform from '@/utils/px-transform'
 
 const Demo1 = () => {
   const flexContent: CSSProperties = {

--- a/src/packages/layout/demos/taro/demo2.tsx
+++ b/src/packages/layout/demos/taro/demo2.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react'
 import { Row, Col } from '@nutui/nutui-react-taro'
-import { pxTransform } from '@tarojs/taro'
 import { View } from '@tarojs/components'
+import pxTransform from '@/utils/px-transform'
 
 const Demo2 = () => {
   const flexContent: CSSProperties = {

--- a/src/packages/layout/demos/taro/demo3.tsx
+++ b/src/packages/layout/demos/taro/demo3.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react'
 import { Row, Col } from '@nutui/nutui-react-taro'
-import { pxTransform } from '@tarojs/taro'
 import { View } from '@tarojs/components'
+import pxTransform from '@/utils/px-transform'
 
 const Demo3 = () => {
   const flexContent: CSSProperties = {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修复了 `demo1.tsx`, `demo2.tsx`, 和 `demo3.tsx` 中 `pxTransform` 导入路径的问题，现在从 `@/utils/px-transform` 导入。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->