### PR TITLE
fix(uploader): correct xhrBeforeUpload execution timing

### DIFF
--- a/src/packages/uploader/upload.ts
+++ b/src/packages/uploader/upload.ts
@@ -88,10 +88,12 @@ export class UploaderTaro extends Upload {
 
   uploadTaro(uploadFile: any, env: string) {
     const options = this.options
+    if (options.beforeXhrUpload) {
+      options.beforeXhrUpload(uploadFile, options)
+      return
+    }
     if (env === 'WEB') {
       this.upload()
-    } else if (options.beforeXhrUpload) {
-      options.beforeXhrUpload(uploadFile, options)
     } else {
       const uploadTask = uploadFile({
         url: options.url,


### PR DESCRIPTION
原来taroUpload的代码逻辑似乎有错误.
有beforeXhrUpload应该执行，而不是被env === 'WEB'所拦截了
- [x] 日常 bug 修复



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在上传流程中添加了 `beforeXhrUpload` 选项的支持，允许在上传前执行自定义逻辑。
	- 该选项不再受限于特定环境，增强了上传过程的灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->