### PR TITLE
fix(uploader): beforeUpload should trigger every time before uploading

### DIFF
--- a/src/packages/uploader/__tests__/uploader.spec.tsx
+++ b/src/packages/uploader/__tests__/uploader.spec.tsx
@@ -90,7 +90,7 @@ test('should render base uploader other props', () => {
   fireEvent.click(container.querySelectorAll('.close')[0])
   expect(onDelete).toBeCalled()
 
-  const toast2 = container.querySelector('.nut-uploader-preview-img-c')
+  const toast2 = container.querySelector('.nut-uploader-preview-img-c .nut-img')
   expect(toast2).toBeTruthy()
   fireEvent.click(container.querySelectorAll('.nut-uploader-preview-img-c')[0])
   expect(fileItemClick).toBeCalled()

--- a/src/packages/uploader/demos/h5/demo1.tsx
+++ b/src/packages/uploader/demos/h5/demo1.tsx
@@ -8,7 +8,6 @@ const Demo1 = () => {
     console.log('start触发')
   }
   const beforeUpload = async (files: File[]) => {
-    console.log('bbb')
     const allowedTypes = ['image/png']
     const filteredFiles = Array.from(files).filter((file) =>
       allowedTypes.includes(file.type)

--- a/src/packages/uploader/demos/h5/demo1.tsx
+++ b/src/packages/uploader/demos/h5/demo1.tsx
@@ -7,10 +7,19 @@ const Demo1 = () => {
   const onStart = () => {
     console.log('start触发')
   }
+  const beforeUpload = async (files: File[]) => {
+    console.log('bbb')
+    const allowedTypes = ['image/png']
+    const filteredFiles = Array.from(files).filter((file) =>
+      allowedTypes.includes(file.type)
+    )
+    return filteredFiles
+  }
   return (
     <>
       <Cell style={{ flexWrap: 'wrap', paddingBottom: '0px' }}>
         <Uploader
+          beforeUpload={beforeUpload}
           url={uploadUrl}
           onStart={onStart}
           style={{

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -359,7 +359,7 @@ const InternalUploader: ForwardRefRenderFunction<
       beforeUpload(new Array<File>().slice.call(files)).then(
         (f: Array<File> | boolean) => {
           const _files: File[] = filterFiles(new Array<File>().slice.call(f))
-          if (!_files) $el.value = ''
+          if (!_files.length) $el.value = ''
           readFile(_files)
         }
       )

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -105,7 +105,6 @@ const InternalUploader: ForwardRefRenderFunction<
 > = (props, ref) => {
   const { locale } = useConfig()
   const fileListRef = useRef<FileItem[]>([])
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const {
     children,
     uploadIcon,
@@ -360,7 +359,7 @@ const InternalUploader: ForwardRefRenderFunction<
       beforeUpload(new Array<File>().slice.call(files)).then(
         (f: Array<File> | boolean) => {
           const _files: File[] = filterFiles(new Array<File>().slice.call(f))
-          if (!_files) fileInputRef.current?.reset()
+          if (!_files) $el.value = ''
           readFile(_files)
         }
       )
@@ -389,7 +388,6 @@ const InternalUploader: ForwardRefRenderFunction<
           )}
           {Number(maxCount) > fileList.length && (
             <input
-              ref={fileInputRef}
               className="nut-uploader-input"
               type="file"
               capture={capture}
@@ -430,7 +428,6 @@ const InternalUploader: ForwardRefRenderFunction<
 
             <input
               className="nut-uploader-input"
-              ref={fileInputRef}
               type="file"
               capture={capture}
               name={name}

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -105,6 +105,7 @@ const InternalUploader: ForwardRefRenderFunction<
 > = (props, ref) => {
   const { locale } = useConfig()
   const fileListRef = useRef<FileItem[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const {
     children,
     uploadIcon,
@@ -350,9 +351,8 @@ const InternalUploader: ForwardRefRenderFunction<
   }
 
   const fileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (disabled) {
-      return
-    }
+    if (disabled) return
+
     const $el = event.target
     const { files } = $el
 
@@ -360,6 +360,7 @@ const InternalUploader: ForwardRefRenderFunction<
       beforeUpload(new Array<File>().slice.call(files)).then(
         (f: Array<File> | boolean) => {
           const _files: File[] = filterFiles(new Array<File>().slice.call(f))
+          if (!_files) fileInputRef.current?.reset()
           readFile(_files)
         }
       )
@@ -388,6 +389,7 @@ const InternalUploader: ForwardRefRenderFunction<
           )}
           {Number(maxCount) > fileList.length && (
             <input
+              ref={fileInputRef}
               className="nut-uploader-input"
               type="file"
               capture={capture}
@@ -428,6 +430,7 @@ const InternalUploader: ForwardRefRenderFunction<
 
             <input
               className="nut-uploader-input"
+              ref={fileInputRef}
               type="file"
               capture={capture}
               name={name}


### PR DESCRIPTION
原来的beforeUpload在fileChange中进行触发。
Problem：在某些场景：如果用户选择的文件不符合要求，可能不会再次触发 fileChange 事件。
Solution: 在选择的文件没有符合要求的时，通过reset input保证每次的触发
补充： beforeUpload的使用方法、unit test更新
- [x] 日常 bug 修复



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **新特性**
  - 在文件上传组件中增加了对文件输入元素的直接引用，优化了文件上传过程的控制流。
  - 文件输入在没有选中有效文件时会被自动清空，提升了用户体验。
  - 新增异步函数以过滤文件类型，仅允许上传PNG图片，增强了上传过程的验证步骤。

- **测试相关**
  - 更新了测试用例中的查询选择器，增强了对目标元素的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->