### PR TITLE
fix: 日历滚动的时候 最后一个月日历副标题不准确

### DIFF
--- a/src/packages/calendaritem/calendaritem.taro.tsx
+++ b/src/packages/calendaritem/calendaritem.taro.tsx
@@ -447,8 +447,19 @@ export const CalendarItem = React.forwardRef<
 
   const requestAniFrameFunc = (current: number, monthNum: number) => {
     const lastItem = monthsData[monthsData.length - 1]
-    const containerHeight = lastItem.cssHeight + lastItem.scrollTop
-
+    let HEIGHT_ITEM = 60 // 一行日历的高度
+    const LAST_MONTN_HAS_SIX_LINE = lastItem.monthData.length > 35
+    if (popup && autoBackfill) {
+      HEIGHT_ITEM = LAST_MONTN_HAS_SIX_LINE ? 60 : 80
+    } else if (popup && !autoBackfill) {
+      // 在popup里展示 且底部有确认按钮
+      HEIGHT_ITEM = LAST_MONTN_HAS_SIX_LINE ? 0 : 60
+    } else {
+      HEIGHT_ITEM = LAST_MONTN_HAS_SIX_LINE ? 120 : 140
+    }
+    // 让整个日历区域变高 确保能滚动到最后一个日历
+    const containerHeight =
+      lastItem.cssHeight + lastItem.scrollTop + HEIGHT_ITEM
     requestAniFrame(() => {
       // 初始化 日历位置
       if (monthsRef && monthsPanel && viewAreaRef) {
@@ -459,7 +470,7 @@ export const CalendarItem = React.forwardRef<
         nextTick(() => setScrollWithAnimation(true))
       }
     })
-    setAvgHeight(Math.floor(containerHeight / (monthNum + 1)))
+    setAvgHeight(Math.floor((containerHeight - HEIGHT_ITEM) / (monthNum + 1)))
   }
 
   const initData = () => {
@@ -533,32 +544,13 @@ export const CalendarItem = React.forwardRef<
     }
     const scrollTop = (e.target as HTMLElement).scrollTop
     Taro.getEnv() === 'WEB' && setScrollTop(scrollTop)
-    let current = Math.floor(scrollTop / avgHeight)
+    // avgHeight变小 确保current能取到最后一个月的索引
+    const current = Math.floor(scrollTop / avgHeight)
     if (current < 0) return
-    if (!monthsData[current + 1]) return
-    const nextTop = monthsData[current + 1].scrollTop
-    const nextHeight = monthsData[current + 1].cssHeight
-    if (current === 0) {
-      if (scrollTop >= nextTop) {
-        current += 1
-      }
-    } else if (current > 0 && current < monthsNum - 1) {
-      if (scrollTop >= nextTop) {
-        current += 1
-      }
-      if (scrollTop < monthsData[current].scrollTop) {
-        current -= 1
-      }
-    } else {
-      const viewPosition = Math.round(scrollTop + viewHeight)
-      if (current + 1 <= monthsNum && viewPosition >= nextTop + nextHeight) {
-        current += 1
-      }
-      if (current >= 1 && scrollTop < monthsData[current - 1].scrollTop) {
-        current -= 1
-      }
+    if (current === monthsData.length - 1) {
+      setDefaultRange(monthsNum, current)
+      return
     }
-
     setDefaultRange(monthsNum, current)
   }
 

--- a/src/packages/calendaritem/calendaritem.tsx
+++ b/src/packages/calendaritem/calendaritem.tsx
@@ -447,8 +447,19 @@ export const CalendarItem = React.forwardRef<
 
   const requestAniFrameFunc = (current: number, monthNum: number) => {
     const lastItem = monthsData[monthsData.length - 1]
-    const containerHeight = lastItem.cssHeight + lastItem.scrollTop
-
+    let HEIGHT_ITEM = 60 // 一行日历的高度
+    const LAST_MONTN_HAS_SIX_LINE = lastItem.monthData.length > 35
+    if (popup && autoBackfill) {
+      HEIGHT_ITEM = LAST_MONTN_HAS_SIX_LINE ? 60 : 80
+    } else if (popup && !autoBackfill) {
+      // 在popup里展示 且底部有确认按钮
+      HEIGHT_ITEM = LAST_MONTN_HAS_SIX_LINE ? 0 : 60
+    } else {
+      HEIGHT_ITEM = LAST_MONTN_HAS_SIX_LINE ? 120 : 140
+    }
+    // 让整个日历区域变高 确保能滚动到最后一个日历
+    const containerHeight =
+      lastItem.cssHeight + lastItem.scrollTop + HEIGHT_ITEM
     requestAniFrame(() => {
       // 初始化 日历位置
       if (monthsRef && monthsPanel && viewAreaRef) {
@@ -457,8 +468,7 @@ export const CalendarItem = React.forwardRef<
         getMonthsRef().scrollTop = monthsData[current].scrollTop
       }
     })
-
-    setAvgHeight(Math.floor(containerHeight / (monthNum + 1)))
+    setAvgHeight(Math.floor((containerHeight - HEIGHT_ITEM) / (monthNum + 1)))
   }
 
   const initData = () => {
@@ -532,32 +542,13 @@ export const CalendarItem = React.forwardRef<
       return
     }
     const scrollTop = (e.target as HTMLElement).scrollTop
-    let current = Math.floor(scrollTop / avgHeight)
+    // avgHeight变小 确保current能取到最后一个月的索引
+    const current = Math.floor(scrollTop / avgHeight)
     if (current < 0) return
-    if (!monthsData[current + 1]) return
-    const nextTop = monthsData[current + 1].scrollTop
-    const nextHeight = monthsData[current + 1].cssHeight
-    if (current === 0) {
-      if (scrollTop >= nextTop) {
-        current += 1
-      }
-    } else if (current > 0 && current < monthsNum - 1) {
-      if (scrollTop >= nextTop) {
-        current += 1
-      }
-      if (scrollTop < monthsData[current].scrollTop) {
-        current -= 1
-      }
-    } else {
-      const viewPosition = Math.round(scrollTop + viewHeight)
-      if (current + 1 <= monthsNum && viewPosition >= nextTop + nextHeight) {
-        current += 1
-      }
-      if (current >= 1 && scrollTop < monthsData[current - 1].scrollTop) {
-        current -= 1
-      }
+    if (current === monthsData.length - 1) {
+      setDefaultRange(monthsNum, current)
+      return
     }
-
     setDefaultRange(monthsNum, current)
   }
 


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？
- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/2384
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
具体问题：将日历滚动到最后一个月份，上面的副标题展示的日期不是最后一个月的日期
实现方案：
根据以下情况给日历的容器增加高度 使得能滚动到最后一个月
1.在popup里展示+底部按钮
2.在popup里展示+无底部按钮
3.平铺展示
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 日历组件的高度调整机制得到增强，现在可以根据最后一个月的数据行数和弹出状态动态调整高度。
	- 改善了当前月份的索引计算逻辑，使其更加简洁，响应用户的滚动操作更流畅。

- **错误修复**
	- 修正了关于当前月份更新的逻辑，减少了潜在的索引管理错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->