### PR TITLE
fix: vite5 relative warnings and deprecated usage

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# .env
+VITE_RTL=ltr

--- a/src/sites/doc/components/demoblock/codeblock.tsx
+++ b/src/sites/doc/components/demoblock/codeblock.tsx
@@ -5,7 +5,8 @@ import DemoBlock from './demoblock'
 import './demoblock.scss'
 
 const modules = import.meta.glob('@/packages/**/demos/*/*.tsx', {
-  as: 'raw',
+  query: '?raw',
+  import: 'default',
   eager: true,
 })
 // console.log('modules', modules)

--- a/src/sites/theme/router.ts
+++ b/src/sites/theme/router.ts
@@ -1,6 +1,7 @@
 const modulesPage = import.meta.glob('/src/packages/**/doc.md', {
-  as: 'raw',
-  eager: true
+  query: '?raw',
+  import: 'default',
+  eager: true,
 })
 const routes: any[] = []
 for (const path in modulesPage) {
@@ -13,8 +14,9 @@ for (const path in modulesPage) {
 }
 
 const modulesENPage = import.meta.glob('/src/packages/**/doc.en-US.md', {
-  as: 'raw',
-  eager: true
+  query: '?raw',
+  import: 'default',
+  eager: true,
 })
 // console.log('modulesENPage', modulesENPage)
 for (const path in modulesENPage) {
@@ -27,8 +29,9 @@ for (const path in modulesENPage) {
 }
 
 const modulesTaroPage = import.meta.glob('/src/packages/**/doc.taro.md', {
-  as: 'raw',
-  eager: true
+  query: '?raw',
+  import: 'default',
+  eager: true,
 })
 // console.log('modulesTaroPage', modulesTaroPage)
 for (const path in modulesTaroPage) {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增环境变量 `VITE_RTL`，设置为 `ltr`，用于配置应用的环境设置。
- **改进**
	- 更新了模块导入方式，优化了 `codeblock.tsx` 和 `router.ts` 文件中的模块处理，提升了组件加载和使用的灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->