### PR TITLE
feat(menuitem): add css classnames to enhance custom style abilities

### DIFF
--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -237,17 +237,21 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
                 >
                   {item.value === innerValue ? (
                     <>
-                      {icon || (
+                      {icon ? (
+                        React.cloneElement(icon, {
+                          className: `nut-menu-container-item-icon ${icon.props.className || ''}`,
+                        })
+                      ) : (
                         <Check
                           color={activeColor}
                           size={16}
-                          className={getIconCName(item.value, value)}
+                          className={`nut-menu-container-item-icon ${getIconCName(item.value, value)}`}
                         />
                       )}
                     </>
                   ) : null}
                   <View
-                    className={getIconCName(item.value, value)}
+                    className={`nut-menu-container-item-title ${getIconCName(item.value, value)}`}
                     style={{
                       color: `${item.value === innerValue ? activeColor : ''}`,
                     }}

--- a/src/packages/menuitem/menuitem.tsx
+++ b/src/packages/menuitem/menuitem.tsx
@@ -229,7 +229,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
                   }}
                 >
                   {item.value === innerValue ? (
-                    <i>
+                    <i className="nut-menu-container-item-icon">
                       {icon || (
                         <Check
                           color={activeColor}
@@ -239,7 +239,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
                     </i>
                   ) : null}
                   <div
-                    className={getIconCName(item.value, value)}
+                    className={`nut-menu-container-item-title ${getIconCName(item.value, value)}`}
                     style={{
                       color: `${item.value === innerValue ? activeColor : ''}`,
                     }}


### PR DESCRIPTION
chore(menuitem): 新增css类名，增强自定义样式能力
- [x] 代码风格优化



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `MenuItem` 组件中添加了图标的条件渲染功能。如果图标存在，将克隆并添加额外的样式类；否则，将渲染默认的 `Check` 图标，并应用修改后的样式类名。

- **样式**
  - 更新了图标和标题元素的类名，分别为 `"nut-menu-container-item-icon"` 和 `"nut-menu-container-item-title"`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->