### PR TITLE
fix(elevator): 采用唯一ID，避免未传入 className 导致的报错

### DIFF
--- a/src/packages/elevator/elevator.taro.tsx
+++ b/src/packages/elevator/elevator.taro.tsx
@@ -1,15 +1,16 @@
 import React, {
-  FunctionComponent,
-  useRef,
-  useEffect,
-  useState,
   createContext,
+  FunctionComponent,
+  useEffect,
+  useRef,
+  useState,
 } from 'react'
-import Taro, { nextTick, createSelectorQuery } from '@tarojs/taro'
+import Taro, { createSelectorQuery, nextTick } from '@tarojs/taro'
 
 import { ScrollView } from '@tarojs/components'
 import classNames from 'classnames'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
+import useUuid from '@/utils/use-uuid'
 
 export const elevatorContext = createContext({} as ElevatorData)
 
@@ -65,6 +66,7 @@ export const Elevator: FunctionComponent<
     ...defaultProps,
     ...props,
   }
+  const uuid = useUuid()
   const classPrefix = 'nut-elevator'
   const listview = useRef<HTMLDivElement>(null)
   const initData = {
@@ -106,7 +108,7 @@ export const Elevator: FunctionComponent<
     for (let i = 0; i < state.current.listGroup.length; i++) {
       const query = createSelectorQuery()
       query
-        .selectAll(`.${className} .nut-elevator-item-${i}`)
+        .selectAll(`.${classPrefix}-${uuid} .nut-elevator-item-${i}`)
         .boundingClientRect()
       // eslint-disable-next-line no-loop-func
       query.exec((res: any) => {
@@ -180,7 +182,7 @@ export const Elevator: FunctionComponent<
   const setListGroup = () => {
     if (listview.current) {
       createSelectorQuery()
-        .selectAll(`.${className} .nut-elevator-list-item`)
+        .selectAll(`.${classPrefix}-${uuid} .nut-elevator-list-item`)
         .node((el) => {
           state.current.listGroup = [...Object.keys(el)]
           calculateHeight()
@@ -220,7 +222,11 @@ export const Elevator: FunctionComponent<
   }, [listview])
 
   return (
-    <div className={`${classPrefix} ${className}`} style={style} {...rest}>
+    <div
+      className={`${classPrefix} ${className} ${classPrefix}-${uuid}`}
+      style={style}
+      {...rest}
+    >
       <div
         className={`${classPrefix}-list`}
         style={{ height: Number.isNaN(+height) ? height : `${height}px` }}


### PR DESCRIPTION


### 🤔 这个变动的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

计算逻辑依赖用户传入的 classname，如果未传入 className，会出现错误。

### 💡 需求背景和解决方案

通过内置唯一 ID 来实现计算

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了电梯组件的功能，确保每个实例具有唯一的标识符。
  - 添加了新的钩子 `useUuid`，用于生成唯一的元素标识符。

- **改进**
  - 更新了组件的返回语句，以包含唯一的类名，避免类名冲突。
  - 调整了触摸事件和滚动行为的处理逻辑，确保一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->