### PR TITLE
chore: 修复 pxTransform 类型导致构建错误

### DIFF
--- a/src/utils/px-transform.ts
+++ b/src/utils/px-transform.ts
@@ -1,8 +1,8 @@
 import { pxTransform as transform } from '@tarojs/taro'
 import { harmony, rn } from './platform-taro'
 
-export default function pxTransform(value: number) {
-  if (harmony()) return transform(value)
+export default function pxTransform(value: number, radix: number) {
+  if (harmony()) return transform(value, radix || 375)
   if (rn()) return value
   return `${value}px`
 }

--- a/src/utils/px-transform.ts
+++ b/src/utils/px-transform.ts
@@ -1,6 +1,8 @@
 import { pxTransform as transform } from '@tarojs/taro'
 import { harmony, rn } from './platform-taro'
-export default function pxTransform(value: number, radix: number) {
+
+export default function pxTransform(value: number, radix?: number): any {
+  // @ts-ignore
   if (harmony()) return transform(value, radix || 375)
   if (rn()) return value
   return `${value}px`

--- a/src/utils/px-transform.ts
+++ b/src/utils/px-transform.ts
@@ -2,6 +2,7 @@ import { pxTransform as transform } from '@tarojs/taro'
 import { harmony, rn } from './platform-taro'
 
 export default function pxTransform(value: number) {
-  if (harmony() || rn()) return transform(value)
+  if (harmony()) return transform(value)
+  if (rn()) return value
   return `${value}px`
 }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了 `pxTransform` 函数，使 `radix` 参数成为可选项，增强了函数的灵活性。
	- 添加了默认的 `radix` 值为 `375`，确保即使未提供该参数函数也能正常工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->