### PR TITLE
添加inputNumber组件的全选中文本可配置

### DIFF
--- a/src/packages/inputnumber/demo.taro.tsx
+++ b/src/packages/inputnumber/demo.taro.tsx
@@ -13,6 +13,7 @@ import Demo6 from './demos/taro/demo6'
 import Demo7 from './demos/taro/demo7'
 import Demo8 from './demos/taro/demo8'
 import Demo9 from './demos/taro/demo9'
+import Demo10 from './demos/taro/demo10'
 
 const InputNumberDemo = () => {
   const [translated] = useTranslate({
@@ -29,6 +30,7 @@ const InputNumberDemo = () => {
       '65bafb1d': '支持异步修改',
       '7e2394ae': '自定义按钮大小',
       '7e2394be': '支持formatter',
+      '5b7286d1': '支持取消全选中文本',
     },
     'zh-TW': {
       '6333c786': '超出限制事件觸發',
@@ -43,6 +45,7 @@ const InputNumberDemo = () => {
       '65bafb1d': '支持異步修改',
       '7e2394ae': '自定義按鈕大小',
       '7e2394be': '支持formatter',
+      '5b7286d1': '支援取消全選中文本',
     },
     'en-US': {
       '6333c786': 'Exceeded limit event triggered',
@@ -57,6 +60,7 @@ const InputNumberDemo = () => {
       '65bafb1d': 'Support for asynchronous modification',
       '7e2394ae': 'custom button size',
       '7e2394be': 'support formatter',
+      '5b7286d1': 'support deselect all text',
     },
   })
 
@@ -104,6 +108,11 @@ const InputNumberDemo = () => {
 
         <h2>Formatter</h2>
         <Demo9 />
+
+        <h2>{translated['5b7286d1']}</h2>
+        <Cell>
+          <Demo10 />
+        </Cell>
       </div>
     </>
   )

--- a/src/packages/inputnumber/demo.tsx
+++ b/src/packages/inputnumber/demo.tsx
@@ -10,6 +10,7 @@ import Demo6 from './demos/h5/demo6'
 import Demo7 from './demos/h5/demo7'
 import Demo8 from './demos/h5/demo8'
 import Demo9 from './demos/h5/demo9'
+import Demo10 from './demos/h5/demo10'
 
 const InputNumberDemo = () => {
   const [translated] = useTranslate({
@@ -26,6 +27,7 @@ const InputNumberDemo = () => {
       '65bafb1d': '支持异步修改',
       '7e2394ae': '自定义按钮大小',
       '7e2394be': '支持formatter',
+      '5b7286d1': '支持取消全选中文本',
     },
     'zh-TW': {
       '6333c786': '超出限制事件觸發',
@@ -40,6 +42,7 @@ const InputNumberDemo = () => {
       '65bafb1d': '支持異步修改',
       '7e2394ae': '自定義按鈕大小',
       '7e2394be': '支持formatter',
+      '5b7286d1': '支援取消全選中文本',
     },
     'en-US': {
       '6333c786': 'Exceeded limit event triggered',
@@ -54,6 +57,7 @@ const InputNumberDemo = () => {
       '65bafb1d': 'Support for asynchronous modification',
       '7e2394ae': 'custom button size',
       '7e2394be': 'support formatter',
+      '5b7286d1': 'support deselect all text',
     },
   })
 
@@ -100,6 +104,11 @@ const InputNumberDemo = () => {
 
         <h2>Formatter</h2>
         <Demo9 />
+
+        <h2>{translated['5b7286d1']}</h2>
+        <Cell>
+          <Demo10 />
+        </Cell>
       </div>
     </>
   )

--- a/src/packages/inputnumber/demos/h5/demo10.tsx
+++ b/src/packages/inputnumber/demos/h5/demo10.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import { InputNumber } from '@nutui/nutui-react'
+
+const Demo10 = () => {
+  return <InputNumber defaultValue={1} allowEmpty select={false} />
+}
+export default Demo10

--- a/src/packages/inputnumber/demos/taro/demo10.tsx
+++ b/src/packages/inputnumber/demos/taro/demo10.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import { InputNumber } from '@nutui/nutui-react-taro'
+
+const Demo10 = () => {
+  return <InputNumber defaultValue={1} allowEmpty select={false} />
+}
+export default Demo10

--- a/src/packages/inputnumber/doc.en-US.md
+++ b/src/packages/inputnumber/doc.en-US.md
@@ -98,6 +98,14 @@ Asynchronous modification through `change` event and `model-value`
 
 :::
 
+### support deselect all text
+
+:::demo
+
+<CodeBlock src='h5/demo10.tsx'></CodeBlock>
+
+:::
+
 ## InputNumber
 
 ### Props
@@ -114,6 +122,7 @@ Asynchronous modification through `change` event and `model-value`
 | disabled | Disable all features | `boolean` | `false` |
 | readOnly | Read only status disables input box operation behavior | `boolean` | `false` |
 | async | Support for asynchronous modification | `boolean` | `false` |
+| select | Support deselect all text | `boolean` | `true` |
 | formatter | Specifies the format of the value displayed in the input box | `function(value: number \| string): string` | `-` |
 | onPlus | Triggered when the Add button is clicked | `(e: MouseEvent) => void` | `-` |
 | onMinus | Triggered when the decrease button is clicked | `(e: MouseEvent) => void` | `-` |

--- a/src/packages/inputnumber/doc.md
+++ b/src/packages/inputnumber/doc.md
@@ -20,16 +20,6 @@ import { InputNumber } from '@nutui/nutui-react'
 
 :::
 
-### 全选设置
-
-取消全选
-
-:::demo
-
-<CodeBlock src='h5/demo10.tsx'></CodeBlock>
-
-:::
-
 ### 步长设置
 
 设置步长 `step` 5
@@ -108,6 +98,14 @@ import { InputNumber } from '@nutui/nutui-react'
 
 :::
 
+### 支持取消文本全选中
+
+:::demo
+
+<CodeBlock src='h5/demo10.tsx'></CodeBlock>
+
+:::
+
 ## InputNumber
 
 ### Props
@@ -124,7 +122,7 @@ import { InputNumber } from '@nutui/nutui-react'
 | disabled | 禁用所有功能 | `boolean` | `false` |
 | readOnly | 只读状态禁用输入框操作行为 | `boolean` | `false` |
 | async | 支持异步修改 | `boolean` | `false` |
-| select | 支持修改全选 | `boolean` | `true` |
+| select | 支持取消文本全选中 | `boolean` | `true` |
 | formatter | 指定输入框展示值的格式 | `function(value: number \| string): string` | `-` |
 | onPlus | 点击增加按钮时触发 | `(e: MouseEvent) => void` | `-` |
 | onMinus | 点击减少按钮时触发 | `(e: MouseEvent) => void` | `-` |

--- a/src/packages/inputnumber/doc.md
+++ b/src/packages/inputnumber/doc.md
@@ -20,6 +20,16 @@ import { InputNumber } from '@nutui/nutui-react'
 
 :::
 
+### 全选设置
+
+取消全选
+
+:::demo
+
+<CodeBlock src='h5/demo10.tsx'></CodeBlock>
+
+:::
+
 ### 步长设置
 
 设置步长 `step` 5
@@ -114,6 +124,7 @@ import { InputNumber } from '@nutui/nutui-react'
 | disabled | 禁用所有功能 | `boolean` | `false` |
 | readOnly | 只读状态禁用输入框操作行为 | `boolean` | `false` |
 | async | 支持异步修改 | `boolean` | `false` |
+| select | 支持修改全选 | `boolean` | `true` |
 | formatter | 指定输入框展示值的格式 | `function(value: number \| string): string` | `-` |
 | onPlus | 点击增加按钮时触发 | `(e: MouseEvent) => void` | `-` |
 | onMinus | 点击减少按钮时触发 | `(e: MouseEvent) => void` | `-` |

--- a/src/packages/inputnumber/inputnumber.taro.tsx
+++ b/src/packages/inputnumber/inputnumber.taro.tsx
@@ -23,6 +23,7 @@ export interface InputNumberProps extends BasicComponent {
   step: number
   digits: number
   async: boolean
+  select: boolean
   formatter?: (value?: string | number) => string
   onPlus: (e: React.MouseEvent) => void
   onMinus: (e: React.MouseEvent) => void
@@ -46,6 +47,7 @@ const defaultProps = {
   step: 1,
   digits: 0,
   async: false,
+  select: true,
 } as InputNumberProps
 
 const classPrefix = `nut-inputnumber`
@@ -66,6 +68,7 @@ export const InputNumber: FunctionComponent<
     digits,
     step,
     async,
+    select,
     className,
     style,
     formatter,
@@ -86,10 +89,10 @@ export const InputNumber: FunctionComponent<
   const [focused, setFocused] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
-    if (focused) {
+    if (select && focused) {
       inputRef.current?.select?.()
     }
-  }, [focused])
+  }, [select, focused])
 
   const [shadowValue, setShadowValue] = usePropsValue<number | null | string>({
     value: typeof value === 'string' ? parseFloat(value) : value,

--- a/src/packages/inputnumber/inputnumber.tsx
+++ b/src/packages/inputnumber/inputnumber.tsx
@@ -21,6 +21,7 @@ export interface InputNumberProps extends BasicComponent {
   step: number
   digits: number
   async: boolean
+  select: boolean
   formatter?: (value?: string | number) => string
   onPlus: (e: React.MouseEvent) => void
   onMinus: (e: React.MouseEvent) => void
@@ -43,6 +44,7 @@ const defaultProps = {
   step: 1,
   digits: 0,
   async: false,
+  select: true,
 } as InputNumberProps
 
 const classPrefix = `nut-inputnumber`
@@ -62,6 +64,7 @@ export const InputNumber: FunctionComponent<
     digits,
     step,
     async,
+    select,
     className,
     style,
     formatter,
@@ -82,10 +85,10 @@ export const InputNumber: FunctionComponent<
   const [focused, setFocused] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
-    if (focused) {
+    if (select && focused) {
       inputRef.current?.select?.()
     }
-  }, [focused])
+  }, [select, focused])
 
   const [shadowValue, setShadowValue] = usePropsValue<number | null | string>({
     value: typeof value === 'string' ? parseFloat(value) : value,


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[inputNumber在h5页面上获取焦点之后会默认全选中输入框中的值](https://github.com/jdf2e/nutui-react/issues/2640)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 `Demo10` 演示组件，展示“支持取消全选文本”功能。
  - `InputNumber` 组件新增 `select` 属性，允许用户控制文本选择行为，默认值为 `true`。

- **文档更新**
  - 更新了 `InputNumber` 组件的文档，新增关于 `select` 属性的说明及演示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->