### PR TITLE
chore: update dependency linguist-languages to be included within package

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "husky": "^9.0.11",
     "inquirer": "^10.1.4",
     "jscodeshift": "^17.0.0",
-    "linguist-languages": "^7.27.0",
     "lint-staged": "^15.2.2",
     "lzutf8": "0.6.3",
     "map-stream": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^19.0.3",
     "@loadable/component": "^5.16.3",
-    "prettier-markdown-table": "1.0.1",
+    "prettier-markdown-table": "^1.0.2",
     "@mdx-js/mdx": "^3.0.1",
     "@mdx-js/react": "^3.0.1",
     "@mdx-js/rollup": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,9 +235,6 @@ importers:
       jscodeshift:
         specifier: ^17.0.0
         version: 17.0.0(@babel/preset-env@7.25.4(@babel/core@7.25.2))
-      linguist-languages:
-        specifier: ^7.27.0
-        version: 7.27.0
       lint-staged:
         specifier: ^15.2.2
         version: 15.2.9
@@ -6927,9 +6924,6 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-
-  linguist-languages@7.27.0:
-    resolution: {integrity: sha512-Wzx/22c5Jsv2ag+uKy+ITanGA5hzvBZngrNGDXLTC7ZjGM6FLCYGgomauTkxNJeP9of353OM0pWqngYA180xgw==}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
@@ -18285,8 +18279,6 @@ snapshots:
   lilconfig@3.1.2: {}
 
   lines-and-columns@1.2.4: {}
-
-  linguist-languages@7.27.0: {}
 
   linkify-it@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,8 +275,8 @@ importers:
         specifier: ^3.2.5
         version: 3.3.3
       prettier-markdown-table:
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: ^1.0.2
+        version: 1.0.2
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -6925,6 +6925,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linguist-languages@7.27.0:
+    resolution: {integrity: sha512-Wzx/22c5Jsv2ag+uKy+ITanGA5hzvBZngrNGDXLTC7ZjGM6FLCYGgomauTkxNJeP9of353OM0pWqngYA180xgw==}
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
@@ -8380,8 +8383,8 @@ packages:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
 
-  prettier-markdown-table@1.0.1:
-    resolution: {integrity: sha512-4UrRDtD/k0xc5BAjI2Zv/L1cf6gTm7tdb4Uks0xUJ3Dm4brIbFMYkRdF/h6bqC1+SVSonNoD+ZcilmjH4wD0sA==}
+  prettier-markdown-table@1.0.2:
+    resolution: {integrity: sha512-WYaAn3GX8hn1v+dZcHljxgZfG0PeWvP2Ufav0vzvlDiWhb8uj+FIKpUIMiaf6uP1PF8Ni/1m7X6FwucSgCvY2w==}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -18280,6 +18283,8 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linguist-languages@7.27.0: {}
+
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
@@ -20063,7 +20068,9 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-markdown-table@1.0.1: {}
+  prettier-markdown-table@1.0.2:
+    dependencies:
+      linguist-languages: 7.27.0
 
   prettier@2.8.8:
     optional: true

--- a/src/packages/rate/doc.md
+++ b/src/packages/rate/doc.md
@@ -121,7 +121,7 @@ import { Rate } from '@nutui/nutui-react'
 | allowHalf | 是否半星 | `boolean` | `false` |
 | readOnly | 是否只读 | `boolean` | `false` |
 | disabled | 是否禁用 | `boolean` | `false` |
-| touchable | 是否允许滑动选择 ｜ `boolean` | `false` |
+| touchable | 是否允许滑动选择 | `boolean` | `false` |
 | onChange | 当前 star 数修改时触发 | `(value: number) => void` | `-` |
 | onTouchEnd | touch 滑动结束时触发 | `(event: TouchEvent, value: number) => void` | `-` |
 


### PR DESCRIPTION
 linguist-languages 应该在安装prettier-markdown-table的时候自动安装，更新了prettier-markdown-table中的linguist从devDependencies => dependencies



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
	- 更新了 `prettier-markdown-table` 包的版本，可能包含新功能或修复。
- **变更**
	- 移除了 `linguist-languages` 包，可能影响依赖该包的功能。
- **文档**
	- 修正了 `Rate` 组件中 `touchable` 属性文档的格式对齐问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->