### PR TITLE
fix(backtop & menu):  lint, code simplification, deprecated pageYOffset removed

### DIFF
--- a/src/packages/backtop/__test__/backtop.spec.tsx
+++ b/src/packages/backtop/__test__/backtop.spec.tsx
@@ -8,21 +8,19 @@ import BackTop from '@/packages/backtop'
 test('backtop props test', () => {
   const handleClick = vi.fn()
   const { container } = render(
-    <BackTop
-      target="target"
-      threshold={200}
-      style={{
-        right: '20px',
-        bottom: '50px',
-      }}
-      onClick={handleClick}
-    />
+    <div id="target" style={{ height: '100vh' }}>
+      {new Array(24).fill(0).map((_, index) => {
+        return <div key={index}>我是测试数据{index}</div>
+      })}
+      <BackTop
+        target="target"
+        className="backtop-button"
+        onClick={handleClick}
+      />
+    </div>
   )
-  expect(container.querySelector('.nut-backtop')).toHaveAttribute(
-    'style',
-    'z-index: 900; right: 20px; bottom: 50px;'
-  )
-  fireEvent.click(container)
+  const chooseTagEle = container.querySelectorAll('.backtop-button')[0]
+  fireEvent.click(chooseTagEle)
   expect(handleClick).toBeCalled
 })
 

--- a/src/packages/backtop/backtop.taro.tsx
+++ b/src/packages/backtop/backtop.taro.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react'
+import React, { FunctionComponent, useState, useCallback } from 'react'
 import type { MouseEvent } from 'react'
 import { usePageScroll, pageScrollTo } from '@tarojs/taro'
 import { Top } from '@nutui/icons-react-taro'
@@ -29,14 +29,17 @@ export const BackTop: FunctionComponent<
     ...props,
   }
   const classPrefix = 'nut-backtop'
-  const [backTop, SetBackTop] = useState(false)
+  const [backTop, setBackTop] = useState(false)
   const cls = classNames(classPrefix, { show: backTop }, className)
   // 监听用户滑动页面事件
-  usePageScroll((res) => {
-    const { scrollTop } = res
-    scrollTop >= threshold ? SetBackTop(true) : SetBackTop(false)
-  })
-  // 返回顶部点击事件
+  const handleScroll = useCallback(
+    (res: { scrollTop: number }) => {
+      const { scrollTop } = res
+      setBackTop(scrollTop >= threshold)
+    },
+    [threshold]
+  )
+  usePageScroll(handleScroll)
   const goTop = (e: MouseEvent<HTMLDivElement>) => {
     onClick && onClick(e)
     pageScrollTo({

--- a/src/packages/backtop/backtop.taro.tsx
+++ b/src/packages/backtop/backtop.taro.tsx
@@ -28,17 +28,20 @@ export const BackTop: FunctionComponent<
     ...defaultProps,
     ...props,
   }
-
   const classPrefix = 'nut-backtop'
-
   const [backTop, SetBackTop] = useState(false)
-
+  const cls = classNames(
+    classPrefix,
+    {
+      show: backTop,
+    },
+    className
+  )
   // 监听用户滑动页面事件
   usePageScroll((res) => {
     const { scrollTop } = res
     scrollTop >= threshold ? SetBackTop(true) : SetBackTop(false)
   })
-
   // 返回顶部点击事件
   const goTop = (e: MouseEvent<HTMLDivElement>) => {
     onClick && onClick(e)
@@ -47,7 +50,6 @@ export const BackTop: FunctionComponent<
       duration: duration > 0 ? duration : 0,
     })
   }
-
   const styles =
     Object.keys(style || {}).length !== 0
       ? {
@@ -59,21 +61,8 @@ export const BackTop: FunctionComponent<
           bottom: '20px',
           zIndex,
         }
-
   return (
-    <div
-      className={classNames(
-        classPrefix,
-        {
-          show: backTop,
-        },
-        className
-      )}
-      style={styles}
-      onClick={(e) => {
-        goTop(e)
-      }}
-    >
+    <div className={cls} style={styles} onClick={(e) => goTop(e)}>
       {children || <Top size={19} className="nut-backtop-main" />}
     </div>
   )

--- a/src/packages/backtop/backtop.taro.tsx
+++ b/src/packages/backtop/backtop.taro.tsx
@@ -30,13 +30,7 @@ export const BackTop: FunctionComponent<
   }
   const classPrefix = 'nut-backtop'
   const [backTop, SetBackTop] = useState(false)
-  const cls = classNames(
-    classPrefix,
-    {
-      show: backTop,
-    },
-    className
-  )
+  const cls = classNames(classPrefix, { show: backTop }, className)
   // 监听用户滑动页面事件
   usePageScroll((res) => {
     const { scrollTop } = res

--- a/src/packages/backtop/backtop.tsx
+++ b/src/packages/backtop/backtop.tsx
@@ -1,12 +1,16 @@
-import React, { FunctionComponent, useEffect, useState, useRef } from 'react'
+import React, {
+  FunctionComponent,
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+} from 'react'
 import type { MouseEvent } from 'react'
 import { Top } from '@nutui/icons-react'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
-import requestAniFrame from '@/utils/raf'
+import requestAniFrame, { cancelRaf } from '@/utils/raf'
 import { useRtl } from '@/packages/configprovider'
-
-declare const window: any
 
 export interface BackTopProps extends BasicComponent {
   target: string
@@ -46,33 +50,43 @@ export const BackTop: FunctionComponent<
   const [backTop, SetBackTop] = useState(false)
   const [scrollTop, SetScrollTop] = useState(0)
   let startTime = 0
-  const scrollEl: any = useRef<any>(null)
-  useEffect(() => {
-    init()
-    return () => removeEventListener()
-  }, [])
+  const scrollEl = useRef<any>(null)
+  const cls = classNames(
+    classPrefix,
+    {
+      show: backTop,
+    },
+    className
+  )
 
-  const init = () => {
+  const scrollListener = useCallback(() => {
+    let top = null
+    if (scrollEl.current instanceof Window) {
+      top = scrollEl.current.scrollY
+    } else {
+      top = scrollEl.current?.scrollTop
+    }
+    SetScrollTop(top)
+    SetBackTop(top >= threshold)
+  }, [threshold])
+
+  const init = useCallback(() => {
     if (target && document.getElementById(target)) {
-      scrollEl.current = document.getElementById(target) as HTMLElement | Window
+      scrollEl.current = document.getElementById(target)
     } else {
       scrollEl.current = window
     }
-    addEventListener()
-    initCancelAniFrame()
-  }
-  const scrollListener = () => {
-    let top: any = null
-    if (scrollEl.current instanceof Window) {
-      top = scrollEl.current.pageYOffset
-      SetScrollTop(top)
-    } else {
-      top = scrollEl.current.scrollTop
-      SetScrollTop(top)
+    scrollEl.current?.addEventListener('scroll', scrollListener, false)
+    scrollEl.current?.addEventListener('resize', scrollListener, false)
+  }, [target, scrollListener])
+
+  useEffect(() => {
+    init()
+    return () => {
+      scrollEl.current?.removeEventListener('scroll', scrollListener, false)
+      scrollEl.current?.removeEventListener('resize', scrollListener, false)
     }
-    const showBtn = top >= threshold
-    SetBackTop(showBtn)
-  }
+  }, [init, scrollListener])
 
   const scroll = (y = 0) => {
     if (scrollEl.current instanceof Window) {
@@ -90,29 +104,14 @@ export const BackTop: FunctionComponent<
       scroll(y)
       cid = requestAniFrame(fn)
       if (t === duration || y === 0) {
-        window.cancelAnimationFrame(cid)
+        cancelRaf(cid)
       }
     })
   }
 
-  const initCancelAniFrame = () => {
-    window.cancelAnimationFrame = window.webkitCancelAnimationFrame
-  }
-
-  function addEventListener() {
-    scrollEl.current?.addEventListener('scroll', scrollListener, false)
-    scrollEl.current?.addEventListener('resize', scrollListener, false)
-  }
-
-  function removeEventListener() {
-    scrollEl.current?.removeEventListener('scroll', scrollListener, false)
-    scrollEl.current?.removeEventListener('resize', scrollListener, false)
-  }
-
   const goTop = (e: MouseEvent<HTMLDivElement>) => {
     onClick && onClick(e)
-    const otime = +new Date()
-    startTime = otime
+    startTime = +new Date()
     duration > 0 ? scrollAnimation() : scroll()
   }
 
@@ -129,19 +128,7 @@ export const BackTop: FunctionComponent<
         }
 
   return (
-    <div
-      className={classNames(
-        classPrefix,
-        {
-          show: backTop,
-        },
-        className
-      )}
-      style={styles}
-      onClick={(e) => {
-        goTop(e)
-      }}
-    >
+    <div className={cls} style={styles} onClick={(e) => goTop(e)}>
       {children || <Top width={19} height={19} className="nut-backtop-main" />}
     </div>
   )

--- a/src/packages/backtop/backtop.tsx
+++ b/src/packages/backtop/backtop.tsx
@@ -51,13 +51,7 @@ export const BackTop: FunctionComponent<
   const [scrollTop, SetScrollTop] = useState(0)
   let startTime = 0
   const scrollEl = useRef<any>(null)
-  const cls = classNames(
-    classPrefix,
-    {
-      show: backTop,
-    },
-    className
-  )
+  const cls = classNames(classPrefix, { show: backTop }, className)
 
   const scrollListener = useCallback(() => {
     let top = null

--- a/src/packages/menu/__test__/__snapshots__/menu.spec.tsx.snap
+++ b/src/packages/menu/__test__/__snapshots__/menu.spec.tsx.snap
@@ -193,15 +193,3 @@ exports[`should match snapshot of two columns in one line 1`] = `
   </div>
 </DocumentFragment>
 `;
-
-exports[`should match snapshot of two columns in one line 2`] = `
-<DocumentFragment>
-  <div
-    class="nut-menu"
-  >
-    <div
-      class="nut-menu-bar"
-    />
-  </div>
-</DocumentFragment>
-`;

--- a/src/packages/menu/__test__/__snapshots__/menu.spec.tsx.snap
+++ b/src/packages/menu/__test__/__snapshots__/menu.spec.tsx.snap
@@ -96,3 +96,112 @@ exports[`should match snapshot 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`should match snapshot of two columns in one line 1`] = `
+<DocumentFragment>
+  <div
+    class="nut-menu"
+  >
+    <div
+      class="nut-menu-bar"
+    >
+      <div
+        class="nut-menu-title nut-menu-title-0"
+      >
+        <div
+          class="nut-menu-title-text"
+        >
+          全部商品
+        </div>
+        <svg
+          aria-labelledby="ArrowDown"
+          class="nut-icon nut-icon-ArrowDown nut-menu-title-icon"
+          role="presentation"
+          style="width: 12px; height: 12px;"
+          viewBox="0 0 1024 1024"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M158.17 289.83a42.67 42.67 0 1 0-60.34 60.34l384 384a42.67 42.67 0 0 0 60.36 0l384-384a42.67 42.67 0 1 0-60.36-60.34L512 643.67z"
+            fill="currentColor"
+            fill-opacity="0.9"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="nut-menu-container"
+    >
+      <div
+        class="nut-menu-container-wrap"
+        style="display: none;"
+      >
+        <div
+          class="nut-menu-container-content"
+        >
+          <div
+            class="nut-menu-container-item active"
+            style="flex-basis: 50%;"
+          >
+            <i
+              class="nut-menu-container-item-icon"
+            >
+              <svg
+                aria-labelledby="Check"
+                class="nut-icon nut-icon-Check "
+                color=""
+                role="presentation"
+                viewBox="0 0 1024 1024"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M998.4 245.03c-219.43 153.6-398.63 332.8-552.23 552.23-40.23 58.51-128 54.86-164.57-3.66-69.49-106.06-149.94-186.51-256-256-51.2-32.91-18.29-113.37 40.23-98.74 117.03 21.94 208.46 69.49 292.57 146.28 157.26-190.17 358.4-340.11 588.8-435.2 62.17-25.6 106.06 58.51 51.2 95.09"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+              </svg>
+            </i>
+            <div
+              class="nut-menu-container-item-title "
+            >
+              全部商品
+            </div>
+          </div>
+          <div
+            class="nut-menu-container-item "
+            style="flex-basis: 50%;"
+          >
+            <div
+              class="nut-menu-container-item-title "
+            >
+              新款商品
+            </div>
+          </div>
+          <div
+            class="nut-menu-container-item "
+            style="flex-basis: 50%;"
+          >
+            <div
+              class="nut-menu-container-item-title "
+            >
+              活动商品
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`should match snapshot of two columns in one line 2`] = `
+<DocumentFragment>
+  <div
+    class="nut-menu"
+  >
+    <div
+      class="nut-menu-bar"
+    />
+  </div>
+</DocumentFragment>
+`;

--- a/src/packages/menu/__test__/menu.spec.tsx
+++ b/src/packages/menu/__test__/menu.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useRef } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Success } from '@nutui/icons-react'
@@ -27,7 +27,7 @@ test('should match snapshot', () => {
     { text: '活动商品', value: 2 },
   ]
   const { asFragment } = render(
-    <Menu>
+    <Menu overlay={false}>
       <Menu.Item options={options} value={0} />
     </Menu>
   )
@@ -49,6 +49,42 @@ test('should match snapshot of two columns in one line', () => {
 })
 
 test('test props', async () => {
+  const App = () => {
+    const options = [
+      { text: '全部商品', value: 0 },
+      { text: '新款商品', value: 1 },
+      { text: '活动商品', value: 2 },
+    ]
+
+    const itemRef = useRef(null)
+    return (
+      <Menu lockScroll={false}>
+        <Menu.Item
+          className="custom-className"
+          title="custom title"
+          options={options}
+          value={0}
+          disabled
+          direction="up"
+          icon={<Success />}
+          activeTitleClass="activeTitleClass"
+          inactiveTitleClass="inactiveTitleClass"
+          onChange={testClick}
+        />
+        <Menu.Item />
+        <Menu.Item title="筛选" ref={itemRef}>
+          <div
+            className="test-menu-item"
+            onClick={() => {
+              ;(itemRef.current as any)?.toggle(false)
+            }}
+          >
+            确认
+          </div>
+        </Menu.Item>
+      </Menu>
+    )
+  }
   mockGetBoundingClientRect({
     width: 300,
     height: 100,
@@ -56,36 +92,23 @@ test('test props', async () => {
     top: 0,
     right: 300,
   })
-  const options = [
-    { text: '全部商品', value: 0 },
-    { text: '新款商品', value: 1 },
-    { text: '活动商品', value: 2 },
-  ]
   const testClick = vi.fn((val) => undefined)
-
-  const { container, getByText } = render(
-    <Menu lockScroll={false}>
-      <Menu.Item
-        className="custom-className"
-        title="custom title"
-        options={options}
-        value={0}
-        disabled
-        direction="up"
-        icon={<Success />}
-        activeTitleClass="activeTitleClass"
-        inactiveTitleClass="inactiveTitleClass"
-        onChange={testClick}
-      />
-      <Menu.Item />
-    </Menu>
-  )
+  const { container, getByText } = render(<App />)
 
   await act(() => {
     fireEvent.click(getByText('custom title'))
     fireEvent.click(container.querySelectorAll('.nut-menu-container-item')[1])
     expect(testClick).toBeCalledWith({ text: '新款商品', value: 1 })
   })
+
+  const overlayContainer = container.querySelectorAll(
+    '.nut-menu-container-overlay'
+  )[0]
+
+  fireEvent.click(overlayContainer)
+
+  const menuitem = container.querySelectorAll('.test-menu-item')[0]
+  fireEvent.click(menuitem)
 
   expect(container.querySelector('.custom-className')).toHaveClass(
     'custom-className'

--- a/src/packages/menu/__test__/menu.spec.tsx
+++ b/src/packages/menu/__test__/menu.spec.tsx
@@ -3,7 +3,6 @@ import { act, fireEvent, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Success } from '@nutui/icons-react'
 import Menu from '@/packages/menu'
-import MenuItem from '@/packages/menuitem'
 
 function mockGetBoundingClientRect(rect: any): () => void {
   const spy = vi.spyOn(Element.prototype, 'getBoundingClientRect')
@@ -29,7 +28,21 @@ test('should match snapshot', () => {
   ]
   const { asFragment } = render(
     <Menu>
-      <MenuItem options={options} value={0} />
+      <Menu.Item options={options} value={0} />
+    </Menu>
+  )
+  expect(asFragment()).toMatchSnapshot()
+})
+
+test('should match snapshot of two columns in one line', () => {
+  const options = [
+    { text: '全部商品', value: 0 },
+    { text: '新款商品', value: 1 },
+    { text: '活动商品', value: 2 },
+  ]
+  const { asFragment } = render(
+    <Menu scrollFixed>
+      <Menu.Item options={options} value={0} columns={2} />
     </Menu>
   )
   expect(asFragment()).toMatchSnapshot()
@@ -52,26 +65,25 @@ test('test props', async () => {
 
   const { container, getByText } = render(
     <Menu lockScroll={false}>
-      <MenuItem
+      <Menu.Item
         className="custom-className"
         title="custom title"
         options={options}
         value={0}
         disabled
-        columns={2}
+        direction="up"
         icon={<Success />}
         activeTitleClass="activeTitleClass"
         inactiveTitleClass="inactiveTitleClass"
         onChange={testClick}
       />
+      <Menu.Item />
     </Menu>
   )
 
   await act(() => {
     fireEvent.click(getByText('custom title'))
-
     fireEvent.click(container.querySelectorAll('.nut-menu-container-item')[1])
-
     expect(testClick).toBeCalledWith({ text: '新款商品', value: 1 })
   })
 

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import classNames from 'classnames'
 import { ArrowDown, ArrowUp } from '@nutui/icons-react-taro'
 import { OptionItem, MenuItem } from '@/packages/menuitem/menuitem.taro'
@@ -53,29 +59,30 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
     ...props,
   }
   const menuRef = useRef(null)
+  const [showMenuItem, setShowMenuItem] = useState<boolean[]>([])
+  const [menuItemTitle, setMenuItemTitle] = useState<string[]>([])
   const [isScrollFixed, setIsScrollFixed] = useState(false)
+  const cls = classNames(`nut-menu`, className, {
+    'scroll-fixed': isScrollFixed,
+  })
 
   const getScrollTop = (el: Element | Window) => {
-    return Math.max(0, 'scrollTop' in el ? el.scrollTop : el.pageYOffset)
+    return Math.max(0, 'scrollTop' in el ? el.scrollTop : el.scrollY)
   }
-  const onScroll = () => {
-    const { scrollFixed } = props
-
+  const onScroll = useCallback(() => {
     const scrollTop = getScrollTop(window)
     const isFixed =
       scrollTop > (typeof scrollFixed === 'boolean' ? 30 : Number(scrollFixed))
     setIsScrollFixed(isFixed)
-  }
+  }, [scrollFixed])
 
   useEffect(() => {
     if (scrollFixed) {
       window.addEventListener('scroll', onScroll)
     }
     return () => window.removeEventListener('scroll', onScroll)
-  }, [])
+  }, [scrollFixed, onScroll])
 
-  const [showMenuItem, setShowMenuItem] = useState<boolean[]>([])
-  const [menuItemTitle, setMenuItemTitle] = useState<string[]>([])
   const toggleMenuItem: MenuCallBackFunction = (index, from = 'NORMAL') => {
     showMenuItem[index] = !showMenuItem[index]
     if (showMenuItem[index]) {
@@ -97,7 +104,6 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
     menuItemTitle[index] = text
     setMenuItemTitle([...menuItemTitle])
   }
-
   const cloneChildren = () => {
     return React.Children.map(children, (child, index) => {
       return React.cloneElement(child as any, {
@@ -179,13 +185,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
     })
   }
   return (
-    <div
-      {...rest}
-      className={classNames(`nut-menu`, className, {
-        'scroll-fixed': isScrollFixed,
-      })}
-      ref={menuRef}
-    >
+    <div {...rest} className={cls} ref={menuRef}>
       <div
         className={classNames('nut-menu-bar', {
           opened: showMenuItem.includes(true),

--- a/src/packages/menu/menu.taro.tsx
+++ b/src/packages/menu/menu.taro.tsx
@@ -67,7 +67,10 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   })
 
   const getScrollTop = (el: Element | Window) => {
-    return Math.max(0, 'scrollTop' in el ? el.scrollTop : el.scrollY)
+    return Math.max(
+      0,
+      el === window ? window.scrollY : (el as Element).scrollTop
+    )
   }
   const onScroll = useCallback(() => {
     const scrollTop = getScrollTop(window)

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -67,7 +67,10 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
   })
 
   const getScrollTop = (el: Element | Window) => {
-    return Math.max(0, 'scrollTop' in el ? el.scrollTop : el.scrollY)
+    return Math.max(
+      0,
+      el === window ? window.scrollY : (el as Element).scrollTop
+    )
   }
   const onScroll = useCallback(() => {
     const scrollTop = getScrollTop(window)

--- a/src/packages/menu/menu.tsx
+++ b/src/packages/menu/menu.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import classNames from 'classnames'
 import { ArrowDown, ArrowUp } from '@nutui/icons-react'
 import { OptionItem, MenuItem } from '@/packages/menuitem/menuitem'
@@ -53,29 +59,30 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
     ...props,
   }
   const menuRef = useRef(null)
+  const [showMenuItem, setShowMenuItem] = useState<boolean[]>([])
+  const [menuItemTitle, setMenuItemTitle] = useState<string[]>([])
   const [isScrollFixed, setIsScrollFixed] = useState(false)
+  const cls = classNames(`nut-menu`, className, {
+    'scroll-fixed': isScrollFixed,
+  })
 
   const getScrollTop = (el: Element | Window) => {
-    return Math.max(0, 'scrollTop' in el ? el.scrollTop : el.pageYOffset)
+    return Math.max(0, 'scrollTop' in el ? el.scrollTop : el.scrollY)
   }
-  const onScroll = () => {
-    const { scrollFixed } = props
-
+  const onScroll = useCallback(() => {
     const scrollTop = getScrollTop(window)
     const isFixed =
       scrollTop > (typeof scrollFixed === 'boolean' ? 30 : Number(scrollFixed))
     setIsScrollFixed(isFixed)
-  }
+  }, [scrollFixed])
 
   useEffect(() => {
     if (scrollFixed) {
       window.addEventListener('scroll', onScroll)
     }
     return () => window.removeEventListener('scroll', onScroll)
-  }, [])
+  }, [scrollFixed, onScroll])
 
-  const [showMenuItem, setShowMenuItem] = useState<boolean[]>([])
-  const [menuItemTitle, setMenuItemTitle] = useState<string[]>([])
   const toggleMenuItem: MenuCallBackFunction = (index, from = 'NORMAL') => {
     showMenuItem[index] = !showMenuItem[index]
     if (showMenuItem[index]) {
@@ -180,13 +187,7 @@ export const Menu: FunctionComponent<Partial<MenuProps>> & {
     })
   }
   return (
-    <div
-      {...rest}
-      className={classNames(`nut-menu`, className, {
-        'scroll-fixed': isScrollFixed,
-      })}
-      ref={menuRef}
-    >
+    <div {...rest} className={cls} ref={menuRef}>
       <div
         className={classNames('nut-menu-bar', {
           opened: showMenuItem.includes(true),

--- a/src/packages/menuitem/menuitem.taro.tsx
+++ b/src/packages/menuitem/menuitem.taro.tsx
@@ -90,9 +90,21 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
   useEffect(() => {
     setShowPopup(show)
   }, [show])
+
+  const getParentOffset = useCallback(() => {
+    setTimeout(async () => {
+      const p = parent.menuRef.current
+      const rect = await getRectByTaro(p)
+      setPosition({
+        height: rect.height,
+        top: rect.top,
+      })
+    }, 100)
+  }, [parent.menuRef])
+
   useEffect(() => {
     getParentOffset()
-  }, [showPopup])
+  }, [showPopup, getParentOffset])
 
   const windowHeight = useMemo(() => getSystemInfoSync().windowHeight, [])
   const updateItemOffset = useCallback(() => {
@@ -106,7 +118,8 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
         })
       }
     })
-  }, [direction, windowHeight])
+  }, [direction, windowHeight, parent.lockScroll, parent.menuRef])
+
   usePageScroll(updateItemOffset)
 
   useImperativeHandle<any, any>(ref, () => ({
@@ -136,16 +149,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     top: 0,
     height: 0,
   })
-  const getParentOffset = () => {
-    setTimeout(async () => {
-      const p = parent.menuRef.current
-      const rect = await getRectByTaro(p)
-      setPosition({
-        height: rect.height,
-        top: rect.top,
-      })
-    }, 100)
-  }
+
   const isShow = () => {
     if (showPopup) return {}
     return { display: 'none' }

--- a/src/packages/menuitem/menuitem.tsx
+++ b/src/packages/menuitem/menuitem.tsx
@@ -1,6 +1,7 @@
 import React, {
   CSSProperties,
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -87,9 +88,23 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
   useEffect(() => {
     setShowPopup(show)
   }, [show])
+
+  const getParentOffset = useCallback(() => {
+    setTimeout(() => {
+      const p = parent.menuRef.current
+      if (p) {
+        const rect = p.getBoundingClientRect()
+        setPosition({
+          height: rect.height,
+          top: rect.top,
+        })
+      }
+    })
+  }, [parent.menuRef])
+
   useEffect(() => {
     getParentOffset()
-  }, [showPopup])
+  }, [showPopup, getParentOffset])
 
   useImperativeHandle<any, any>(ref, () => ({
     toggle: (s: boolean) => {
@@ -128,19 +143,6 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
     return getScrollParent(parent.menuRef, window)
   }, [parent.menuRef])
 
-  const getParentOffset = () => {
-    setTimeout(() => {
-      const p = parent.menuRef.current
-      if (p) {
-        const rect = p.getBoundingClientRect()
-        setPosition({
-          height: rect.height,
-          top: rect.top,
-        })
-      }
-    })
-  }
-
   useEffect(() => {
     if (!parent.lockScroll) {
       scrollParent?.addEventListener('scroll', getParentOffset, false)
@@ -148,7 +150,7 @@ export const MenuItem = forwardRef((props: Partial<MenuItemProps>, ref) => {
         scrollParent?.removeEventListener('scroll', getParentOffset, false)
       }
     }
-  }, [])
+  }, [parent.lockScroll, scrollParent, getParentOffset])
 
   const getPosition = (): CSSProperties => {
     return direction === 'down'

--- a/src/utils/raf.ts
+++ b/src/utils/raf.ts
@@ -2,7 +2,7 @@ export const inBrowser = typeof window !== 'undefined'
 
 // 防频
 function requestAniFrame() {
-  if (typeof window !== 'undefined') {
+  if (inBrowser) {
     const _window = window as any
     return (
       _window.requestAnimationFrame ||
@@ -19,7 +19,8 @@ function requestAniFrame() {
 
 export function cancelRaf(id: number) {
   if (inBrowser) {
-    cancelAnimationFrame(id)
+    const _window = window as any
+    ;(_window.cancelAnimationFrame || _window.webkitCancelAnimationFrame)(id)
   } else {
     clearTimeout(id)
   }


### PR DESCRIPTION


<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [x] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 优化了 `BackTop` 和 `Menu` 组件的状态管理和性能。
	- 在 `Menu` 组件中添加了新的状态变量以跟踪菜单项的可见性和标题。

- **改进**
	- 引入 `useCallback` 钩子以提高性能。
	- 简化了 `goTop` 函数和渲染逻辑。
	- 更新了 `getScrollTop` 函数以使用 `scrollY`。
	- 更新了 `BackTop` 和 `Menu` 组件的测试用例以增强结构和全面性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->