### PR TITLE
fix(uploader): 修复选择多个文件上传只会上传一个文件的问题 Fixes #2549

### DIFF
--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -387,6 +387,7 @@ const InternalUploader: ForwardRefRenderFunction<
   }
 
   const readFile = <T extends TFileType>(files: T[]) => {
+    const results: FileItem[] = []
     files.forEach((file: T, index: number) => {
       let fileType = file.type
       const filepath = (file.tempFilePath || file.path) as string
@@ -428,8 +429,9 @@ const InternalUploader: ForwardRefRenderFunction<
         fileItem.url = fileType === 'video' ? file.thumbTempFilePath : filepath
       }
       executeUpload(fileItem, index)
-      setFileList([...fileList, fileItem])
+      results.push(fileItem)
     })
+    setFileList([...fileList, ...results])
   }
 
   const filterFiles = <T extends TFileType>(files: T[]) => {

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -288,6 +288,7 @@ const InternalUploader: ForwardRefRenderFunction<
   }
 
   const readFile = (files: File[]) => {
+    const results: FileItem[] = []
     files.forEach((file: File, index: number) => {
       const formData = new FormData()
       formData.append(name, file)
@@ -306,13 +307,15 @@ const InternalUploader: ForwardRefRenderFunction<
         const reader = new FileReader()
         reader.onload = (event: ProgressEvent<FileReader>) => {
           fileItem.url = (event.target as FileReader).result as string
-          setFileList([...fileList, fileItem])
+          // setFileList([...fileList, fileItem])
+          results.push(fileItem)
         }
         reader.readAsDataURL(file)
       } else {
-        setFileList([...fileList, fileItem])
+        results.push(fileItem)
       }
     })
+    setFileList([...fileList, ...results])
   }
 
   const filterFiles = (files: File[]) => {


### PR DESCRIPTION
修复[#2549](https://github.com/jdf2e/nutui-react/issues/2549)
- 修复了 readFile 方法中多文件处理的缺陷
- 调整文件读取逻辑，确保所有选中的文件都能正确处理

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 优化了文件上传组件的文件处理逻辑，提高了状态管理效率。
	- 增强了文件大小验证，确保超大文件被过滤，并触发相应回调。
	- 改进了文件删除流程，增加了删除前的回调控制。

- **修复**
	- 精简了文件项的状态更新逻辑，确保上传进度和结果的状态及时更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->