### PR TITLE
fix(tag): 解决taro-h5图文demo不展示图标问题+harmonycpp适配问题修改

### DIFF
--- a/src/packages/tag/demos/taro/demo4.tsx
+++ b/src/packages/tag/demos/taro/demo4.tsx
@@ -1,15 +1,9 @@
 import React from 'react'
 import { Cell, Tag } from '@nutui/nutui-react-taro'
 import { Image, Text, View } from '@tarojs/components'
-import Taro from '@tarojs/taro'
+import pxTransform from '@/utils/px-transform'
 
 const Demo4 = () => {
-  const convertSize = (size: number) => {
-    if (Taro.getEnv() === Taro.ENV_TYPE.RN) {
-      return size
-    }
-    return `${size}px`
-  }
   return (
     <>
       <Cell
@@ -26,14 +20,15 @@ const Demo4 = () => {
             >
               <Image
                 style={{
-                  height: convertSize(10),
-                  width: convertSize(10),
+                  height: pxTransform(11),
+                  width: pxTransform(10),
+                  lineHeight: 1,
                 }}
                 src="https://img13.360buyimg.com/imagetools/jfs/t1/249078/11/8928/559/6641c6f6F823e1c5e/a90a3b3cab20caaa.png"
               />
               <Text
                 style={{
-                  fontSize: convertSize(10),
+                  fontSize: pxTransform(10),
                   color: 'white',
                 }}
               >

--- a/src/packages/tag/tag.harmony.css
+++ b/src/packages/tag/tag.harmony.css
@@ -53,6 +53,8 @@
   align-items: center;
   justify-content: center;
   font-size: 10px;
+  color: #ffffff;
+  margin-left: 4px;
 }
 .nut-tag-plain {
   background-color: #fff;

--- a/src/packages/tag/tag.scss
+++ b/src/packages/tag/tag.scss
@@ -67,6 +67,8 @@
     align-items: center;
     justify-content: center;
     font-size: $tag-font-size;
+    color: $tag-color;
+    margin-left: 4px;
   }
 
   &-plain {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了 `.nut-tag` 组件的样式，增强了自定义图标的视觉效果。

- **样式**
	- `.nut-tag-custom-icon` 类现在包含 `color: #ffffff;` 和 `margin-left: 4px;` 属性，以改善自定义图标的外观。
	- SCSS 中的 `.nut-tag-custom-icon` 类也添加了 `color: $tag-color;` 和 `margin-left: 4px;` 属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->