### PR TITLE
fix(Form): Form 组件文档 demo 中 Switch 组件使用问题

### DIFF
--- a/src/packages/form/demos/h5/demo7.tsx
+++ b/src/packages/form/demos/h5/demo7.tsx
@@ -58,7 +58,7 @@ const Demo7 = () => {
         <Form.Item label="Input" name="form_input">
           <Input placeholder="placeholder" />
         </Form.Item>
-        <Form.Item label="Switch" name="switch">
+        <Form.Item label="Switch" name="switch" valuePropName="checked">
           <Switch />
         </Form.Item>
         <Form.Item label="Checkbox" name="checkbox">

--- a/src/packages/form/demos/taro/demo7.tsx
+++ b/src/packages/form/demos/taro/demo7.tsx
@@ -58,7 +58,7 @@ const Demo7 = () => {
         <Form.Item label="Input" name="form_input">
           <Input placeholder="placeholder" />
         </Form.Item>
-        <Form.Item label="Switch" name="switch">
+        <Form.Item label="Switch" name="switch" valuePropName="checked">
           <Switch />
         </Form.Item>
         <Form.Item label="Checkbox" name="checkbox">

--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -28,7 +28,6 @@ const defaultProps = {
   defaultValue: '',
   showCount: false,
   maxLength: 140,
-  placeholder: '',
   readOnly: false,
   disabled: false,
   autoSize: false,

--- a/src/packages/textarea/textarea.tsx
+++ b/src/packages/textarea/textarea.tsx
@@ -26,7 +26,6 @@ const defaultProps = {
   showCount: false,
   rows: 2,
   maxLength: 140,
-  placeholder: '',
   readOnly: false,
   disabled: false,
   autoSize: false,


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

Form 文档中使用 Switch 组件时没有指定 valuePropName，这会导致通过 setFieldsValue 赋值不生效

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
	- 在 `Demo7` 组件的开关输入中，添加了 `valuePropName="checked"` 属性，以正确管理开关的状态。
	- 更新了 `TextArea` 组件的 `placeholder` 处理逻辑，改为基于语言环境动态赋值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->