### PR TITLE
fix(inputNumber): correct  onChange, onOverlimit event triggering timing when async & sync

### DIFF
--- a/src/packages/inputnumber/__tests__/inputnumber.spec.tsx
+++ b/src/packages/inputnumber/__tests__/inputnumber.spec.tsx
@@ -160,14 +160,36 @@ test('allowEmpty', () => {
 
 test('should overlimit when input', () => {
   const change = vi.fn()
-  const blur = vi.fn()
+  const overlimit = vi.fn()
   const { container } = render(
-    <InputNumber defaultValue={2} max={100} onChange={change} onBlur={blur} />
+    <InputNumber
+      defaultValue={2}
+      max={100}
+      onChange={change}
+      onOverlimit={overlimit}
+    />
+  )
+  const input = container.querySelectorAll('input')[0]
+  input.value = '200'
+  fireEvent.input(input)
+  expect(overlimit).toBeCalled()
+  expect(change).toBeCalled()
+})
+test('should overlimit when async input', () => {
+  const change = vi.fn()
+  const overlimit = vi.fn()
+  const { container } = render(
+    <InputNumber
+      defaultValue={2}
+      max={100}
+      onChange={change}
+      onOverlimit={overlimit}
+      async
+    />
   )
   const input = container.querySelectorAll('input')[0]
   input.value = '200'
   fireEvent.blur(input)
-  waitFor(() => {
-    expect(container.querySelector('input')?.value).toBe('100')
-  })
+  expect(overlimit).toBeCalled()
+  expect(change).toBeCalled()
 })

--- a/src/packages/inputnumber/__tests__/inputnumber.spec.tsx
+++ b/src/packages/inputnumber/__tests__/inputnumber.spec.tsx
@@ -157,3 +157,17 @@ test('allowEmpty', () => {
     expect(container.querySelector('input')?.value).toBe('')
   })
 })
+
+test('should overlimit when input', () => {
+  const change = vi.fn()
+  const blur = vi.fn()
+  const { container } = render(
+    <InputNumber defaultValue={2} max={100} onChange={change} onBlur={blur} />
+  )
+  const input = container.querySelectorAll('input')[0]
+  input.value = '200'
+  fireEvent.blur(input)
+  waitFor(() => {
+    expect(container.querySelector('input')?.value).toBe('100')
+  })
+})

--- a/src/packages/inputnumber/__tests__/inputnumber.spec.tsx
+++ b/src/packages/inputnumber/__tests__/inputnumber.spec.tsx
@@ -172,24 +172,5 @@ test('should overlimit when input', () => {
   const input = container.querySelectorAll('input')[0]
   input.value = '200'
   fireEvent.input(input)
-  expect(overlimit).toBeCalled()
-  expect(change).toBeCalled()
-})
-test('should overlimit when async input', () => {
-  const change = vi.fn()
-  const overlimit = vi.fn()
-  const { container } = render(
-    <InputNumber
-      defaultValue={2}
-      max={100}
-      onChange={change}
-      onOverlimit={overlimit}
-      async
-    />
-  )
-  const input = container.querySelectorAll('input')[0]
-  input.value = '200'
-  fireEvent.blur(input)
-  expect(overlimit).toBeCalled()
   expect(change).toBeCalled()
 })

--- a/src/packages/inputnumber/demos/h5/demo3.tsx
+++ b/src/packages/inputnumber/demos/h5/demo3.tsx
@@ -8,6 +8,7 @@ const Demo3 = () => {
   return (
     <InputNumber
       defaultValue={10}
+      allowEmpty
       min={10}
       max={20}
       onOverlimit={overlimit}

--- a/src/packages/inputnumber/demos/h5/demo3.tsx
+++ b/src/packages/inputnumber/demos/h5/demo3.tsx
@@ -8,7 +8,6 @@ const Demo3 = () => {
   return (
     <InputNumber
       defaultValue={10}
-      allowEmpty
       min={10}
       max={20}
       onOverlimit={overlimit}

--- a/src/packages/inputnumber/demos/h5/demo3.tsx
+++ b/src/packages/inputnumber/demos/h5/demo3.tsx
@@ -2,11 +2,19 @@ import React from 'react'
 import { InputNumber, Toast } from '@nutui/nutui-react'
 
 const Demo3 = () => {
-  const overlimit = () => {
+  const overlimit = (e: any) => {
     Toast.show({ content: '超出限制事件触发', icon: 'warn' })
   }
   return (
-    <InputNumber defaultValue={10} min={10} max={20} onOverlimit={overlimit} />
+    <InputNumber
+      defaultValue={10}
+      min={10}
+      max={20}
+      onOverlimit={overlimit}
+      onChange={(v) => {
+        console.log('onChange', v)
+      }}
+    />
   )
 }
 export default Demo3

--- a/src/packages/inputnumber/demos/h5/demo8.tsx
+++ b/src/packages/inputnumber/demos/h5/demo8.tsx
@@ -3,13 +3,26 @@ import { InputNumber, Toast } from '@nutui/nutui-react'
 
 const Demo8 = () => {
   const [inputValue, setInputValue] = useState(0)
+  const overlimit = (e: any) => {
+    console.log('超出限制事件触发', e)
+  }
   const onChange = (value: string | number) => {
     Toast.show({ icon: 'loading', content: '异步演示2秒后更改' })
+    console.log('onChange', value)
     setTimeout(() => {
       setInputValue(Number(value))
       Toast.clear()
     }, 2000)
   }
-  return <InputNumber value={inputValue} min={-6} onChange={onChange} async />
+  return (
+    <InputNumber
+      value={inputValue}
+      min={-6}
+      max={6}
+      onChange={onChange}
+      onOverlimit={overlimit}
+      async
+    />
+  )
 }
 export default Demo8

--- a/src/packages/inputnumber/demos/taro/demo3.tsx
+++ b/src/packages/inputnumber/demos/taro/demo3.tsx
@@ -22,6 +22,9 @@ const Demo3 = () => {
         min={10}
         max={20}
         onOverlimit={overlimit}
+        onChange={(v) => {
+          console.log('onChange', v)
+        }}
       />
       <Toast
         type={toastType}

--- a/src/packages/inputnumber/demos/taro/demo8.tsx
+++ b/src/packages/inputnumber/demos/taro/demo8.tsx
@@ -21,7 +21,7 @@ const Demo8 = () => {
     setTimeout(() => {
       setInputValue(Number(value))
       SetShow(false)
-    }, 200)
+    }, 2000)
   }
   return (
     <>

--- a/src/packages/inputnumber/demos/taro/demo8.tsx
+++ b/src/packages/inputnumber/demos/taro/demo8.tsx
@@ -12,16 +12,27 @@ const Demo8 = () => {
     SetToastType(type)
     SetShow(true)
   }
+  const overlimit = (e: any) => {
+    console.log('超出限制事件触发', e)
+  }
   const onChange = (value: string | number) => {
     toastShow('异步演示 2 秒后更改', 'loading')
+    console.log('onChange', value)
     setTimeout(() => {
       setInputValue(Number(value))
       SetShow(false)
-    }, 2000)
+    }, 200)
   }
   return (
     <>
-      <InputNumber value={inputValue} min="-6" onChange={onChange} async />
+      <InputNumber
+        value={inputValue}
+        min={-6}
+        max={6}
+        onChange={onChange}
+        onOverlimit={overlimit}
+        async
+      />
       <Toast
         type={toastType}
         visible={show}

--- a/src/packages/inputnumber/inputnumber.taro.tsx
+++ b/src/packages/inputnumber/inputnumber.taro.tsx
@@ -191,9 +191,10 @@ export const InputNumber: FunctionComponent<
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const val = clampValue(valueStr)
-    if (val !== Number(e.target.value)) {
-      onOverlimit?.(e)
-    }
+    // input暂不触发onOverlimit
+    // if (val !== Number(e.target.value)) {
+    //   onOverlimit?.(e)
+    // }
     if (val !== Number(shadowValue)) {
       onChange?.(val, e)
     }

--- a/src/packages/inputnumber/inputnumber.taro.tsx
+++ b/src/packages/inputnumber/inputnumber.taro.tsx
@@ -26,7 +26,7 @@ export interface InputNumberProps extends BasicComponent {
   formatter?: (value?: string | number) => string
   onPlus: (e: React.MouseEvent) => void
   onMinus: (e: React.MouseEvent) => void
-  onOverlimit: (e: React.MouseEvent) => void
+  onOverlimit: (e: React.MouseEvent | ChangeEvent<HTMLInputElement>) => void
   onBlur: (e: React.FocusEvent<HTMLInputElement>) => void
   onFocus: (e: React.FocusEvent<HTMLInputElement>) => void
   onChange: (
@@ -181,7 +181,24 @@ export const InputNumber: FunctionComponent<
     if (text === '-') return null
     return text
   }
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const clampValue = (valueStr: string | null) => {
+    if (valueStr === null) return defaultValue
+    const val = Number(parseFloat(valueStr || '0').toFixed(digits))
+    return Math.max(Number(min), Math.min(Number(max), val))
+  }
+  const handleValueChange = (
+    valueStr: string | null,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const val = clampValue(valueStr)
+    if (val !== Number(e.target.value)) {
+      onOverlimit?.(e)
+    }
+    if (val !== Number(shadowValue)) {
+      onChange?.(val, e)
+    }
+  }
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     // 设置 input 值， 在 blur 时格式化
     setInputValue(e.target.value)
     const valueStr = parseValue(e.target.value)
@@ -192,11 +209,9 @@ export const InputNumber: FunctionComponent<
         setShadowValue(defaultValue)
       }
     } else {
-      setShadowValue(valueStr as any)
+      setShadowValue(clampValue(valueStr) as any)
     }
-    if (!async) {
-      onChange?.(parseFloat(valueStr || '0').toFixed(digits) as any, e)
-    }
+    !async && handleValueChange(valueStr, e)
   }
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     setFocused(true)
@@ -205,15 +220,22 @@ export const InputNumber: FunctionComponent<
         ? bound(Number(shadowValue), Number(min), Number(max)).toString()
         : ''
     )
-    onFocus && onFocus(e)
+    onFocus?.(e)
   }
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     setFocused(false)
-    onBlur && onBlur(e)
-    if (async) {
-      const valueStr = parseValue(e.target.value)
-      onChange?.(parseFloat(valueStr || '0').toFixed(digits) as any, e)
+    onBlur?.(e)
+    const valueStr = parseValue(e.target.value)
+    if (valueStr === null) {
+      if (allowEmpty) {
+        setShadowValue(null)
+      } else {
+        setShadowValue(defaultValue)
+      }
+    } else {
+      setShadowValue(clampValue(valueStr) as any)
     }
+    async && handleValueChange(valueStr, e)
   }
 
   return (

--- a/src/packages/inputnumber/inputnumber.tsx
+++ b/src/packages/inputnumber/inputnumber.tsx
@@ -187,9 +187,10 @@ export const InputNumber: FunctionComponent<
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const val = clampValue(valueStr)
-    if (val !== Number(e.target.value)) {
-      onOverlimit?.(e)
-    }
+    // input暂不触发onOverlimit
+    // if (val !== Number(e.target.value)) {
+    //   onOverlimit?.(e)
+    // }
     if (val !== Number(shadowValue)) {
       onChange?.(val, e)
     }

--- a/src/packages/inputnumber/inputnumber.tsx
+++ b/src/packages/inputnumber/inputnumber.tsx
@@ -24,7 +24,7 @@ export interface InputNumberProps extends BasicComponent {
   formatter?: (value?: string | number) => string
   onPlus: (e: React.MouseEvent) => void
   onMinus: (e: React.MouseEvent) => void
-  onOverlimit: (e: React.MouseEvent) => void
+  onOverlimit: (e: React.MouseEvent | ChangeEvent<HTMLInputElement>) => void
   onBlur: (e: React.FocusEvent<HTMLInputElement>) => void
   onFocus: (e: React.FocusEvent<HTMLInputElement>) => void
   onChange: (
@@ -177,6 +177,23 @@ export const InputNumber: FunctionComponent<
     if (text === '-') return null
     return text
   }
+  const clampValue = (valueStr: string | null) => {
+    if (valueStr === null) return defaultValue
+    const val = Number(parseFloat(valueStr || '0').toFixed(digits))
+    return Math.max(Number(min), Math.min(Number(max), val))
+  }
+  const handleValueChange = (
+    valueStr: string | null,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const val = clampValue(valueStr)
+    if (val !== Number(e.target.value)) {
+      onOverlimit?.(e)
+    }
+    if (val !== Number(shadowValue)) {
+      onChange?.(val, e)
+    }
+  }
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // 设置 input 值， 在 blur 时格式化
     setInputValue(e.target.value)
@@ -188,11 +205,9 @@ export const InputNumber: FunctionComponent<
         setShadowValue(defaultValue)
       }
     } else {
-      setShadowValue(valueStr as any)
+      setShadowValue(clampValue(valueStr) as any)
     }
-    if (!async) {
-      onChange?.(parseFloat(valueStr || '0').toFixed(digits) as any, e)
-    }
+    !async && handleValueChange(valueStr, e)
   }
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     setFocused(true)
@@ -201,15 +216,22 @@ export const InputNumber: FunctionComponent<
         ? bound(Number(shadowValue), Number(min), Number(max)).toString()
         : ''
     )
-    onFocus && onFocus(e)
+    onFocus?.(e)
   }
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     setFocused(false)
-    onBlur && onBlur(e)
-    if (async) {
-      const valueStr = parseValue(e.target.value)
-      onChange?.(parseFloat(valueStr || '0').toFixed(digits) as any, e)
+    onBlur?.(e)
+    const valueStr = parseValue(e.target.value)
+    if (valueStr === null) {
+      if (allowEmpty) {
+        setShadowValue(null)
+      } else {
+        setShadowValue(defaultValue)
+      }
+    } else {
+      setShadowValue(clampValue(valueStr) as any)
     }
+    async && handleValueChange(valueStr, e)
   }
 
   return (


### PR DESCRIPTION
- onChange同步状态下的触发时机参考了[stepper](https://mobile.ant.design/zh/components/stepper)的习惯。
不存在`min`、`max`时，随着输入而触发，而超出限制时，如max={6},input内容由3 -> 60应该触发`onChange`，返回的value为6。而60 -> 600不应该触发`onChange`，而这两种情况下都应该触发`onOverlimit`。
- 在`aysnc`状态下，blur时对值进行检验，`onChange`和`onOverlimit`的触发时机取决于blur时的数据前后的变化。

基于以上规则，进行了改造

- [x] 日常 bug 修复
- [x] 演示代码改进
- [x] TypeScript 定义更新
- [x] 重构
- [x] 代码风格优化



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 增强了 `InputNumber` 组件的事件处理能力，包括新的 `onChange` 和 `onOverlimit` 事件处理程序。
	- 实现了值的范围限制，确保输入在设定的最小值和最大值之间有效。

- **错误修复**
	- 修复了在输入超出限制时的处理逻辑，确保组件正确响应。

- **测试**
	- 新增测试用例，验证 `InputNumber` 组件在输入超出最大值时的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->