### PR TITLE
feat(uploader): support beforeupload props in taro

### DIFF
--- a/src/packages/uploader/demos/taro/demo1.tsx
+++ b/src/packages/uploader/demos/taro/demo1.tsx
@@ -7,11 +7,20 @@ const Demo1 = () => {
   const onStart = () => {
     console.log('start触发')
   }
+  const beforeUpload = async (files: File[]) => {
+    console.log('beforeUpload')
+    const allowedTypes = ['image/png']
+    const filteredFiles = Array.from(files).filter((file) =>
+      allowedTypes.includes(file.type)
+    )
+    return filteredFiles
+  }
   return (
     <Cell style={{ flexWrap: 'wrap' }}>
       <Uploader
         url={uploadUrl}
         onStart={onStart}
+        beforeUpload={beforeUpload}
         style={{
           marginInlineEnd: '10px',
           marginBottom: '10px',

--- a/src/packages/uploader/doc.taro.md
+++ b/src/packages/uploader/doc.taro.md
@@ -168,6 +168,7 @@ app.post('/upload', upload.single('file'), (req, res) => {
 | disabled | 是否禁用文件上传 | `boolean` | `false` |
 | multiple | 是否支持文件多选 | `boolean` | `false` |
 | timeout | 超时时间，单位为毫秒 | `number` \| `string` | `1000 * 30` |
+| beforeUpload | 上传前的函数需要返回一个`Promise`对象 | `(file: File[]) => Promise<File[] \| boolean>` | `-` |
 | beforeXhrUpload | 执行 XHR 上传时，自定义方式 | `(xhr: XMLHttpRequest, options: any) => void` | `-` |
 | beforeDelete | 除文件时的回调，返回值为 false 时不移除。支持返回一个 `Promise` 对象，`Promise` 对象 resolve(false) 或 reject 时不移除 | `(file: FileItem, files: FileItem[]) => boolean` | `-` |
 | onStart | 文件上传开始 | `(option: UploadOptions) => void` | `-` |

--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -115,6 +115,9 @@ export interface UploaderProps extends BasicComponent {
     files: Taro.chooseImage.ImageFile[] | Taro.chooseMedia.ChooseMedia[] | any
   ) => void
   onChange?: (files: FileItem[]) => void
+  beforeUpload?: (
+    files: Taro.chooseImage.ImageFile[] | Taro.chooseMedia.ChooseMedia[] | any
+  ) => Promise<File[] | boolean>
   beforeXhrUpload?: (xhr: XMLHttpRequest, options: any) => void
   beforeDelete?: (file: FileItem, files: FileItem[]) => boolean
   onFileItemClick?: (file: FileItem, index: number) => void
@@ -196,6 +199,7 @@ const InternalUploader: ForwardRefRenderFunction<
     onUpdate,
     onFailure,
     onOversize,
+    beforeUpload,
     beforeXhrUpload,
     beforeDelete,
     ...restProps
@@ -470,14 +474,34 @@ const InternalUploader: ForwardRefRenderFunction<
     // 返回选定照片的本地文件路径列表，tempFilePath可以作为img标签的src属性显示图片
     const { tempFiles } = res
     const _files: Taro.chooseMedia.ChooseMedia[] = filterFiles(tempFiles)
-    readFile(_files)
+    if (beforeUpload) {
+      beforeUpload(new Array<File>().slice.call(_files)).then(
+        (f: Array<File> | boolean) => {
+          const _files: File[] = filterFiles(new Array<File>().slice.call(f))
+          if (!_files.length) res.tempFiles = []
+          readFile(_files)
+        }
+      )
+    } else {
+      readFile(_files)
+    }
   }
 
   const onChangeImage = (res: Taro.chooseImage.SuccessCallbackResult) => {
     // 返回选定照片的本地文件路径列表，tempFilePath可以作为img标签的src属性显示图片
     const { tempFiles } = res
     const _files: Taro.chooseImage.ImageFile[] = filterFiles(tempFiles)
-    readFile(_files)
+    if (beforeUpload) {
+      beforeUpload(new Array<File>().slice.call(_files)).then(
+        (f: Array<File> | boolean) => {
+          const _files: File[] = filterFiles(new Array<File>().slice.call(f))
+          if (!_files.length) res.tempFiles = []
+          readFile(_files)
+        }
+      )
+    } else {
+      readFile(_files)
+    }
   }
 
   const handleItemClick = (file: FileItem, index: number) => {


### PR DESCRIPTION

- [x] 新特性提交
- [x] 站点、文档改进




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了`beforeUpload`异步函数，允许在文件上传前进行自定义验证和过滤，仅处理PNG图像。
  - 更新了`Uploader`组件，支持`beforeUpload`属性，增强了文件上传的灵活性和控制能力。

- **文档**
  - 更新了文件上传功能的文档，详细说明了`beforeUpload`属性的使用及其返回值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->