### PR TITLE
chore(demo): display 'bound dispatchSetState' message in demo8 of table demos

### DIFF
--- a/src/packages/table/demos/h5/demo8.tsx
+++ b/src/packages/table/demos/h5/demo8.tsx
@@ -2,25 +2,8 @@ import React, { useState } from 'react'
 import { Table } from '@nutui/nutui-react'
 
 const Demo8 = () => {
-  const data1 = useState<Array<any>>([
-    {
-      name: 'Tom',
-      gender: '男',
-      record: '小学',
-    },
-    {
-      name: 'Lucy',
-      gender: '女',
-      record: '本科',
-    },
-    {
-      name: 'Jack',
-      gender: '男',
-      record: '高中',
-    },
-  ])
   const [data, setData] = useState<Array<any>>([])
-  const [columns1] = useState([
+  const columns = [
     {
       title: '姓名',
       key: 'name',
@@ -40,11 +23,28 @@ const Demo8 = () => {
       title: '学历',
       key: 'record',
     },
-  ])
+  ]
+  const data1 = [
+    {
+      name: 'Tom',
+      gender: '男',
+      record: '小学',
+    },
+    {
+      name: 'Lucy',
+      gender: '女',
+      record: '本科',
+    },
+    {
+      name: 'Jack',
+      gender: '男',
+      record: '高中',
+    },
+  ]
   setTimeout(() => {
     setData(data1)
   }, 5000)
 
-  return <Table columns={columns1} data={data} style={{ background: '#fff' }} />
+  return <Table columns={columns} data={data} style={{ background: '#fff' }} />
 }
 export default Demo8

--- a/src/packages/table/demos/taro/demo8.tsx
+++ b/src/packages/table/demos/taro/demo8.tsx
@@ -2,36 +2,19 @@ import React, { useState } from 'react'
 import { Table } from '@nutui/nutui-react-taro'
 
 const Demo8 = () => {
-  const [data1] = useState<Array<any>>([
-    {
-      name: 'Tom',
-      sex: '男',
-      record: '小学',
-    },
-    {
-      name: 'Lucy',
-      sex: '女',
-      record: '本科',
-    },
-    {
-      name: 'Jack',
-      sex: '男',
-      record: '高中',
-    },
-  ])
   const [data, setData] = useState<Array<any>>([])
-  const [columns] = useState([
+  const columns = [
     {
       title: '姓名',
       key: 'name',
     },
     {
       title: '性别',
-      key: 'sex',
+      key: 'gender',
       render: (record: any) => {
         return (
-          <span style={{ color: record.sex === '女' ? 'blue' : 'green' }}>
-            {record.sex}
+          <span style={{ color: record.gender === '女' ? 'blue' : 'green' }}>
+            {record.gender}
           </span>
         )
       },
@@ -40,7 +23,24 @@ const Demo8 = () => {
       title: '学历',
       key: 'record',
     },
-  ])
+  ]
+  const data1 = [
+    {
+      name: 'Tom',
+      gender: '男',
+      record: '小学',
+    },
+    {
+      name: 'Lucy',
+      gender: '女',
+      record: '本科',
+    },
+    {
+      name: 'Jack',
+      gender: '男',
+      record: '高中',
+    },
+  ]
   setTimeout(() => {
     setData(data1)
   }, 5000)


### PR DESCRIPTION
Unexpected:
<img width="372" alt="image" src="https://github.com/user-attachments/assets/54c42e38-46f6-4082-9f63-103f49447980">


### 🤔 这个变动的性质是？

- [x] 站点、文档改进
- [x] 演示代码改进




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `Demo8` 组件，直接使用常量数组初始化数据，简化了状态管理。
	- 数据对象中的 `sex` 键已重命名为 `gender`，并相应更新了渲染逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->