### PR TITLE
fix(sticky): rerender sticky when threshold change

### DIFF
--- a/src/packages/sticky/sticky.taro.tsx
+++ b/src/packages/sticky/sticky.taro.tsx
@@ -96,7 +96,7 @@ export const Sticky: FunctionComponent<Partial<StickyProps>> = (props) => {
       zIndex,
     }
     return style
-  }, [fixed, rootRect.height, rootRect.width, transform, position])
+  }, [fixed, rootRect.height, rootRect.width, transform, position, threshold])
 
   const handleScroll: any = async (scrollTop: number) => {
     const curRootRect = await getRectByTaro(rootRef.current)

--- a/src/packages/sticky/sticky.tsx
+++ b/src/packages/sticky/sticky.tsx
@@ -44,12 +44,13 @@ export const Sticky: FunctionComponent<Partial<StickyProps>> = (props) => {
   const stickyRef = useRef<HTMLDivElement>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const [isFixed, setIsFixed] = useState(false)
-
   const [stickyStyle, setStickyStyle] = useState<CSSProperties>({
     [position]: `${threshold}px`,
     zIndex,
   })
-
+  useEffect(() => {
+    setStickyStyle({ ...stickyStyle, [position]: `${threshold}px` })
+  }, [threshold, position])
   const [rootStyle, setRootStyle] = useState({})
 
   const getElement = useCallback(() => {


### PR DESCRIPTION

- [x] 日常 bug 修复


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 增强了 `Sticky` 组件的响应能力，确保其样式动态更新，以适应 `threshold` 和 `position` 的变化。
	- 组件现在能更好地处理粘性功能，提升用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->