### PR TITLE
chore: icons version

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.9",
     "@nutui/icons-react": "^1.0.5",
-    "@nutui/icons-react-taro": "2.0.0-beta.0",
+    "@nutui/icons-react-taro": "^2.0.0-beta.2",
     "@nutui/jdesign-icons-react-taro": "1.0.6-beta.2",
     "@nutui/touch-emulator": "^1.0.0",
     "@react-spring/web": "~9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       '@nutui/icons-react-taro':
-        specifier: 2.0.0-beta.0
-        version: 2.0.0-beta.0
+        specifier: ^2.0.0-beta.2
+        version: 2.0.0-beta.2
       '@nutui/jdesign-icons-react-taro':
         specifier: 1.0.6-beta.2
         version: 1.0.6-beta.2
@@ -1615,8 +1615,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==, tarball: https://r2.cnpmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz}
     engines: {node: '>= 8'}
 
-  '@nutui/icons-react-taro@2.0.0-beta.0':
-    resolution: {integrity: sha512-Wca6RWjy76fT9Co4T8PTjZCB/nzUxxyBR6efYl5tSKUJEvc6FPGHuA2FL6F0Gs9BBHo6ppTs02DRcSohX6UFWQ==}
+  '@nutui/icons-react-taro@2.0.0-beta.2':
+    resolution: {integrity: sha512-2wT+3TVJ8Gab9B27nfxpQZQUWOi8NQ2+rpH9q4XXlSg/9Sa1nLpwjtK3QB/7PsEpqXwpNMf4h4AdfWyyOZ09Rw==}
 
   '@nutui/icons-react@1.0.5':
     resolution: {integrity: sha512-0TYl3Fk+sVz95DKqn/7isYAvaK5YGnaBwMMib4rqYLoqi9GGFwgU9rp2hYXu/X5IYdWgshj0xiuGMK75/vUYbQ==}
@@ -9914,7 +9914,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nutui/icons-react-taro@2.0.0-beta.0': {}
+  '@nutui/icons-react-taro@2.0.0-beta.2': {}
 
   '@nutui/icons-react@1.0.5': {}
 

--- a/src/packages/input/input.harmony.css
+++ b/src/packages/input/input.harmony.css
@@ -44,3 +44,7 @@
   opacity: 1;
   -webkit-text-fill-color: #c2c4cc;
 }
+
+.nut-input-clear {
+  flex: 0;
+}


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增 CSS 类 `.nut-input-clear`，用于防止元素在弹性容器中增长。
- **依赖更新**
	- 更新了 `@nutui/icons-react-taro` 包的版本，从 `2.0.0-beta.0` 更新至 `^2.0.0-beta.2`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->