### PR TITLE
fix(PullToRefresh): 修复PullToRefresh组件disabled属性在taro中无效的问题

### DIFF
--- a/src/packages/pulltorefresh/demo.taro.tsx
+++ b/src/packages/pulltorefresh/demo.taro.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from '@/sites/assets/locale/taro'
 import Demo1 from './demos/taro/demo1'
 import Demo2 from './demos/taro/demo2'
 import Demo3 from './demos/taro/demo3'
+import Demo4 from './demos/taro/demo4'
 
 const PullToRefreshDemo = () => {
   const [translated] = useTranslate({
@@ -12,16 +13,19 @@ const PullToRefreshDemo = () => {
       basic: '基础用法',
       scrollView: 'ScrollView',
       primary: '反白模式',
+      disabled: '禁用',
     },
     'zh-TW': {
       basic: '基礎用法',
       scrollView: 'ScrollView',
       primary: '反白模式',
+      disabled: '禁用',
     },
     'en-US': {
       basic: 'Basic Usage',
       scrollView: 'ScrollView',
       primary: 'reverse',
+      disabled: 'disabled',
     },
   })
   return (
@@ -36,6 +40,9 @@ const PullToRefreshDemo = () => {
 
         <h2>{translated.primary}</h2>
         <Demo3 />
+
+        <h2>{translated.disabled}</h2>
+        <Demo4 />
       </div>
     </>
   )

--- a/src/packages/pulltorefresh/demos/taro/demo4.tsx
+++ b/src/packages/pulltorefresh/demos/taro/demo4.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import { ScrollView } from '@tarojs/components'
+import { PullToRefresh, Cell, Toast } from '@nutui/nutui-react-taro'
+
+const Demo4 = () => {
+  const [list] = useState([1, 2, 3, 4, 5, 6, 7])
+  const [show, SetShow] = useState(false)
+  const [toastMsg, SetToastMsg] = useState('')
+  const toastShow = (msg: any) => {
+    SetToastMsg(msg)
+    SetShow(true)
+  }
+  const [scrollTop, setScrollTop] = useState(0)
+  return (
+    <>
+      <ScrollView
+        style={{ height: '150px' }}
+        scrollY
+        onScrollEnd={(e) => {
+          // scrollTop > 0, PullToRefresh 不触发 touchmove 事件。
+          if (e.detail?.scrollTop) {
+            setScrollTop(e.detail?.scrollTop)
+          }
+        }}
+      >
+        <PullToRefresh
+          scrollTop={scrollTop}
+          onRefresh={() =>
+            new Promise((resolve) => {
+              toastShow('😊')
+              resolve('done')
+            })
+          }
+          disabled
+        >
+          {list.map((item) => (
+            <Cell key={item}>{item}</Cell>
+          ))}
+        </PullToRefresh>
+      </ScrollView>
+      <Toast
+        type="text"
+        visible={show}
+        content={toastMsg}
+        onClose={() => {
+          SetShow(false)
+        }}
+      />
+    </>
+  )
+}
+
+export default Demo4

--- a/src/packages/pulltorefresh/pulltorefresh.taro.tsx
+++ b/src/packages/pulltorefresh/pulltorefresh.taro.tsx
@@ -95,10 +95,11 @@ export const PullToRefresh: FunctionComponent<Partial<PullToRefreshProps>> = (
     return ''
   }
   const handleTouchStart: any = (e: ITouchEvent) => {
+    if (props.disabled) return
     touch.start(e as any)
   }
   const handleTouchMove: any = (e: ITouchEvent) => {
-    if (props.scrollTop > 0) {
+    if (props.scrollTop > 0 || props.disabled) {
       return
     }
     if (status === 'refreshing' || status === 'complete') return
@@ -139,6 +140,7 @@ export const PullToRefresh: FunctionComponent<Partial<PullToRefreshProps>> = (
     setStatus('pulling')
   }
   const handleTouchEnd: any = () => {
+    if (props.disabled) return
     pullingRef.current = false
     if (status === 'canRelease') {
       doRefresh()


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
PullToRefresh组件在taro中disabled属性不生效


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：PullToRefresh组件在taro中disabled属性不生效
解决方案：在操作前判断disabled状态

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在`PullToRefresh`组件中添加了多语言支持（中英文）的“禁用”状态翻译。
	- 新增`Demo4`演示组件，展示了使用NutUI库的下拉刷新功能。

- **Bug修复**
	- 优化了触摸事件处理逻辑，确保在组件处于禁用状态时不响应触摸交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->