### PR TITLE
fix(uploader): use chooseImage API when env ='JD'

### DIFF
--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -260,7 +260,7 @@ const InternalUploader: ForwardRefRenderFunction<
         document.body.appendChild(obj)
       }
     }
-    if ((getEnv() === 'WEAPP' || getEnv() === 'JD') && chooseMedia) {
+    if (getEnv() === 'WEAPP' && chooseMedia) {
       // 其余端全部使用 chooseImage API
       chooseMedia({
         count: multiple ? (maxCount as number) * 1 - fileList.length : 1,


### PR DESCRIPTION

- [x] 日常 bug 修复



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 优化了媒体选择逻辑，确保在'WEAPP'环境下调用`chooseMedia`，其他环境继续使用`chooseImage`。
- **错误修复**
	- 保留了`maxCount`的计算，确保用户选择的文件数量符合最大限制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->