### PR TITLE
feat(menu): allow custom classnames for Menu and dynamic titles

### DIFF
--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -135,7 +135,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
         }
         return (
           <div
-            className={classNames('nut-menu-title', `nut-menu-title${index}`, {
+            className={classNames('nut-menu-title', `nut-menu-title-${index}`, {
               active: showMenuItem[index],
               disabled,
             })}

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -135,14 +135,10 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
         }
         return (
           <div
-            className={classNames(
-              'nut-menu-title ',
-              {
-                active: showMenuItem[index],
-                disabled,
-              },
-              className
-            )}
+            className={classNames('nut-menu-title', `nut-menu-title${index}`, {
+              active: showMenuItem[index],
+              disabled,
+            })}
             style={{ color: showMenuItem[index] ? activeColor : '' }}
             key={index}
             onClick={() => {

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -135,14 +135,10 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
         }
         return (
           <div
-            className={classNames(
-              'nut-menu-title ',
-              {
-                active: showMenuItem[index],
-                disabled,
-              },
-              className
-            )}
+            className={classNames('nut-menu-title', `nut-menu-title${index}`, {
+              active: showMenuItem[index],
+              disabled,
+            })}
             style={{ color: showMenuItem[index] ? activeColor : '' }}
             key={index}
             onClick={(e) => {

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -135,7 +135,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
         }
         return (
           <div
-            className={classNames('nut-menu-title', `nut-menu-title${index}`, {
+            className={classNames('nut-menu-title', `nut-menu-title-${index}`, {
               active: showMenuItem[index],
               disabled,
             })}


### PR DESCRIPTION
支持使用者灵活控制nut-menu与nut-menu-title的样式。
1. 传入的classname默认控制nut-menu
2. 通过我们提供的title${index}类名，控制title

- [x] 新特性提交



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **样式**
  - 优化了菜单组件的 `className` 属性，提升了可读性和可能的性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->