### PR TITLE
fix: 修复日历进行快捷选择日期时 点击确认获取的是上一次的日期

### DIFF
--- a/src/packages/calendaritem/calendaritem.taro.tsx
+++ b/src/packages/calendaritem/calendaritem.taro.tsx
@@ -480,11 +480,13 @@ export const CalendarItem = React.forwardRef<
     monthsData.splice(0)
     initData()
   }
-
   useEffect(() => {
     setCurrentDate(resetDefaultValue() || [])
-    popup && resetRender()
   }, [defaultValue])
+
+  useEffect(() => {
+    popup && resetRender()
+  }, [currentDate])
 
   // 暴露出的API
   const scrollToDate = (date: string) => {

--- a/src/packages/calendaritem/calendaritem.tsx
+++ b/src/packages/calendaritem/calendaritem.tsx
@@ -483,8 +483,11 @@ export const CalendarItem = React.forwardRef<
 
   useEffect(() => {
     setCurrentDate(resetDefaultValue() || [])
-    popup && resetRender()
   }, [defaultValue])
+
+  useEffect(() => {
+    popup && resetRender()
+  }, [currentDate])
 
   // 暴露出的API
   const scrollToDate = (date: string) => {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？
- [ ] 日常 bug 修复


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/jdf2e/nutui-react/issues/2289

### 💡 需求背景和解决方案
Calendar 日历里的自定义按钮，点击最近7天进行快捷选择日期后，点击确定获取不到选择的日期

<img width="465" alt="image" src="https://github.com/jdf2e/nutui-react/assets/24307255/bf769149-34a2-4659-83f1-db65e4edf428">
currentDate变化后重新执行resetRender方法确保renderCurrentDate中的setDefaultDate方法拿到的currentDate是最新的值

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 更新了 `CalendarItem` 组件，以确保在 `currentDate` 更改时正确重新渲染。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->