### PR TITLE
feat(menu): menu-item 组件增加标题icon自定义方式

### DIFF
--- a/src/packages/menu/demos/h5/demo6.tsx
+++ b/src/packages/menu/demos/h5/demo6.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Menu } from '@nutui/nutui-react'
-import { ArrowDown, Star } from '@nutui/icons-react'
+import { ArrowDown, Star, Filter } from '@nutui/icons-react'
 
 const Demo6 = () => {
   const [options] = useState([
@@ -15,7 +15,12 @@ const Demo6 = () => {
   ])
   return (
     <Menu icon={<ArrowDown />}>
-      <Menu.Item options={options} defaultValue={0} icon={<Star />} />
+      <Menu.Item
+        options={options}
+        defaultValue={0}
+        icon={<Star />}
+        titleIcon={<Filter />}
+      />
       <Menu.Item options={options1} defaultValue="a" />
     </Menu>
   )

--- a/src/packages/menu/demos/taro/demo6.tsx
+++ b/src/packages/menu/demos/taro/demo6.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Menu } from '@nutui/nutui-react-taro'
-import { ArrowDown, Star } from '@nutui/icons-react-taro'
+import { ArrowDown, Star, Filter } from '@nutui/icons-react-taro'
 
 const Demo6 = () => {
   const [options] = useState([
@@ -15,7 +15,12 @@ const Demo6 = () => {
   ])
   return (
     <Menu icon={<ArrowDown />}>
-      <Menu.Item options={options} defaultValue={0} icon={<Star />} />
+      <Menu.Item
+        options={options}
+        defaultValue={0}
+        icon={<Star />}
+        titleIcon={<Filter />}
+      />
       <Menu.Item options={options1} defaultValue="a" />
     </Menu>
   )

--- a/src/packages/menu/doc.en-US.md
+++ b/src/packages/menu/doc.en-US.md
@@ -97,6 +97,7 @@ Popup can be closed with toggle method in menu instance.
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | title | Item title | `string` | `Current selected value` |
+| titleIcon | menu item icon | `React.ReactNode` | `ArrowUp/ArrowDown` |
 | options | Options | `Array` | `-` |
 | disabled | Whether to disable dropdown item | `boolean` | `false` |
 | columns | Display how many options in one line | `number` | `1` |

--- a/src/packages/menu/doc.md
+++ b/src/packages/menu/doc.md
@@ -97,6 +97,7 @@ import { Menu } from '@nutui/nutui-react'
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | title | 菜单项标题 | `string` | `当前选中项文字` |
+| titleIcon | 菜单项 icon | `React.ReactNode` | `ArrowUp/ArrowDown` |
 | options | 选项数组 | `array` | `-` |
 | disabled | 是否禁用菜单 | `boolean` | `false` |
 | columns | 可以设置一行展示多少列 options | `number` | `1` |

--- a/src/packages/menu/doc.taro.md
+++ b/src/packages/menu/doc.taro.md
@@ -97,6 +97,7 @@ import { Menu } from '@nutui/nutui-react-taro'
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | title | 菜单项标题 | `string` | `当前选中项文字` |
+| titleIcon | 菜单项 icon | `React.ReactNode` | `ArrowUp/ArrowDown` |
 | options | 选项数组 | `array` | `-` |
 | disabled | 是否禁用菜单 | `boolean` | `false` |
 | columns | 可以设置一行展示多少列 options | `number` | `1` |

--- a/src/packages/menu/doc.zh-TW.md
+++ b/src/packages/menu/doc.zh-TW.md
@@ -97,6 +97,7 @@ import { Menu } from '@nutui/nutui-react'
 | 屬性 | 說明 | 類型 | 默認值 |
 | --- | --- | --- | --- |
 | title | 菜單項標題 | `string` | `當前選中項文字` |
+| titleIcon | 菜單項 icon | `React.ReactNode` | `ArrowUp/ArrowDown` |
 | options | 選項數組 | `array` | `-` |
 | disabled | 是否禁用菜單 | `boolean` | `false` |
 | columns | 可以設置一行展示多少列 options | `number` | `1` |

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -120,8 +120,15 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   const menuTitle = () => {
     return React.Children.map(children, (child, index) => {
       if (React.isValidElement(child)) {
-        const { title, options, value, defaultValue, disabled, direction } =
-          child.props
+        const {
+          title,
+          titleIcon,
+          options,
+          value,
+          defaultValue,
+          disabled,
+          direction,
+        } = child.props
         const selected = options?.filter(
           (option: OptionItem) =>
             option.value === (value !== undefined ? value : defaultValue)
@@ -132,6 +139,23 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
           if (selected && selected.length && selected[0].text)
             return selected[0].text
           return ''
+        }
+        const finallyIcon = () => {
+          if (titleIcon) return titleIcon
+          if (icon) return icon
+          return direction === 'up' ? (
+            <ArrowUp
+              className="nut-menu-title-icon"
+              width="12px"
+              height="12px"
+            />
+          ) : (
+            <ArrowDown
+              className="nut-menu-title-icon"
+              width="12px"
+              height="12px"
+            />
+          )
         }
         return (
           <div
@@ -147,12 +171,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
             }}
           >
             <div className="nut-menu-title-text">{finallyTitle()}</div>
-            {icon ||
-              (direction === 'up' ? (
-                <ArrowUp className="nut-menu-title-icon" size="12px" />
-              ) : (
-                <ArrowDown className="nut-menu-title-icon" size="12px" />
-              ))}
+            {finallyIcon()}
           </div>
         )
       }

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -120,8 +120,15 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   const menuTitle = () => {
     return React.Children.map(children, (child, index) => {
       if (React.isValidElement(child)) {
-        const { title, options, value, defaultValue, disabled, direction } =
-          child.props
+        const {
+          title,
+          titleIcon,
+          options,
+          value,
+          defaultValue,
+          disabled,
+          direction,
+        } = child.props
         const selected = options?.filter(
           (option: OptionItem) =>
             option.value === (value !== undefined ? value : defaultValue)
@@ -132,6 +139,23 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
           if (selected && selected.length && selected[0].text)
             return selected[0].text
           return ''
+        }
+        const finallyIcon = () => {
+          if (titleIcon) return titleIcon
+          if (icon) return icon
+          return direction === 'up' ? (
+            <ArrowUp
+              className="nut-menu-title-icon"
+              width="12px"
+              height="12px"
+            />
+          ) : (
+            <ArrowDown
+              className="nut-menu-title-icon"
+              width="12px"
+              height="12px"
+            />
+          )
         }
         return (
           <div
@@ -148,20 +172,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
             }}
           >
             <div className="nut-menu-title-text">{finallyTitle()}</div>
-            {icon ||
-              (direction === 'up' ? (
-                <ArrowUp
-                  className="nut-menu-title-icon"
-                  width="12px"
-                  height="12px"
-                />
-              ) : (
-                <ArrowDown
-                  className="nut-menu-title-icon"
-                  width="12px"
-                  height="12px"
-                />
-              ))}
+            {finallyIcon()}
           </div>
         )
       }

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -24,6 +24,7 @@ export interface OptionItem {
 
 export interface MenuItemProps extends BasicComponent {
   title: React.ReactNode
+  titleIcon: React.ReactNode
   options: OptionItem[]
   disabled: boolean
   columns: number
@@ -40,6 +41,7 @@ export interface MenuItemProps extends BasicComponent {
 
 const defaultProps = {
   ...ComponentDefaults,
+  titleIcon: null,
   columns: 1,
   direction: 'down',
   icon: null,

--- a/src/packages/menuitem/menuitem.tsx
+++ b/src/packages/menuitem/menuitem.tsx
@@ -23,6 +23,7 @@ export interface OptionItem {
 
 export interface MenuItemProps extends BasicComponent {
   title: React.ReactNode
+  titleIcon: React.ReactNode
   options: OptionItem[]
   disabled: boolean
   columns: number
@@ -39,6 +40,7 @@ export interface MenuItemProps extends BasicComponent {
 
 const defaultProps = {
   ...ComponentDefaults,
+  titleIcon: null,
   columns: 1,
   direction: 'down',
   icon: null,


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/jdf2e/nutui-react/issues/2487

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 解决 Menu 标题的 icon 自定义程度不足问题
2. Menu.Item 增加 `titleIcon` 用于配置标题 icon

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 在菜单组件中新增`titleIcon`属性，允许用户在菜单项旁边显示自定义图标，提升界面清晰度和交互体验。
	- 在Demo6组件中引入了新的`Filter`图标，进一步增强了菜单项的视觉表示。

- **文档**
	- 更新了菜单组件文档，增加了关于`titleIcon`属性的描述，帮助开发者更好地理解和使用该功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->