### PR TITLE
fix(overlay):  tour position offset in tour.taro

### DIFF
--- a/src/packages/overlay/overlay.scss
+++ b/src/packages/overlay/overlay.scss
@@ -23,9 +23,8 @@
 
 .nut-overflow-hidden {
   overflow: hidden !important;
-
   .taro_page {
-    overflow: hidden !important;
+    position: fixed;
   }
 }
 

--- a/src/packages/overlay/overlay.scss
+++ b/src/packages/overlay/overlay.scss
@@ -23,9 +23,6 @@
 
 .nut-overflow-hidden {
   overflow: hidden !important;
-  .taro_page {
-    overflow: hidden !important;
-  }
 }
 
 .nut-overlay-slide {

--- a/src/packages/overlay/overlay.scss
+++ b/src/packages/overlay/overlay.scss
@@ -24,7 +24,7 @@
 .nut-overflow-hidden {
   overflow: hidden !important;
   .taro_page {
-    position: fixed;
+    overflow: hidden !important;
   }
 }
 

--- a/src/packages/tour/tour.taro.tsx
+++ b/src/packages/tour/tour.taro.tsx
@@ -104,11 +104,7 @@ export const Tour: FunctionComponent<
     setActive(0)
     setShowTour(visible)
     setShowPopup(visible)
-    if (visible) {
-      setTimeout(() => {
-        getRootPosition()
-      })
-    }
+    getRootPosition()
   }, [visible])
 
   useEffect(() => {

--- a/src/packages/tour/tour.taro.tsx
+++ b/src/packages/tour/tour.taro.tsx
@@ -101,10 +101,12 @@ export const Tour: FunctionComponent<
   const classes = classNames(classPrefix, className)
 
   useEffect(() => {
+    if (visible) {
+      getRootPosition()
+    }
     setActive(0)
     setShowTour(visible)
     setShowPopup(visible)
-    getRootPosition()
   }, [visible])
 
   useEffect(() => {

--- a/src/packages/tour/tour.taro.tsx
+++ b/src/packages/tour/tour.taro.tsx
@@ -101,12 +101,14 @@ export const Tour: FunctionComponent<
   const classes = classNames(classPrefix, className)
 
   useEffect(() => {
-    if (visible) {
-      getRootPosition()
-    }
     setActive(0)
     setShowTour(visible)
     setShowPopup(visible)
+    if (visible) {
+      setTimeout(() => {
+        getRootPosition()
+      })
+    }
   }, [visible])
 
   useEffect(() => {


### PR DESCRIPTION
官网Tour.taro的demo:


<img width="385" alt="image" src="https://github.com/user-attachments/assets/2ad776f3-5e05-4349-b44e-cf52de647691">

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新特性**
	- 改进了覆盖组件的样式和动画效果，增强了用户体验。
	- 添加了覆盖过渡的动画关键帧，支持渐显和渐隐效果。
	- 调整了右到左（RTL）布局的样式，确保正确对齐。
- **样式**
	- 更新了 `.nut-overlay` 和 `.nut-overflow-hidden` 类的样式规则，优化了溢出处理。
	- 修改了 `Tour` 组件的可见性处理逻辑，提升了位置计算的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->