### PR TITLE
fix(Table): 给个默认背景色，解决在小程序中固定列与滚动内列混合

### DIFF
--- a/src/packages/table/table.scss
+++ b/src/packages/table/table.scss
@@ -74,7 +74,6 @@
           &.nut-table-fixed-left,
           &.nut-table-fixed-right {
             z-index: 4;
-            // 给个默认背景色，解决在小程序中固定列与滚动内列混合
             background-color: #fff;
           }
 

--- a/src/packages/table/table.scss
+++ b/src/packages/table/table.scss
@@ -74,6 +74,8 @@
           &.nut-table-fixed-left,
           &.nut-table-fixed-right {
             z-index: 4;
+            // 给个默认背景色，解决在小程序中固定列与滚动内列混合
+            background-color: #fff;
           }
 
           &:last-child {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/2763
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
- 在飞书小程序中Table组件使用固定属性时，固定列会与滚动内列混合（样式穿透）
- 给个默认背景色，解决在小程序中固定列与滚动内列混合
- 
![image](https://github.com/user-attachments/assets/9363fe83-f5a3-4637-8d73-a6b84cd79273)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为特定表头单元格添加了白色背景色，以增强可视化效果。
- **样式**
	- 修改了`.nut-table-main-head`类中固定左侧和右侧表头单元格的背景颜色。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->