### PR TITLE
fix(countup): 分隔符文字颜色支持css变量修改

### DIFF
--- a/src/packages/animatingnumbers/countup.scss
+++ b/src/packages/animatingnumbers/countup.scss
@@ -25,7 +25,7 @@
     display: flex;
     height: 80%;
     align-items: flex-end;
-    color: $countup-bg-color;
+    color: $countup-separator-color;
   }
 
   &-number {

--- a/src/packages/animatingnumbers/demos/h5/demo2.tsx
+++ b/src/packages/animatingnumbers/demos/h5/demo2.tsx
@@ -7,6 +7,7 @@ const Demo2 = () => {
     nutuiCountupBgColor: `var(--nutui-color-primary)`,
     nutuiCountupColor: `#fff`,
     nutuiCountupLrMargin: `1px`,
+    nutuiCountupSeparatorColor: `var(--nutui-color-primary)`,
   }
   const [value, setEndNumer] = useState('1570.99')
   useEffect(() => {

--- a/src/packages/animatingnumbers/demos/taro/demo2.tsx
+++ b/src/packages/animatingnumbers/demos/taro/demo2.tsx
@@ -7,6 +7,7 @@ const Demo2 = () => {
     nutuiCountupBgColor: `var(--nutui-color-primary)`,
     nutuiCountupColor: `#fff`,
     nutuiCountupLrMargin: `1px`,
+    nutuiCountupSeparatorColor: `var(--nutui-color-primary)`,
   }
   const [value, setEndNumer] = useState('1570.99')
   useEffect(() => {

--- a/src/packages/animatingnumbers/doc.en-US.md
+++ b/src/packages/animatingnumbers/doc.en-US.md
@@ -53,3 +53,4 @@ The component provides the following CSS variables, which can be used to customi
 | \--nutui-countup-lr-margin | margin of item | `0` |
 | \--nutui-countup-bg-color | background color of item | `inherit` |
 | \--nutui-countup-color | color of item | `$color-title` |
+| \--nutui-countup-separator-color | The font color of the separator | `$color-title` |

--- a/src/packages/animatingnumbers/doc.md
+++ b/src/packages/animatingnumbers/doc.md
@@ -53,3 +53,4 @@ import { AnimatingNumbers } from '@nutui/nutui-react'
 | \--nutui-countup-lr-margin | 每个数字的margin | `0` |
 | \--nutui-countup-bg-color | 每个数字块的背景色 | `inherit` |
 | \--nutui-countup-color | 每个数字块的字色 | `$color-title` |
+| \--nutui-countup-separator-color | 分隔符的字体颜色 | `$color-title` |

--- a/src/packages/animatingnumbers/doc.taro.md
+++ b/src/packages/animatingnumbers/doc.taro.md
@@ -53,3 +53,4 @@ import { AnimatingNumbers } from '@nutui/nutui-react-taro'
 | \--nutui-countup-lr-margin | 每个数字的margin | `0` |
 | \--nutui-countup-bg-color | 每个数字块的背景色 | `inherit` |
 | \--nutui-countup-color | 每个数字块的字色 | `$color-title` |
+| \--nutui-countup-separator-color | 分隔符的字体颜色 | `$color-title` |

--- a/src/packages/animatingnumbers/doc.zh-TW.md
+++ b/src/packages/animatingnumbers/doc.zh-TW.md
@@ -53,3 +53,4 @@ import { AnimatingNumbers } from '@nutui/nutui-react'
 | \--nutui-countup-lr-margin | 每個數字的margin | `0` |
 | \--nutui-countup-bg-color | 每個數字塊的背景色 | `inherit` |
 | \--nutui-countup-color | 每個數字塊的字色 | `$color-title` |
+| \--nutui-countup-separator-color | 分隔符的字體顏色 | `$color-title` |

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -2291,6 +2291,10 @@ $countup-border-radius: var(--nutui-countup-border-radius, 4px) !default;
 $countup-lr-margin: var(--nutui-countup-lr-margin, 0) !default;
 $countup-bg-color: var(--nutui-countup-bg-color, inherit) !default;
 $countup-color: var(--nutui-countup-color, $color-title) !default;
+$countup-separator-color: var(
+  --nutui-countup-separator-color,
+  $color-title
+) !default;
 
 // layout（✅）
 $row-content-color: var(--nutui-row-content-color, #fff) !default;


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 添加了新的 CSS 变量 `--nutui-countup-separator-color`，用于自定义计数动画中的分隔符颜色。
  - 在 `customTheme` 对象中新增属性 `nutuiCountupSeparatorColor`，允许用户更改分隔符的颜色。

- **文档**
  - 更新了 `AnimatingNumbers` 组件的文档，包含新的 CSS 变量以增强自定义选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->