### PR TITLE
feat: support actionsheet & numberKeyboard round props to control whether to display round corners

### DIFF
--- a/src/packages/actionsheet/actionsheet.taro.tsx
+++ b/src/packages/actionsheet/actionsheet.taro.tsx
@@ -47,7 +47,7 @@ export const ActionSheet: FunctionComponent<
   const classPrefix = 'nut-actionsheet'
 
   const cancelActionSheet = () => {
-    onCancel && onCancel()
+    onCancel?.()
   }
 
   const chooseItem = (
@@ -55,7 +55,7 @@ export const ActionSheet: FunctionComponent<
     index: number
   ) => {
     if (!item.disabled) {
-      onSelect && onSelect(item, index)
+      onSelect?.(item, index)
     }
   }
 
@@ -69,7 +69,7 @@ export const ActionSheet: FunctionComponent<
       description={description}
       className={classPrefix}
       onClose={() => {
-        onCancel && onCancel()
+        onCancel?.()
       }}
     >
       <div className={`${className}`} style={style}>

--- a/src/packages/actionsheet/actionsheet.taro.tsx
+++ b/src/packages/actionsheet/actionsheet.taro.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
   cancelText: '',
   onCancel: () => {},
   onSelect: () => {},
+  round: true,
 } as unknown as ActionSheetProps
 export const ActionSheet: FunctionComponent<
   Partial<ActionSheetProps> &
@@ -38,6 +39,7 @@ export const ActionSheet: FunctionComponent<
     onSelect,
     visible,
     className,
+    round,
     style,
     ...rest
   } = { ...defaultProps, ...props }
@@ -60,7 +62,7 @@ export const ActionSheet: FunctionComponent<
   return (
     <Popup
       {...rest}
-      round
+      round={round}
       visible={visible}
       position="bottom"
       title={title}

--- a/src/packages/actionsheet/actionsheet.tsx
+++ b/src/packages/actionsheet/actionsheet.tsx
@@ -47,7 +47,7 @@ export const ActionSheet: FunctionComponent<
   const classPrefix = 'nut-actionsheet'
 
   const cancelActionSheet = () => {
-    onCancel && onCancel()
+    onCancel?.()
   }
 
   const chooseItem = (
@@ -55,7 +55,7 @@ export const ActionSheet: FunctionComponent<
     index: number
   ) => {
     if (!item.disabled) {
-      onSelect && onSelect(item, index)
+      onSelect?.(item, index)
     }
   }
 
@@ -69,7 +69,7 @@ export const ActionSheet: FunctionComponent<
       description={description}
       className={classPrefix}
       onClose={() => {
-        onCancel && onCancel()
+        onCancel?.()
       }}
     >
       <div className={`${className}`} style={style}>

--- a/src/packages/actionsheet/actionsheet.tsx
+++ b/src/packages/actionsheet/actionsheet.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
   cancelText: '',
   onCancel: () => {},
   onSelect: () => {},
+  round: true,
 } as unknown as ActionSheetProps
 export const ActionSheet: FunctionComponent<
   Partial<ActionSheetProps> &
@@ -39,6 +40,7 @@ export const ActionSheet: FunctionComponent<
     visible,
     className,
     style,
+    round,
     ...rest
   } = { ...defaultProps, ...props }
 
@@ -60,7 +62,7 @@ export const ActionSheet: FunctionComponent<
   return (
     <Popup
       {...rest}
-      round
+      round={round}
       visible={visible}
       position="bottom"
       title={title}

--- a/src/packages/actionsheet/doc.en-US.md
+++ b/src/packages/actionsheet/doc.en-US.md
@@ -65,6 +65,7 @@ import { ActionSheet } from '@nutui/nutui-react'
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | visible | Mask layer visible | `boolean` | `false` |
+| round | Whether to show rounded corners | `boolean` | `true` |
 | title | Set panel title | `string` | `-` |
 | description | Set panel subtitle/description | `string` | `-` |
 | cancelText | Cancel Text | `string` | `Cancel` |

--- a/src/packages/actionsheet/doc.md
+++ b/src/packages/actionsheet/doc.md
@@ -65,6 +65,7 @@ import { ActionSheet } from '@nutui/nutui-react'
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | visible | 遮罩层可见 | `boolean` | `false` |
+| round | 是否显示圆角 | `boolean` | `true` |
 | title | 设置列表面板标题 | `string` | `-` |
 | description | 设置列表面板副标题/描述 | `string` | `-` |
 | options | 列表项 | `Array` | `[]` |

--- a/src/packages/actionsheet/doc.taro.md
+++ b/src/packages/actionsheet/doc.taro.md
@@ -65,6 +65,7 @@ import { ActionSheet } from '@nutui/nutui-react-taro'
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | visible | 遮罩层可见 | `boolean` | `false` |
+| round | 是否显示圆角 | `boolean` | `true` |
 | title | 设置列表面板标题 | `string` | `-` |
 | description | 设置列表面板副标题/描述 | `string` | `-` |
 | options | 列表项 | `Array` | `[]` |

--- a/src/packages/actionsheet/doc.zh-TW.md
+++ b/src/packages/actionsheet/doc.zh-TW.md
@@ -65,6 +65,7 @@ import { ActionSheet } from '@nutui/nutui-react'
 | 屬性 | 說明 | 類型 | 預設值 |
 | --- | --- | --- | --- |
 | visible | 遮罩層可見 | `boolean` | `false` |
+| round | 是否顯示圓角 | `boolean` | `true` |
 | title | 設定列錶面闆標題 | `string` | \- |
 | description | 設定列錶面闆副標題/描述 | `string` | \- |
 | options | 列錶項 | `Array` | `[]` |

--- a/src/packages/numberkeyboard/_test_/__snapshots__/index.spec.tsx.snap
+++ b/src/packages/numberkeyboard/_test_/__snapshots__/index.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`should match custom snapshot 1`] = `
     style="background-color: rgba(0, 0, 0, 0); --nutui-overlay-zIndex: 9999;"
   />
   <div
-    class="nut-popup nut-popup-round nut-popup-bottom"
+    class="nut-popup nut-popup-bottom"
     style="z-index: 9999;"
   >
     <div
@@ -200,7 +200,7 @@ exports[`should match snapshot 1`] = `
     style="background-color: rgba(0, 0, 0, 0); --nutui-overlay-zIndex: 9999;"
   />
   <div
-    class="nut-popup nut-popup-round nut-popup-bottom"
+    class="nut-popup nut-popup-bottom"
     style="z-index: 9999;"
   >
     <div

--- a/src/packages/numberkeyboard/_test_/__snapshots__/index.spec.tsx.snap
+++ b/src/packages/numberkeyboard/_test_/__snapshots__/index.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`should match custom snapshot 1`] = `
     style="background-color: rgba(0, 0, 0, 0); --nutui-overlay-zIndex: 9999;"
   />
   <div
-    class="nut-popup nut-popup-bottom"
+    class="nut-popup nut-popup-round nut-popup-bottom"
     style="z-index: 9999;"
   >
     <div
@@ -200,7 +200,7 @@ exports[`should match snapshot 1`] = `
     style="background-color: rgba(0, 0, 0, 0); --nutui-overlay-zIndex: 9999;"
   />
   <div
-    class="nut-popup nut-popup-bottom"
+    class="nut-popup nut-popup-round nut-popup-bottom"
     style="z-index: 9999;"
   >
     <div

--- a/src/packages/numberkeyboard/doc.en-US.md
+++ b/src/packages/numberkeyboard/doc.en-US.md
@@ -77,6 +77,7 @@ You can use `rightActions` when you want to set the right actions on the title b
 | onDelete | Emitted when the delete key is pressed | `-` | `-` |
 | onClose | Emitted when the close button or non-keyboard area is clicked is clicked | `-` | `-` |
 | onConfirm | Emitted when confirm key is pressed | `-` | `-` |
+| round | Whether to show rounded corners | `boolean` | `true` |
 
 ## Theming
 

--- a/src/packages/numberkeyboard/doc.md
+++ b/src/packages/numberkeyboard/doc.md
@@ -77,6 +77,7 @@ import { NumberKeyboard } from '@nutui/nutui-react'
 | onDelete | 点击删除键时触发 | `-` | `-` |
 | onClose | 点击关闭按钮或非键盘区域时触发 | `-` | `-` |
 | onConfirm | 点击确定按钮时触发 | `-` | `-` |
+| round | 是否显示圆角 | `boolean` | `true` |
 
 ## 主题定制
 

--- a/src/packages/numberkeyboard/doc.taro.md
+++ b/src/packages/numberkeyboard/doc.taro.md
@@ -77,6 +77,7 @@ import { NumberKeyboard } from '@nutui/nutui-react-taro'
 | onDelete | 点击删除键时触发 | `-` | `-` |
 | onClose | 点击关闭按钮或非键盘区域时触发 | `-` | `-` |
 | onConfirm | 点击确定按钮时触发 | `-` | `-` |
+| round | 是否显示圆角 | `boolean` | `true` |
 
 ## 主题定制
 

--- a/src/packages/numberkeyboard/doc.zh-TW.md
+++ b/src/packages/numberkeyboard/doc.zh-TW.md
@@ -77,6 +77,7 @@ import { NumberKeyboard } from '@nutui/nutui-react'
 | onDelete | 點擊刪除鍵時觸發 | `-` | `-` |
 | onClose | 點擊關閉按鈕或非鍵盤區域時觸發 | `-` | `-` |
 | onConfirm | 點擊確定按鈕時觸發 | `-` | `-` |
+| round | 是否顯示圓角 | `boolean` | `true` |
 
 ## 主題定製
 

--- a/src/packages/numberkeyboard/numberkeyboard.taro.tsx
+++ b/src/packages/numberkeyboard/numberkeyboard.taro.tsx
@@ -48,8 +48,9 @@ export const NumberKeyboard: FunctionComponent<
     onDelete,
     onClose,
     onConfirm,
+    round,
     ...rest
-  } = props
+  } = { ...defaultProps, ...props }
   const classPrefix = 'nut-numberkeyboard'
 
   const getBasicKeys = () => {
@@ -140,13 +141,14 @@ export const NumberKeyboard: FunctionComponent<
 
   return (
     <Popup
+      {...rest}
+      round={round}
       visible={visible}
       position="bottom"
       onOverlayClick={onClose}
       onCloseIconClick={onClose}
       zIndex={9999}
       overlayStyle={{ backgroundColor: 'rgba(0, 0, 0, 0)' }}
-      {...rest}
     >
       <div className={classNames(classPrefix, className)} style={style}>
         {title && (

--- a/src/packages/numberkeyboard/numberkeyboard.taro.tsx
+++ b/src/packages/numberkeyboard/numberkeyboard.taro.tsx
@@ -101,17 +101,37 @@ export const NumberKeyboard: FunctionComponent<
     }
     const onTouchEnd = (item: { id: string; type: string }) => {
       setActive(false)
-      if (item.type === 'num' || item.type === 'custom') {
-        onChange && onChange(item.id)
+      switch (item.type) {
+        case 'num':
+        case 'custom':
+          onChange?.(item.id)
+          break
+        case 'close':
+          onClose?.()
+          break
+        case 'delete':
+          onDelete?.()
+          break
+        case 'confirm':
+          onConfirm?.()
+          break
+        default:
+          break
       }
-      if (item.type === 'close') {
-        onClose && onClose()
-      }
-      if (item.type === 'delete') {
-        onDelete && onDelete()
-      }
-      if (item.type === 'confirm') {
-        onConfirm && onConfirm()
+    }
+    const renderContent = (item: { id: string; type: string }) => {
+      switch (item.type) {
+        case 'num':
+        case 'custom':
+          return <div>{item.id}</div>
+        case 'delete':
+          return <DeleteIcon />
+        case 'close':
+          return <ArrowDown size={18} />
+        case 'confirm':
+          return <>{confirmText || locale.done}</>
+        default:
+          return null
       }
     }
     return (
@@ -128,12 +148,7 @@ export const NumberKeyboard: FunctionComponent<
           onTouchEnd={() => onTouchEnd(item)}
           onTouchCancel={() => onTouchEnd(item)}
         >
-          {(item.type === 'num' || item.type === 'custom') && (
-            <div>{item.id}</div>
-          )}
-          {item.type === 'delete' && <DeleteIcon />}
-          {item.type === 'close' && <ArrowDown size={18} />}
-          {item.type === 'confirm' && <>{confirmText || locale.done}</>}
+          {renderContent(item)}
         </div>
       </div>
     )

--- a/src/packages/numberkeyboard/numberkeyboard.tsx
+++ b/src/packages/numberkeyboard/numberkeyboard.tsx
@@ -106,17 +106,37 @@ export const NumberKeyboard: FunctionComponent<
     }
     const onTouchEnd = (item: { id: string; type: string }) => {
       setActive(false)
-      if (item.type === 'num' || item.type === 'custom') {
-        onChange && onChange(item.id)
+      switch (item.type) {
+        case 'num':
+        case 'custom':
+          onChange?.(item.id)
+          break
+        case 'close':
+          onClose?.()
+          break
+        case 'delete':
+          onDelete?.()
+          break
+        case 'confirm':
+          onConfirm?.()
+          break
+        default:
+          break
       }
-      if (item.type === 'close') {
-        onClose && onClose()
-      }
-      if (item.type === 'delete') {
-        onDelete && onDelete()
-      }
-      if (item.type === 'confirm') {
-        onConfirm && onConfirm()
+    }
+    const renderContent = (item: { id: string; type: string }) => {
+      switch (item.type) {
+        case 'num':
+        case 'custom':
+          return <div>{item.id}</div>
+        case 'delete':
+          return <DeleteIcon />
+        case 'close':
+          return <ArrowDown width={18} height={18} />
+        case 'confirm':
+          return <>{confirmText || locale.done}</>
+        default:
+          return null
       }
     }
     return (
@@ -133,12 +153,7 @@ export const NumberKeyboard: FunctionComponent<
           onTouchEnd={() => onTouchEnd(item)}
           onTouchCancel={() => onTouchEnd(item)}
         >
-          {(item.type === 'num' || item.type === 'custom') && (
-            <div>{item.id}</div>
-          )}
-          {item.type === 'delete' && <DeleteIcon />}
-          {item.type === 'close' && <ArrowDown width={18} height={18} />}
-          {item.type === 'confirm' && <>{confirmText || locale.done}</>}
+          {renderContent(item)}
         </div>
       </div>
     )

--- a/src/packages/numberkeyboard/numberkeyboard.tsx
+++ b/src/packages/numberkeyboard/numberkeyboard.tsx
@@ -26,6 +26,7 @@ const defaultProps = {
   custom: [],
   random: false,
   onClose: () => {},
+  round: true,
 } as unknown as NumberKeyboardProps
 
 export const NumberKeyboard: FunctionComponent<
@@ -47,8 +48,9 @@ export const NumberKeyboard: FunctionComponent<
     onDelete,
     onClose,
     onConfirm,
+    round,
     ...rest
-  } = props
+  } = { ...defaultProps, ...props }
   const classPrefix = 'nut-numberkeyboard'
 
   const getBasicKeys = () => {
@@ -144,13 +146,14 @@ export const NumberKeyboard: FunctionComponent<
 
   return (
     <Popup
+      {...rest}
+      round={round}
       visible={visible}
       position="bottom"
       onOverlayClick={onClose}
       onCloseIconClick={onClose}
       zIndex={9999}
       overlayStyle={{ backgroundColor: 'rgba(0, 0, 0, 0)' }}
-      {...rest}
     >
       <div className={classNames(classPrefix, className)} style={style}>
         {title && (

--- a/src/packages/popup/__tests__/popup.spec.tsx
+++ b/src/packages/popup/__tests__/popup.spec.tsx
@@ -54,7 +54,6 @@ test('pop from bottom', () => {
   const { container } = render(<Popup visible position="bottom" />)
   const pop = container.querySelector('.nut-popup-bottom') as HTMLElement
   expect(pop).toBeTruthy()
-  expect(pop).toHaveClass('nut-popup-round')
 })
 
 test('pop from left', () => {

--- a/src/packages/popup/demos/h5/demo3.tsx
+++ b/src/packages/popup/demos/h5/demo3.tsx
@@ -28,6 +28,7 @@ const Demo3 = () => {
         }}
       />
       <Popup
+        round
         closeable
         visible={showIcon}
         left="返回"
@@ -38,6 +39,7 @@ const Demo3 = () => {
         }}
       />
       <Popup
+        round
         closeable
         visible={showIconPosition}
         closeIconPosition="top-left"
@@ -47,6 +49,7 @@ const Demo3 = () => {
         }}
       />
       <Popup
+        round
         closeable
         closeIcon={<Heart width="15px" height="15px" />}
         visible={showIconDefine}

--- a/src/packages/popup/demos/h5/demo4.tsx
+++ b/src/packages/popup/demos/h5/demo4.tsx
@@ -34,6 +34,7 @@ const Demo4 = () => {
         }}
       />
       <Popup
+        round
         closeable
         closeIcon={<Failure width="12px" height="12px" />}
         visible={showCloseIconStop}

--- a/src/packages/popup/demos/taro/demo3.tsx
+++ b/src/packages/popup/demos/taro/demo3.tsx
@@ -28,6 +28,7 @@ const Demo3 = () => {
         }}
       />
       <Popup
+        round
         closeable
         visible={showIcon}
         left="返回"
@@ -38,6 +39,7 @@ const Demo3 = () => {
         }}
       />
       <Popup
+        round
         closeable
         visible={showIconPosition}
         closeIconPosition="top-left"
@@ -47,6 +49,7 @@ const Demo3 = () => {
         }}
       />
       <Popup
+        round
         closeable
         closeIcon={<Heart size="15px" />}
         visible={showIconDefine}

--- a/src/packages/popup/demos/taro/demo4.tsx
+++ b/src/packages/popup/demos/taro/demo4.tsx
@@ -34,6 +34,7 @@ const Demo4 = () => {
         }}
       />
       <Popup
+        round
         closeable
         closeIcon={<Failure size={12} />}
         visible={showCloseIconStop}

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -144,7 +144,7 @@ export const Popup: FunctionComponent<
     if (destroyOnClose) {
       setShowChildren(true)
     }
-    onOpen && onOpen()
+    onOpen?.()
   }
 
   const close = () => {
@@ -162,30 +162,30 @@ export const Popup: FunctionComponent<
   const onHandleClickOverlay = (e: ITouchEvent) => {
     e.stopPropagation()
     if (closeOnOverlayClick) {
-      const closed = onOverlayClick && onOverlayClick(e)
+      const closed = onOverlayClick?.(e)
       closed && close()
     }
   }
 
   const onHandleClick = (e: ITouchEvent) => {
-    onClick && onClick(e)
+    onClick?.(e)
   }
 
   const onHandleClickCloseIcon = (e: ITouchEvent) => {
-    const closed = onCloseIconClick && onCloseIconClick(e)
+    const closed = onCloseIconClick?.(e)
     closed && close()
   }
 
   const onHandleOpened: EnterHandler<HTMLElement | undefined> | undefined = (
     e: HTMLElement
   ) => {
-    afterShow && afterShow()
+    afterShow?.()
   }
 
   const onHandleClosed: ExitHandler<HTMLElement | undefined> | undefined = (
     e: HTMLElement
   ) => {
-    afterClose && afterClose()
+    afterClose?.()
   }
 
   const resolveContainer = (getContainer: Teleport | undefined) => {
@@ -271,7 +271,7 @@ export const Popup: FunctionComponent<
   const renderNode = () => {
     return (
       <>
-        {overlay ? (
+        {overlay && (
           <>
             <Overlay
               style={overlayStyles}
@@ -282,18 +282,15 @@ export const Popup: FunctionComponent<
               duration={duration}
               onClick={onHandleClickOverlay}
             />
-            {renderPop()}
           </>
-        ) : (
-          <>{renderPop()}</>
         )}
+        <>{renderPop()}</>
       </>
     )
   }
 
   useEffect(() => {
-    visible && open()
-    !visible && close()
+    visible ? open() : close()
   }, [visible])
 
   useEffect(() => {

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -125,7 +125,7 @@ export const Popup: FunctionComponent<
   const popClassName = classNames(
     {
       [`${classPrefix}`]: true,
-      [`${classPrefix}-round`]: round || position === 'bottom',
+      [`${classPrefix}-round`]: round,
       [`${classPrefix}-${position}`]: true,
     },
     className

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -155,7 +155,7 @@ export const Popup: FunctionComponent<
           setShowChildren(false)
         }, Number(duration))
       }
-      onClose && onClose()
+      onClose?.()
     }
   }
 

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -123,7 +123,7 @@ export const Popup: FunctionComponent<
   const popClassName = classNames(
     {
       [`${classPrefix}`]: true,
-      [`${classPrefix}-round`]: round || position === 'bottom',
+      [`${classPrefix}-round`]: round,
       [`${classPrefix}-${position}`]: true,
     },
     className

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -142,7 +142,7 @@ export const Popup: FunctionComponent<
     if (destroyOnClose) {
       setShowChildren(true)
     }
-    onOpen && onOpen()
+    onOpen?.()
   }
 
   const close = () => {
@@ -153,39 +153,39 @@ export const Popup: FunctionComponent<
           setShowChildren(false)
         }, Number(duration))
       }
-      onClose && onClose()
+      onClose?.()
     }
   }
 
   const onHandleClickOverlay = (e: MouseEvent) => {
     e.stopPropagation()
     if (closeOnOverlayClick) {
-      const closed = onOverlayClick && onOverlayClick(e)
+      const closed = onOverlayClick?.(e)
       closed && close()
     }
   }
 
   const onHandleClick: MouseEventHandler<HTMLDivElement> = (e: MouseEvent) => {
-    onClick && onClick(e)
+    onClick?.(e)
   }
 
   const onHandleClickCloseIcon: MouseEventHandler<HTMLDivElement> = (
     e: MouseEvent
   ) => {
-    const closed = onCloseIconClick && onCloseIconClick(e)
+    const closed = onCloseIconClick?.(e)
     closed && close()
   }
 
   const onHandleOpened: EnterHandler<HTMLElement | undefined> | undefined = (
     e: HTMLElement
   ) => {
-    afterShow && afterShow()
+    afterShow?.()
   }
 
   const onHandleClosed: ExitHandler<HTMLElement | undefined> | undefined = (
     e: HTMLElement
   ) => {
-    afterClose && afterClose()
+    afterClose?.()
   }
 
   const resolveContainer = (getContainer: Teleport | undefined) => {
@@ -271,7 +271,7 @@ export const Popup: FunctionComponent<
   const renderNode = () => {
     return (
       <>
-        {overlay ? (
+        {overlay && (
           <>
             <Overlay
               style={overlayStyles}
@@ -282,18 +282,15 @@ export const Popup: FunctionComponent<
               duration={duration}
               onClick={onHandleClickOverlay}
             />
-            {renderPop()}
           </>
-        ) : (
-          <>{renderPop()}</>
         )}
+        <>{renderPop()}</>
       </>
     )
   }
 
   useEffect(() => {
-    visible && open()
-    !visible && close()
+    visible ? open() : close()
   }, [visible])
 
   useEffect(() => {


### PR DESCRIPTION
1. 将popup的round属性暴露给actionsheet,让用户决定是否使用圆角。
2. 区别：默认值：popup是false. actionsheet是true。原因：通常actionsheet有圆角，自定义设置round={false}即可\
3. 测试过程中发现了同时用到了popup的numberkeyboard组件中一些写法的问题，并在round属性上组件和文档同步了actionsheet的处理。
- [x] 站点、文档改进
- [x] 演示代码改进
- [x] 功能增强



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新特性**
  - 在`ActionSheet`组件中新增`round`属性，允许用户配置是否显示圆角，默认值为`true`。
  - 在`NumberKeyboard`组件中新增`round`属性，提升组件的可配置性，默认值为`true`。
  - 更新多个`Popup`组件的实例，支持`round`属性，使其外观更具圆润感。

- **文档**
  - 更新`ActionSheet`组件的文档，添加`round`属性的描述，确保用户了解该功能。
  - 更新`NumberKeyboard`组件的文档，添加`round`属性的描述，增强组件的定制选项。

- **样式**
  - 简化`Popup`组件中`round`类的逻辑，确保只有在`round`属性为真时才应用圆角样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->