### PR TITLE
fix(pulltorefresh): 真机体验优化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@dongdesign/components",
-  "version": "3.0.0-beta.0",
+  "name": "@nutui/nutui-react-taro",
+  "version": "3.0.0-beta.10",
   "style": "dist/style.css",
   "main": "dist/nutui.react.umd.js",
   "module": "dist/es/packages/nutui.react.build.js",
@@ -40,7 +40,10 @@
     "LICENSE",
     "CHANGELOG.md"
   ],
-
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "add": "node scripts/create-component-mode.js && npm run prepare",
     "add:taro:config": "node scripts/taro/generate-taro-route.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nutui/nutui-react-taro",
-  "version": "3.0.0-beta.10",
+  "name": "@dongdesign/components",
+  "version": "3.0.0-beta.0",
   "style": "dist/style.css",
   "main": "dist/nutui.react.umd.js",
   "module": "dist/es/packages/nutui.react.build.js",
@@ -40,10 +40,7 @@
     "LICENSE",
     "CHANGELOG.md"
   ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
+
   "scripts": {
     "add": "node scripts/create-component-mode.js && npm run prepare",
     "add:taro:config": "node scripts/taro/generate-taro-route.js",

--- a/src/packages/loading/demos/taro/demo1.tsx
+++ b/src/packages/loading/demos/taro/demo1.tsx
@@ -25,7 +25,7 @@ const Demo1 = () => {
           type="lottie"
           jsonData={data}
           lottieProps={{
-            autoplay: false,
+            autoPlay: false,
             loop: false,
             style: { width: 56, height: 56 },
           }}

--- a/src/packages/lottie/mp.taro.tsx
+++ b/src/packages/lottie/mp.taro.tsx
@@ -1,11 +1,11 @@
 import React, { useImperativeHandle, useRef } from 'react'
 import {
   createSelectorQuery,
+  getEnv,
   getSystemInfoSync,
   useReady,
   useUnload,
 } from '@tarojs/taro'
-import { Canvas } from '@tarojs/components'
 import lottie from 'lottie-miniprogram'
 import useUuid from '@/utils/use-uuid'
 import { LottieProps } from './types'
@@ -82,7 +82,28 @@ export const Lottie = React.forwardRef((props: LottieProps, ref: any) => {
       animation.current.removeEventListener('complete', onComplete)
     animation.current && animation.current.destroy()
   })
-  return <Canvas id={id} canvas-id={id} type="2d" style={style} />
+
+  return getEnv() === 'WEAPP' || getEnv() === 'JD' ? (
+    <canvas
+      id={id}
+      // @ts-ignore
+      // eslint-disable-next-line react/no-unknown-property
+      canvasId={id}
+      // eslint-disable-next-line react/no-unknown-property
+      disalbeScroll
+      type="2d"
+      style={style}
+    />
+  ) : (
+    <canvas
+      id={id}
+      // eslint-disable-next-line react/no-unknown-property
+      canvas-id={id}
+      // eslint-disable-next-line react/no-unknown-property
+      disalbe-scroll
+      style={style}
+    />
+  )
 })
 
 Lottie.displayName = 'NutLottie'

--- a/src/packages/pulltorefresh/pulltorefresh.taro.tsx
+++ b/src/packages/pulltorefresh/pulltorefresh.taro.tsx
@@ -176,6 +176,7 @@ export const PullToRefresh: FunctionComponent<Partial<PullToRefreshProps>> = (
     <View
       className={classes}
       style={props.style}
+      catchMove
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}


### PR DESCRIPTION
不加 catchmove 的时候，拖动会出现页面一起被拉下来的情况

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **包名和版本更新**
	- 包名从 `@nutui/nutui-react-taro` 更改为 `@dongdesign/components`
	- 版本从 `3.0.0-beta.10` 降级到 `3.0.0-beta.0`
	- 移除了发布配置

- **组件优化**
	- Loading 组件的 Lottie 属性从 `autoplay` 更新为 `autoPlay`
	- Lottie 组件增加环境适配性，优化不同平台的 canvas 渲染
	- PullToRefresh 组件新增 `catchMove` 属性，改善触摸事件处理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->