### PR TITLE
RFC: props 和 css 文件的关联

### DIFF
--- a/scripts/generate-nutui.js
+++ b/scripts/generate-nutui.js
@@ -15,12 +15,16 @@ const raws = []
 
 config.nav.map((item) => {
   item.packages.forEach((element) => {
-    let { name, show, exportEmpty, exclude } = element
+    let { name, show, exportEmpty, exclude, cssExperiment } = element
     if (exclude) return
     if (show || exportEmpty) {
       importStr += `import ${name} from '@/packages/${name.toLowerCase()}';\n`
       importStr += `export * from '@/packages/${name.toLowerCase()}';\n`
-      importScssStr += `import '@/packages/${name.toLowerCase()}/${name.toLowerCase()}.scss';\n`
+      if(cssExperiment) {
+        importScssStr += `import '@/packages/${name.toLowerCase()}/style/index.scss';\n`
+      } else {
+        importScssStr += `import '@/packages/${name.toLowerCase()}/${name.toLowerCase()}.scss';\n`
+      }
 
       packages.push(name)
     }

--- a/scripts/taro/generate-nutui-taro.js
+++ b/scripts/taro/generate-nutui-taro.js
@@ -13,14 +13,20 @@ const raws = []
 
 config.nav.map((item) => {
   item.packages.forEach((element) => {
-    let { name, show, type, taro, exportEmpty, exclude, rn } = element
+    let { name, show, type, taro, exportEmpty, exclude, rn, cssExperiment } = element
     if (exclude) return
 
     importStr += `import ${name} from '@/packages/${name.toLowerCase()}/index.taro'\n`
     importStr += `export * from '@/packages/${name.toLowerCase()}/index.taro'\n`
     importRNStr += `import ${name} from '@/packages/${name.toLowerCase()}/index.${rn?'rn':'taro'}'\n`
     importRNStr += `export * from '@/packages/${name.toLowerCase()}/index.${rn?'rn':'taro'}'\n`
-    importScssStr += `import '@/packages/${name.toLowerCase()}/${name.toLowerCase()}.scss'\n`
+
+    if(cssExperiment) {
+      importScssStr += `import '@/packages/${name.toLowerCase()}/style/index.scss';\n`
+    } else {
+      importScssStr += `import '@/packages/${name.toLowerCase()}/${name.toLowerCase()}.scss'\n`
+    }
+
     packages.push(name)
 
     glob

--- a/src/config.json
+++ b/src/config.json
@@ -67,6 +67,7 @@
           "sort": 1,
           "show": true,
           "taro": true,
+          "cssExperiment": true,
           "author": ""
         },
         {

--- a/src/packages/button/style/block.scss
+++ b/src/packages/button/style/block.scss
@@ -1,0 +1,4 @@
+.nut-button-block {
+  display: block;
+  width: 100%;
+}

--- a/src/packages/button/style/css.json
+++ b/src/packages/button/style/css.json
@@ -1,0 +1,16 @@
+{
+  "default": {
+    "type": "default",
+    "size": "normal",
+    "shape": "round",
+    "fill": "solid"
+  },
+  "properties": {
+    "type": 1,
+    "size": 1,
+    "shape": 1,
+    "loading": 1,
+    "disabled": 1,
+    "fill": 2
+  }
+}

--- a/src/packages/button/style/disabled.scss
+++ b/src/packages/button/style/disabled.scss
@@ -1,0 +1,10 @@
+.nut-button-disabled {
+  opacity: 0.2;
+}
+
+.nut-button-disabled {
+  .nutui-ssxxx {
+    xxsdf {
+    }
+  }
+}

--- a/src/packages/button/style/fill-dashed.scss
+++ b/src/packages/button/style/fill-dashed.scss
@@ -1,0 +1,7 @@
+.nut-button-dashed {
+  color: currentColor;
+  border-width: 1px;
+  border-color: currentColor;
+  border-style: dashed;
+  background: transparent;
+}

--- a/src/packages/button/style/fill-none.scss
+++ b/src/packages/button/style/fill-none.scss
@@ -1,0 +1,7 @@
+.nut-button-none {
+  border-color: transparent;
+}
+
+taro-button-core:after {
+  border-color: transparent !important;
+}

--- a/src/packages/button/style/fill-outline.scss
+++ b/src/packages/button/style/fill-outline.scss
@@ -1,0 +1,7 @@
+.nut-button-outline {
+  color: currentColor;
+  border-width: 1px;
+  border-color: currentColor;
+  border-style: solid;
+  background: transparent;
+}

--- a/src/packages/button/style/fill-solid.scss
+++ b/src/packages/button/style/fill-solid.scss
@@ -1,0 +1,5 @@
+.nut-button-solid {
+  background: $button-primary-background-color;
+  color: $button-primary-color;
+  border-color: transparent;
+}

--- a/src/packages/button/style/fill.scss
+++ b/src/packages/button/style/fill.scss
@@ -1,0 +1,4 @@
+@import './fill-none.scss';
+@import './fill-dashed.scss';
+@import './fill-outline.scss';
+@import './fill-solid.scss';

--- a/src/packages/button/style/index.scss
+++ b/src/packages/button/style/index.scss
@@ -1,0 +1,7 @@
+// index.scss 组件样式的入口文件，集合所有内容
+@import './layout.scss';
+@import './type.scss';
+@import './fill.scss';
+@import './size.scss';
+@import './block.scss';
+@import './disabled.scss';

--- a/src/packages/button/style/layout.scss
+++ b/src/packages/button/style/layout.scss
@@ -1,0 +1,69 @@
+// 组件的基础样式
+.nut-button {
+  position: relative;
+  display: inline-block;
+  width: auto;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  height: $button-default-height;
+  font-size: $button-default-font-size;
+  font-weight: $button-default-font-weight;
+  text-align: center;
+  cursor: pointer;
+  transition: $button-transition;
+  color: $button-default-color;
+  background: $button-default-background-color;
+  border-width: $button-border-width;
+
+  user-select: none;
+  touch-action: manipulation;
+  -webkit-appearance: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+.nut-button-wrap {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+.nut-button-text {
+  margin-left: $button-text-icon-margin;
+}
+
+.nut-button-text-right {
+  margin-right: $button-text-icon-margin;
+}
+
+.nut-button-children {
+  display: flex;
+  flex-direction: row;
+  background: transparent;
+}
+
+.nut-button::before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  background-color: $color-mask;
+  border: inherit;
+  border-color: $color-mask;
+  border-radius: inherit;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  content: ' ';
+}
+
+.nut-button::after {
+  border: none;
+}
+
+.nut-button:active::before {
+  opacity: 0.1;
+}

--- a/src/packages/button/style/loading.scss
+++ b/src/packages/button/style/loading.scss
@@ -1,0 +1,4 @@
+.nut-button-loading {
+  cursor: default;
+  opacity: 0.9;
+}

--- a/src/packages/button/style/size-large.scss
+++ b/src/packages/button/style/size-large.scss
@@ -1,0 +1,6 @@
+.nut-button-large {
+  height: $button-large-height;
+  padding: $button-large-padding;
+  font-size: $button-large-font-size;
+  font-weight: $button-large-font-weight;
+}

--- a/src/packages/button/style/size-mini.scss
+++ b/src/packages/button/style/size-mini.scss
@@ -1,0 +1,5 @@
+.nut-button-mini {
+  height: $button-mini-height;
+  padding: $button-mini-padding;
+  font-size: $button-mini-font-size;
+}

--- a/src/packages/button/style/size-normal.scss
+++ b/src/packages/button/style/size-normal.scss
@@ -1,0 +1,3 @@
+.nut-button-normal {
+  padding: $button-normal-padding;
+}

--- a/src/packages/button/style/size-small.scss
+++ b/src/packages/button/style/size-small.scss
@@ -1,0 +1,5 @@
+.nut-button-small {
+  height: $button-small-height;
+  padding: $button-small-padding;
+  font-size: $button-small-font-size;
+}

--- a/src/packages/button/style/size-xlarge.scss
+++ b/src/packages/button/style/size-xlarge.scss
@@ -1,0 +1,6 @@
+.nut-button-xlarge {
+  height: $button-xlarge-height;
+  padding: $button-xlarge-padding;
+  font-size: $button-xlarge-font-size;
+  font-weight: $button-large-font-weight;
+}

--- a/src/packages/button/style/size.scss
+++ b/src/packages/button/style/size.scss
@@ -1,0 +1,5 @@
+@import './size-mini.scss';
+@import './size-small.scss';
+@import './size-normal.scss';
+@import './size-large.scss';
+@import './size-xlarge.scss';

--- a/src/packages/button/style/type-danger.scss
+++ b/src/packages/button/style/type-danger.scss
@@ -1,0 +1,6 @@
+.nut-button-danger {
+  color: $button-danger-color;
+  border-color: transparent;
+  background-origin: border-box;
+  background: $button-danger-background-color;
+}

--- a/src/packages/button/style/type-default.scss
+++ b/src/packages/button/style/type-default.scss
@@ -1,0 +1,6 @@
+// 组件属性和对应变体的文件
+
+.nut-button-default {
+  border-style: solid;
+  border-color: $button-default-border-color;
+}

--- a/src/packages/button/style/type-info.scss
+++ b/src/packages/button/style/type-info.scss
@@ -1,0 +1,6 @@
+.nut-button-info {
+  color: $button-info-color;
+  background: $button-info-background-color;
+  background-origin: border-box;
+  border-color: transparent;
+}

--- a/src/packages/button/style/type-primary.scss
+++ b/src/packages/button/style/type-primary.scss
@@ -1,0 +1,6 @@
+.nut-button-primary {
+  color: $button-primary-color;
+  border-color: transparent;
+  background-origin: border-box;
+  background: $button-primary-background-color;
+}

--- a/src/packages/button/style/type-success.scss
+++ b/src/packages/button/style/type-success.scss
@@ -1,0 +1,6 @@
+.nut-button-success {
+  color: $button-success-color;
+  border-color: transparent;
+  background-origin: border-box;
+  background: $button-success-background-color;
+}

--- a/src/packages/button/style/type-warning.scss
+++ b/src/packages/button/style/type-warning.scss
@@ -1,0 +1,6 @@
+.nut-button-warning {
+  color: $button-warning-color;
+  border-color: transparent;
+  background-origin: border-box;
+  background: $button-warning-background-color;
+}

--- a/src/packages/button/style/type.scss
+++ b/src/packages/button/style/type.scss
@@ -1,0 +1,6 @@
+@import './type-default.scss';
+@import './type-primary.scss';
+@import './type-info.scss';
+@import './type-success.scss';
+@import './type-warning.scss';
+@import './type-danger.scss';


### PR DESCRIPTION
当前组件库中组件的设计是将所有功能的样式文件书写到一个文件中，在进行组件使用的时候，css 相关的 tree shake 并不能最优化的处理。

基于上面的问题，可以通过将css 进行拆分，按照变体的方式实现组件，然后在编译阶段根据 props 按需引入样式文件。从而解决用户反馈的”我只使用了 Button 组件的 type 属性，为什么要把所有 css 内容进行打包“的问题。

## css 文件的拆分方式

index.scss：组件的入口
layout.scss: 组件的基础布局
[属性名].scss: 组件属性的入口
[属性名-属性值].scss：组件具体的变体实现

## css 的层叠优先级

为了能正确的加载 css 文件，需要开发过程中显示的组织好 css 类的层叠级别。所以需要再组件中设置 css.json 文件，根据此文件来处理 css 层叠优先级。

具体格式：

```json
{
  "default": {
    "type": "default",
    "size": "normal",
    "shape": "round",
    "fill": "solid"
  },
  "properties": {
    "type": 1,
    "size": 1,
    "shape": 1,
    "loading": 1,
    "disabled": 1,
    "fill": 2
  }
}
```

说明：`default` 声明组件的默认变体。`properties` 声明属性变体的层叠优先级，数字越大层叠优先级越高。

