### PR TITLE
feat(calendar): support renderBottomButton props

### DIFF
--- a/src/packages/calendar/calendar.taro.tsx
+++ b/src/packages/calendar/calendar.taro.tsx
@@ -25,6 +25,7 @@ export interface CalendarProps {
   firstDayOfWeek: number
   disableDate: (date: CalendarDay) => boolean
   renderHeaderButtons?: () => string | JSX.Element
+  renderBottomButton?: () => string | JSX.Element
   renderDay?: (date: CalendarDay) => string | JSX.Element
   renderDayTop?: (date: CalendarDay) => string | JSX.Element
   renderDayBottom?: (date: CalendarDay) => string | JSX.Element
@@ -90,6 +91,7 @@ export const Calendar = React.forwardRef<
     firstDayOfWeek,
     disableDate,
     renderHeaderButtons,
+    renderBottomButton,
     renderDay,
     renderDayTop,
     renderDayBottom,
@@ -153,6 +155,7 @@ export const Calendar = React.forwardRef<
         firstDayOfWeek={firstDayOfWeek}
         disableDate={disableDate}
         renderHeaderButtons={renderHeaderButtons}
+        renderBottomButton={renderBottomButton}
         renderDay={renderDay}
         renderDayTop={renderDayTop}
         renderDayBottom={renderDayBottom}

--- a/src/packages/calendar/calendar.tsx
+++ b/src/packages/calendar/calendar.tsx
@@ -25,6 +25,7 @@ export interface CalendarProps {
   firstDayOfWeek: number
   disableDate: (date: CalendarDay) => boolean
   renderHeaderButtons?: () => string | JSX.Element
+  renderBottomButton?: () => string | JSX.Element
   renderDay?: (date: CalendarDay) => string | JSX.Element
   renderDayTop?: (date: CalendarDay) => string | JSX.Element
   renderDayBottom?: (date: CalendarDay) => string | JSX.Element
@@ -90,6 +91,7 @@ export const Calendar = React.forwardRef<
     firstDayOfWeek,
     disableDate,
     renderHeaderButtons,
+    renderBottomButton,
     renderDay,
     renderDayTop,
     renderDayBottom,
@@ -138,6 +140,7 @@ export const Calendar = React.forwardRef<
         children={children}
         type={type}
         autoBackfill={autoBackfill}
+        renderBottomButton={renderBottomButton}
         popup={popup}
         title={title || locale.calendaritem.title}
         defaultValue={defaultValue}

--- a/src/packages/calendar/doc.en-US.md
+++ b/src/packages/calendar/doc.en-US.md
@@ -122,6 +122,7 @@ import { Calendar } from '@nutui/nutui-react'
 | firstDayOfWeek | first day of week | `0-6` | `0` |
 | disableDate | set disable date | `(date: CalendarDay) => boolean` | `-` |
 | renderHeaderButtons | custom buttons, under the title but above the subtitle | `() => string` \| `JSX.Element` | `-` |
+| renderBottomButton | Custom calendar bottom button | `() => string` \| `JSX.Element` | `-` |
 | renderDay | day info | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayTop | something above day | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayBottom | something under day | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |

--- a/src/packages/calendar/doc.md
+++ b/src/packages/calendar/doc.md
@@ -122,6 +122,7 @@ import { Calendar } from '@nutui/nutui-react'
 | firstDayOfWeek | 设置周起始日 | `0-6` | `0` |
 | disableDate | 设置不可选日期 | `(date: CalendarDay) => boolean` | `-` |
 | renderHeaderButtons | 自定义日历标题下部，可用以添加自定义操作 | `() => string` \| `JSX.Element` | `-` |
+| renderBottomButton | 自定义日历底部按钮 | `() => string` \| `JSX.Element` | `-` |
 | renderDay | 日期信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayTop | 日期顶部信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayBottom | 日期底部信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |

--- a/src/packages/calendar/doc.taro.md
+++ b/src/packages/calendar/doc.taro.md
@@ -122,6 +122,7 @@ import { Calendar } from '@nutui/nutui-react-taro'
 | firstDayOfWeek | 设置周起始日 | `0-6` | `0` |
 | disableDate | 设置不可选日期 | `(date: CalendarDay) => boolean` | `-` |
 | renderHeaderButtons | 自定义日历标题下部，可用以添加自定义操作 | `() => string` \| `JSX.Element` | `-` |
+| renderBottomButton | 自定义日历底部按钮 | `() => string` \| `JSX.Element` | `-` |
 | renderDay | 日期信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayTop | 日期顶部信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayBottom | 日期底部信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |

--- a/src/packages/calendar/doc.zh-TW.md
+++ b/src/packages/calendar/doc.zh-TW.md
@@ -122,6 +122,7 @@ import { Calendar } from '@nutui/nutui-react'
 | firstDayOfWeek | 設置周起始日 | `0-6` | `0` |
 | disableDate | 設置不可選日期 | `(date: CalendarDay) => boolean` | `-` |
 | renderHeaderButtons | 自定義日歴標題下部，可用以添加自定義操作 | `() => string` \| `JSX.Element` | `-` |
+| renderBottomButton | 自定義日歴底部按鈕 | `() => string` \| `JSX.Element` | `-` |
 | renderDay | 日期信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayTop | 日期頂部信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |
 | renderDayBottom | 日期底部信息 | `(date: CalendarDay) => string` \| `JSX.Element` | `-` |

--- a/src/packages/calendaritem/calendaritem.taro.tsx
+++ b/src/packages/calendaritem/calendaritem.taro.tsx
@@ -56,6 +56,7 @@ export interface CalendarItemProps extends PopupProps {
   firstDayOfWeek: number
   disableDate: (date: CalendarDay) => boolean
   renderHeaderButtons: () => string | JSX.Element
+  renderBottomButton: () => string | JSX.Element
   renderDay: (date: CalendarDay) => string | JSX.Element
   renderDayTop: (date: CalendarDay) => string | JSX.Element
   renderDayBottom: (date: CalendarDay) => string | JSX.Element
@@ -121,6 +122,7 @@ export const CalendarItem = React.forwardRef<
     renderDay,
     renderDayTop,
     renderDayBottom,
+    renderBottomButton,
     value,
     onConfirm,
     onUpdate,
@@ -876,8 +878,12 @@ export const CalendarItem = React.forwardRef<
     return (
       <div className="nut-calendar-footer">
         {children}
-        <div className="calendar-confirm-btn" onClick={confirm}>
-          {confirmText || locale.confirm}
+        <div onClick={confirm}>
+          {renderBottomButton() || (
+            <div className="calendar-confirm-btn">
+              {confirmText || locale.confirm}
+            </div>
+          )}
         </div>
       </div>
     )

--- a/src/packages/calendaritem/calendaritem.taro.tsx
+++ b/src/packages/calendaritem/calendaritem.taro.tsx
@@ -879,7 +879,9 @@ export const CalendarItem = React.forwardRef<
       <div className="nut-calendar-footer">
         {children}
         <div onClick={confirm}>
-          {renderBottomButton() || (
+          {renderBottomButton ? (
+            renderBottomButton()
+          ) : (
             <div className="calendar-confirm-btn">
               {confirmText || locale.confirm}
             </div>

--- a/src/packages/calendaritem/calendaritem.tsx
+++ b/src/packages/calendaritem/calendaritem.tsx
@@ -878,7 +878,9 @@ export const CalendarItem = React.forwardRef<
       <div className="nut-calendar-footer">
         {children}
         <div onClick={confirm}>
-          {renderBottomButton() || (
+          {renderBottomButton ? (
+            renderBottomButton()
+          ) : (
             <div className="calendar-confirm-btn">
               {confirmText || locale.confirm}
             </div>

--- a/src/packages/calendaritem/calendaritem.tsx
+++ b/src/packages/calendaritem/calendaritem.tsx
@@ -55,6 +55,7 @@ export interface CalendarItemProps extends PopupProps {
   firstDayOfWeek: number
   disableDate: (date: CalendarDay) => boolean
   renderHeaderButtons: () => string | JSX.Element
+  renderBottomButton: () => string | JSX.Element
   renderDay: (date: CalendarDay) => string | JSX.Element
   renderDayTop: (date: CalendarDay) => string | JSX.Element
   renderDayBottom: (date: CalendarDay) => string | JSX.Element
@@ -116,6 +117,7 @@ export const CalendarItem = React.forwardRef<
     firstDayOfWeek,
     disableDate,
     renderHeaderButtons,
+    renderBottomButton,
     renderDay,
     renderDayTop,
     renderDayBottom,
@@ -875,8 +877,12 @@ export const CalendarItem = React.forwardRef<
     return (
       <div className="nut-calendar-footer">
         {children}
-        <div className="calendar-confirm-btn" onClick={confirm}>
-          {confirmText || locale.confirm}
+        <div onClick={confirm}>
+          {renderBottomButton() || (
+            <div className="calendar-confirm-btn">
+              {confirmText || locale.confirm}
+            </div>
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在日历组件中新增可选属性 `renderBottomButton`，允许用户自定义底部按钮的渲染。
- **文档更新**
	- 更新了相关文档，以反映 `renderBottomButton` 属性的目的、类型及默认值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->