### PR TITLE
fix(infinite): loadingText未居中

### DIFF
--- a/src/packages/infiniteloading/demo.taro.tsx
+++ b/src/packages/infiniteloading/demo.taro.tsx
@@ -40,7 +40,10 @@ const InfiniteLoadingDemo = () => {
   return (
     <>
       <Header />
-      <ScrollView className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
+      <ScrollView
+        className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}
+        showScrollbar={false}
+      >
         <View className="h2">{translated['84aa6bce']}</View>
         <Demo1 />
         <View className="h2">{translated.eb4236fe}</View>

--- a/src/packages/infiniteloading/infiniteloading.taro.tsx
+++ b/src/packages/infiniteloading/infiniteloading.taro.tsx
@@ -12,7 +12,6 @@ import { useConfig } from '@/packages/configprovider/configprovider.taro'
 
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import { InfiniteLoadingType } from './types'
-import pxTransform from '@/utils/px-transform'
 
 export interface InfiniteLoadingProps
   extends BasicComponent,
@@ -73,16 +72,15 @@ export const InfiniteLoading: FunctionComponent<
   const y = useRef(0)
   const refreshMaxH = useRef(0)
   const distance = useRef(0)
-  const classPrefix = 'nut-infinite'
+
   const classes = classNames(classPrefix, className, `${classPrefix}-${type}`)
 
   useEffect(() => {
     refreshMaxH.current = threshold
-    const timer = setTimeout(() => {
+    setTimeout(() => {
       getScrollHeight()
     }, 200)
-    return () => clearTimeout(timer)
-  }, [hasMore, isInfiniting, threshold])
+  }, [hasMore, isInfiniting])
 
   /** 获取需要滚动的距离 */
   const getScrollHeight = () => {
@@ -96,7 +94,7 @@ export const InfiniteLoading: FunctionComponent<
 
   const getStyle = () => {
     return {
-      height: topDisScoll < 0 ? pxTransform(0) : pxTransform(topDisScoll),
+      height: topDisScoll < 0 ? `0px` : `${topDisScoll}px`,
       transition: `height 0.2s cubic-bezier(0.25,0.1,0.25,1)`,
     }
   }
@@ -189,20 +187,14 @@ export const InfiniteLoading: FunctionComponent<
       onTouchMove={touchMove}
       onTouchEnd={touchEnd}
     >
-      <View
-        className={`${classPrefix}-top`}
-        ref={refreshTop}
-        style={getStyle()}
-      >
-        <View className={`${classPrefix}-top-tips`}>
+      <View className="nut-infinite-top" ref={refreshTop} style={getStyle()}>
+        <View className="nut-infinite-top-tips">
           {pullingText || locale.infiniteloading.pullRefreshText}
         </View>
       </View>
-      <View className={`${classPrefix}-container`}>{children}</View>
-      <View className={`${classPrefix}-bottom`}>
-        <View className={`${classPrefix}-bottom-tips`}>
-          {getBottomTipsText()}
-        </View>
+      <View className="nut-infinite-container">{children}</View>
+      <View className="nut-infinite-bottom">
+        <View className="nut-infinite-bottom-tips">{getBottomTipsText()}</View>
       </View>
     </ScrollView>
   )

--- a/src/packages/infiniteloading/infiniteloading.taro.tsx
+++ b/src/packages/infiniteloading/infiniteloading.taro.tsx
@@ -78,10 +78,11 @@ export const InfiniteLoading: FunctionComponent<
 
   useEffect(() => {
     refreshMaxH.current = threshold
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       getScrollHeight()
     }, 200)
-  }, [hasMore, isInfiniting])
+    return () => clearTimeout(timer)
+  }, [hasMore, isInfiniting, threshold])
 
   /** 获取需要滚动的距离 */
   const getScrollHeight = () => {

--- a/src/packages/infiniteloading/infiniteloading.taro.tsx
+++ b/src/packages/infiniteloading/infiniteloading.taro.tsx
@@ -12,6 +12,7 @@ import { useConfig } from '@/packages/configprovider/configprovider.taro'
 
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import { InfiniteLoadingType } from './types'
+import pxTransform from '@/utils/px-transform'
 
 export interface InfiniteLoadingProps
   extends BasicComponent,
@@ -94,7 +95,7 @@ export const InfiniteLoading: FunctionComponent<
 
   const getStyle = () => {
     return {
-      height: topDisScoll < 0 ? `0px` : `${topDisScoll}px`,
+      height: topDisScoll < 0 ? pxTransform(0) : pxTransform(topDisScoll),
       transition: `height 0.2s cubic-bezier(0.25,0.1,0.25,1)`,
     }
   }


### PR DESCRIPTION
重复定义了classPrefix导致的

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `ScrollView` 组件中添加了 `showScrollbar` 属性，默认设置为 `false`，影响滚动条的可见性。
  
- **样式更新**
	- 修改了 `InfiniteLoading` 组件的类名，采用更明确的命名方案，确保样式一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->