### PR TITLE
fix(cascader): 受控状态下 value 变化时同步组件选中状态

### DIFF
--- a/src/packages/cascader/cascader.taro.tsx
+++ b/src/packages/cascader/cascader.taro.tsx
@@ -171,6 +171,10 @@ const InternalCascader: ForwardRefRenderFunction<
     initData()
   }, [options, format])
 
+  useEffect(() => {
+    syncValue()
+  }, [value])
+
   const initData = async () => {
     // 初始化开始处理数据
     state.lazyLoadMap.clear()

--- a/src/packages/cascader/cascader.tsx
+++ b/src/packages/cascader/cascader.tsx
@@ -170,6 +170,10 @@ const InternalCascader: ForwardRefRenderFunction<
     initData()
   }, [options, format])
 
+  useEffect(() => {
+    syncValue()
+  }, [value])
+
   const initData = async () => {
     // 初始化开始处理数据
     state.lazyLoadMap.clear()


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/jdf2e/nutui-react/issues/2583

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
修复 Cascader 组件受控状态下修改 value 时，组件选中状态未变更问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增强了 `InternalCascader` 组件对 `value` 属性变化的响应能力，确保内部状态与外部值保持同步，从而改善用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->