### PR TITLE
fix: Uploade 组件无法预览图片

### DIFF
--- a/src/packages/uploader/uploader.scss
+++ b/src/packages/uploader/uploader.scss
@@ -178,7 +178,8 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        height: 100%;
+        width: var(--nutui-uploader-image-width, 100px);
+        height: var(--nutui-uploader-image-height, 100px);
         position: initial;
         border-radius: $uploader-image-border-radius;
       }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/2821

### 💡 需求背景和解决方案

Uploade 组件无法预览图片

重新修改对应元素的宽高

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了上传组件的样式，使其图像尺寸更具灵活性，支持动态调整。

- **样式**
	- 修改了`.nut-uploader-img-c`类的高度属性为宽度属性，使用CSS变量实现响应式设计。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->