### PR TITLE
chore: update to support taro e2e test

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,8 +29,7 @@ jobs:
           CI: true
         run: pnpm cypress install --force && pnpm e2e:run:h5
 
-      # Taro的自动化测试，demo包管理解决后解除注释
-      # - name: Run E2E Tests for Taro
-      #   env:
-      #     CI: true
-      #   pnpm cypress install --force && run: pnpm e2e:run:taro
+      - name: Run E2E Tests for Taro
+        env:
+          CI: true
+        run: pnpm cypress install --force && pnpm e2e:run:taro

--- a/cypress/e2e/taro/index.cy.js
+++ b/cypress/e2e/taro/index.cy.js
@@ -1,4 +1,3 @@
-import { describe } from 'yargs'
 import { checkTaroBlank } from '../common/pageWhiteTest.cy'
 
 describe('All Taro Demos White Page Test', () => {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dev:taro:jdrn": "pnpm run clone:rn && pnpm --dir ./packages/nutui-taro-demo dev:jdrn",
     "dev:taro:rn:dark": "THEME=dark pnpm dev:taro:rn",
     "dev:taro": "pnpm run update:taro:entry && pnpm --dir ./packages/nutui-taro-demo dev",
+    "dev:taro:h5": "pnpm dev:taro h5",
     "dev:jdtaro": "pnpm run update:taro:entry && JD=1 pnpm --dir ./packages/nutui-taro-demo dev",
     "dev:jdtaro:jdharmonycpp": "pnpm run clone:jdharmony cpp &&pnpm run update:taro:entry && JD=1 pnpm --dir ./packages/nutui-taro-demo dev:jdharmonycpp",
     "dev:jdtaro:jdharmony": "pnpm run clone:jdharmony  && pnpm run update:taro:entry && JD=1 pnpm --dir ./packages/nutui-taro-demo dev:jdharmony",
@@ -91,8 +92,8 @@
     "e2e:run:h5": "start-server-and-test dev http://localhost:5173/ cypress:run",
     "e2e:run:h5": "start-server-and-test dev http://localhost:5173/ cypress:run",
     "e2e:open:h5": "start-server-and-test dev http://localhost:5173/ cypress:open",
-    "e2e:run:taro": "start-server-and-test dev:taro h5 http://localhost:10086 cypress:run:taro",
-    "e2e:open:taro": "start-server-and-test dev:taro h5 http://localhost:10086 cypress:open:taro",
+    "e2e:run:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:run:taro",
+    "e2e:open:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:open:taro",
     "update:taro:entry": "node ./scripts/rn/update-taro-entry",
     "upgradeTaro": "pnpm --dir ./packages/nutui-taro-demo upgradeTaro"
   },

--- a/package.json
+++ b/package.json
@@ -89,9 +89,10 @@
     "cypress:run:taro": "cypress run --env baseUrl=http://localhost:10086/#/ --spec 'cypress/e2e/taro/index.cy.js'",
     "cypress:open:taro": "cypress open --env baseUrl=http://localhost:10086/#/ 'cypress/e2e/taro/index.cy.js'",
     "e2e:run:h5": "start-server-and-test dev http://localhost:5173/ cypress:run",
+    "e2e:run:h5": "start-server-and-test dev http://localhost:5173/ cypress:run",
     "e2e:open:h5": "start-server-and-test dev http://localhost:5173/ cypress:open",
-    "e2e:run:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:run:taro",
-    "e2e:open:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:open:taro",
+    "e2e:run:taro": "start-server-and-test dev:taro h5 http://localhost:10086 cypress:run:taro",
+    "e2e:open:taro": "start-server-and-test dev:taro h5 http://localhost:10086 cypress:open:taro",
     "update:taro:entry": "node ./scripts/rn/update-taro-entry",
     "upgradeTaro": "pnpm --dir ./packages/nutui-taro-demo upgradeTaro"
   },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "e2e:run:h5": "start-server-and-test dev http://localhost:5173/ cypress:run",
     "e2e:open:h5": "start-server-and-test dev http://localhost:5173/ cypress:open",
     "e2e:run:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:run:taro",
-    "e2e:open:taro": "start-server-and-test dev:taroh5 http://localhost:10086 cypress:open:taro",
+    "e2e:open:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:open:taro",
     "update:taro:entry": "node ./scripts/rn/update-taro-entry",
     "upgradeTaro": "pnpm --dir ./packages/nutui-taro-demo upgradeTaro"
   },

--- a/package.json
+++ b/package.json
@@ -90,10 +90,9 @@
     "cypress:run:taro": "cypress run --env baseUrl=http://localhost:10086/#/ --spec 'cypress/e2e/taro/index.cy.js'",
     "cypress:open:taro": "cypress open --env baseUrl=http://localhost:10086/#/ 'cypress/e2e/taro/index.cy.js'",
     "e2e:run:h5": "start-server-and-test dev http://localhost:5173/ cypress:run",
-    "e2e:run:h5": "start-server-and-test dev http://localhost:5173/ cypress:run",
     "e2e:open:h5": "start-server-and-test dev http://localhost:5173/ cypress:open",
     "e2e:run:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:run:taro",
-    "e2e:open:taro": "start-server-and-test dev:taro:h5 http://localhost:10086 cypress:open:taro",
+    "e2e:open:taro": "start-server-and-test dev:taroh5 http://localhost:10086 cypress:open:taro",
     "update:taro:entry": "node ./scripts/rn/update-taro-entry",
     "upgradeTaro": "pnpm --dir ./packages/nutui-taro-demo upgradeTaro"
   },

--- a/scripts/rn/update-taro-entry.js
+++ b/scripts/rn/update-taro-entry.js
@@ -8,6 +8,7 @@ const param = process.env.C
 
 // C=radio pnpm dev:taro:jdharmonycpp or C=radio,button,cell pnpm dev:taro:jdharmonycpp
 function specialComponent(name) {
+  if(!param) return true
   const entries = param.split(',').map((i) => i.toLowerCase())
   return entries.includes(name.toLowerCase())
 }


### PR DESCRIPTION
 update ci.yml to support taro e2e test 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 添加了针对 Taro 的 E2E 测试工作流步骤。
	- 新增开发脚本 `"dev:taro:h5"` 以支持 Taro 框架的 H5 开发。
- **修复**
	- 更新了 E2E 测试脚本的引用，确保正确性。
	- 修改了组件过滤逻辑，增强了基于 `param` 变量的组件包含灵活性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->