### PR TITLE
fix: 子组件不存在demo.taro.tsx，应该跳过子组件

### DIFF
--- a/scripts/rn/copy-file.js
+++ b/scripts/rn/copy-file.js
@@ -76,6 +76,7 @@ const removeFile = async (url) => {
 }
 
 const modify = (fileUrl, importStatement) => {
+  if(!fse.ensureFileSync(fileUrl)) return
   fse.readFile(fileUrl, 'utf8').then((content) => {
     let modifiedContent = content
     modifiedContent = [importStatement, modifiedContent.slice(0)].join('')


### PR DESCRIPTION
在 config.json 中将 form 和 formitem 组件的版本号改为3.0，启动 rn 会出现错误。

<img width="762" alt="image" src="https://github.com/user-attachments/assets/b86cd88a-3439-4e67-bae4-5c38ff28d7f4">
