### PR TITLE
fix(popup): 增加禁止 page 滚动的例子

### DIFF
--- a/src/packages/popup/demos/taro/demo8.tsx
+++ b/src/packages/popup/demos/taro/demo8.tsx
@@ -20,6 +20,7 @@ const Demo8 = () => {
         onOpen={() => {
           // @ts-ignore
           Taro.getEnv().toLowerCase() === 'weapp' &&
+            // @ts-ignore
             wx.setPageStyle({
               complete: console.log,
               style: { overflow: 'hidden' },

--- a/src/packages/popup/demos/taro/demo8.tsx
+++ b/src/packages/popup/demos/taro/demo8.tsx
@@ -13,7 +13,19 @@ const Demo8 = () => {
           setScrollPenetration(true)
         }}
       />
-      <Popup visible={scrollPenetration} position="bottom" lockScroll>
+      <Popup
+        visible={scrollPenetration}
+        position="bottom"
+        lockScroll
+        onOpen={() => {
+          // @ts-ignore
+          Taro.getEnv().toLowerCase() === 'weapp' &&
+            wx.setPageStyle({
+              complete: console.log,
+              style: { overflow: 'hidden' },
+            })
+        }}
+      >
         <ScrollView scrollY style={{ height: '200px' }}>
           {Array.from({ length: 200 })
             .fill('')

--- a/src/packages/popup/doc.taro.md
+++ b/src/packages/popup/doc.taro.md
@@ -80,6 +80,8 @@ import { Popup } from '@nutui/nutui-react-taro'
 
 如果需要内容支持溢出滚动，则需要包裹一层 ScrollView 组件。
 
+如果 page 可以滚动，可以在 popup 的 onOpen 中通过环境判断来动态设置 page 标签的样式。
+
 :::demo
 
 <CodeBlock src='taro/demo8.tsx'></CodeBlock>


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在 `Popup` 组件中添加了 `onOpen` 事件处理程序，以改善在特定环境（如微信小程序）中的弹出行为，防止页面滚动。

- **文档**
	- 更新了 `Popup` 组件的文档，增加了关于弹出时处理滚动行为的说明，强调了 `lockScroll` 属性和 `catchMove` 方法的使用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->