### PR TITLE
feat(popover): 增加最大宽度设置，支持文本超过最大宽度时，换行展示。

### DIFF
--- a/src/packages/popover/doc.en-US.md
+++ b/src/packages/popover/doc.en-US.md
@@ -165,3 +165,4 @@ The component provides the following CSS variables, which can be used to customi
 | \--nutui-popover-divider-color | The bottom border color of the options area | `$color-border` |
 | \--nutui-popover-disable-color | Option Disabled Colors | `$color-text-disabled` |
 | \--nutui-popover-menu-item-padding | The padding value of each item in the option area menu | `8px` |
+| \--nutui-popover-menu-item-width | The width value of each item in the options | `160px` |

--- a/src/packages/popover/doc.md
+++ b/src/packages/popover/doc.md
@@ -167,3 +167,4 @@ PopoverList 属性是一个由对象构成的数组，数组中的每个对象�
 | \--nutui-popover-divider-color | 选项区的底部 border 颜色 | `$color-border` |
 | \--nutui-popover-disable-color | 选项禁用的颜色 | `$color-text-disabled` |
 | \--nutui-popover-menu-item-padding | 选项区菜单每一项的 padding 值 | `8px` |
+| \--nutui-popover-menu-item-width | 选项区菜单每一项宽度值，超过宽度值后，会折行展示，保障信息的完整性 | `160px` |

--- a/src/packages/popover/doc.taro.md
+++ b/src/packages/popover/doc.taro.md
@@ -158,3 +158,4 @@ PopoverList 属性是一个由对象构成的数组，数组中的每个对象�
 | \--nutui-popover-divider-color | 选项区的底部 border 颜色 | `$color-border` |
 | \--nutui-popover-disable-color | 选项禁用的颜色 | `$color-text-disabled` |
 | \--nutui-popover-menu-item-padding | 选项区菜单每一项的 padding 值 | `8px` |
+| \--nutui-popover-menu-item-width | 选项区菜单每一项宽度值，超过宽度值后，会折行展示，保障信息的完整性 | `160px` |

--- a/src/packages/popover/doc.zh-TW.md
+++ b/src/packages/popover/doc.zh-TW.md
@@ -167,3 +167,4 @@ PopoverList 屬性是一個由對象構成的數組，數組中的每個對象�
 | \--nutui-popover-divider-color | 選項區的底部 border 顏色 | `$color-border` |
 | \--nutui-popover-disable-color | 選項禁用的顏色 | `$color-text-disabled` |
 | \--nutui-popover-menu-item-padding | 選項區菜單每一項的 padding 值 | `8px` |
+| \--nutui-popover-menu-item-width | 選項區菜單每一項宽度值，超过宽度值后，会折行展示，保障信息的完整性 | `160px` |

--- a/src/packages/popover/doc.zh-TW.md
+++ b/src/packages/popover/doc.zh-TW.md
@@ -167,4 +167,4 @@ PopoverList 屬性是一個由對象構成的數組，數組中的每個對象�
 | \--nutui-popover-divider-color | 選項區的底部 border 顏色 | `$color-border` |
 | \--nutui-popover-disable-color | 選項禁用的顏色 | `$color-text-disabled` |
 | \--nutui-popover-menu-item-padding | 選項區菜單每一項的 padding 值 | `8px` |
-| \--nutui-popover-menu-item-width | 選項區菜單每一項宽度值，超过宽度值后，会折行展示，保障信息的完整性 | `160px` |
+| \--nutui-popover-menu-item-width | 選項區菜單每一項寬度值，超過寬度值後，會折行展示，保障信息的完整性 | `160px` |

--- a/src/packages/popover/popover.scss
+++ b/src/packages/popover/popover.scss
@@ -227,7 +227,18 @@
   color: $popover-content-background-color;
 
   .nut-popover-arrow {
-    border-bottom-color: $popover-text-color;
+    &-top {
+      border-top-color: $popover-text-color;
+    }
+    &-bottom {
+      border-bottom-color: $popover-text-color;
+    }
+    &-left {
+      border-left-color: $popover-text-color;
+    }
+    &-right {
+      border-right-color: $popover-text-color;
+    }
   }
 
   .nut-popover-content {

--- a/src/packages/popover/popover.scss
+++ b/src/packages/popover/popover.scss
@@ -103,12 +103,6 @@
         border-bottom: none;
       }
 
-      // &:hover:not(:only-child) {
-      //   cursor: pointer;
-      //   color: $popover-hover-text-color;
-      //   background-color: $popover-hover-background-color;
-      // }
-
       &:hover:nth-of-type(2) {
         border-radius: 8px 8px 0px 0px;
       }
@@ -132,9 +126,10 @@
       }
 
       &-name {
-        width: 100%;
+        width: calc(100% - 34px);
         word-break: keep-all;
         margin: 0 6px 0 4px;
+        flex: 1;
       }
 
       &-action-icon {
@@ -174,7 +169,6 @@
 
     &-top-start {
       left: 0;
-
       .nut-popover-arrow-top-start {
         left: 16px;
         transform: translateX(0%);
@@ -190,7 +184,6 @@
 
     &-bottom-end {
       right: 0;
-
       .nut-popover-arrow-bottom-end {
         right: 16px;
         transform: translateX(0%);
@@ -199,7 +192,6 @@
 
     &-bottom-start {
       left: 0;
-
       .nut-popover-arrow-bottom-start {
         left: 16px;
         transform: translateX(0%);

--- a/src/packages/popover/popover.scss
+++ b/src/packages/popover/popover.scss
@@ -95,6 +95,8 @@
       justify-content: center;
       padding: $popover-menu-item-padding;
       border-bottom: 1px solid $popover-divider-color;
+      max-width: $popover-menu-item-width;
+      word-wrap: break-word;
 
       &:last-child {
         margin-bottom: 0px;
@@ -227,18 +229,7 @@
   color: $popover-content-background-color;
 
   .nut-popover-arrow {
-    &-top {
-      border-top-color: $popover-text-color;
-    }
-    &-bottom {
-      border-bottom-color: $popover-text-color;
-    }
-    &-left {
-      border-left-color: $popover-text-color;
-    }
-    &-right {
-      border-right-color: $popover-text-color;
-    }
+    border-bottom-color: $popover-text-color;
   }
 
   .nut-popover-content {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1553,6 +1553,7 @@ $popover-menu-item-padding: var(
   --nutui-popover-menu-item-padding,
   8px
 ) !default;
+$popover-menu-item-width: var(--nutui-popover-menu-item-width, 160px) !default;
 
 //progress（✅）
 $progress-height: var(--nutui-progress-height, 10px) !default;


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

```
$popover-menu-item-width: var(--nutui-popover-menu-item-width, 160px) !default;

```

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
  - 新增 CSS 变量 `--nutui-popover-menu-item-width`，用于自定义 Popover 组件菜单项的宽度。

- **文档更新**
  - 更新了 Popover 组件的文档，包含了新 CSS 变量的说明，增强了自定义样式选项的全面性。

- **样式改进**
  - 在 `.nut-popover-menu-item` 类中添加了 `max-width` 和 `word-wrap` 属性，以改善菜单项的布局和可读性。
  - 更新了 `.nut-popover-menu-item-name` 类的宽度和弹性属性。

- **变量更新**
  - 新增变量 `$popover-menu-item-width`，用于设置 Popover 菜单项的默认宽度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->