### PR TITLE
fix(navbar): safearea displays abnormal when safeAreaInsetTop has been set true

### DIFF
--- a/src/packages/navbar/navbar.scss
+++ b/src/packages/navbar/navbar.scss
@@ -24,11 +24,6 @@
     width: 100%;
   }
 
-  &-safe-area-inset-top {
-    padding-top: constant(safe-area-inset-top);
-    padding-top: env(safe-area-inset-top);
-  }
-
   &-title {
     min-width: 53%;
     margin: 0 auto;

--- a/src/packages/navbar/navbar.taro.tsx
+++ b/src/packages/navbar/navbar.taro.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
-
 import { ITouchEvent, View } from '@tarojs/components'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import { getRectByTaro } from '@/utils/get-rect-by-taro'
+import { SafeArea } from '@/packages/safearea/safearea.taro'
 
 export interface NavBarProps extends BasicComponent {
   left: React.ReactNode
@@ -164,6 +164,7 @@ export const NavBar: FunctionComponent<Partial<NavBarProps>> = (props) => {
 
   return (
     <>
+      {safeAreaInsetTop && <SafeArea position="top" />}
       {fixed && placeholder ? (
         <View className={`${classPrefix}-placeholder`}>{renderWrapper()}</View>
       ) : (

--- a/src/packages/navbar/navbar.taro.tsx
+++ b/src/packages/navbar/navbar.taro.tsx
@@ -156,7 +156,6 @@ export const NavBar: FunctionComponent<Partial<NavBarProps>> = (props) => {
 
   const classes = classNames({
     [`${classPrefix}-fixed`]: fixed,
-    [`${classPrefix}-safe-area-inset-top`]: safeAreaInsetTop,
     [`${classPrefix}-title-align-${titleAlign}`]: true,
   })
 

--- a/src/packages/navbar/navbar.tsx
+++ b/src/packages/navbar/navbar.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import { getRect } from '@/utils/use-client-rect'
+import { SafeArea } from '@/packages/safearea/safearea'
 
 export interface NavBarProps extends BasicComponent {
   left: React.ReactNode
@@ -153,7 +154,6 @@ export const NavBar: FunctionComponent<Partial<NavBarProps>> = (props) => {
 
   const classes = classNames({
     [`${classPrefix}-fixed`]: fixed,
-    [`${classPrefix}-safe-area-inset-top`]: safeAreaInsetTop,
     [`${classPrefix}-title-align-${titleAlign}`]: true,
   })
 
@@ -161,6 +161,7 @@ export const NavBar: FunctionComponent<Partial<NavBarProps>> = (props) => {
 
   return (
     <>
+      {safeAreaInsetTop && <SafeArea position="top" />}
       {fixed && placeholder ? (
         <div className={`${classPrefix}-placeholder`}>{renderWrapper()}</div>
       ) : (


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 导航栏组件现在可以根据 `safeAreaInsetTop` 属性条件性地包含 `SafeArea` 组件，以确保在安全区域内的显示。

- **样式**
  - 移除了导航栏的 `.nut-navbar-safe-area-inset-top` 类，取消了与安全区域内边距相关的样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->