### PR TITLE
fix(textarea): 字数限制文本遮挡输入框的内容

### DIFF
--- a/src/packages/textarea/doc.en-US.md
+++ b/src/packages/textarea/doc.en-US.md
@@ -107,3 +107,4 @@ The component provides the following CSS variables, which can be used to customi
 | \--nutui-textarea-text-color | text color | `$color-title` |
 | \--nutui-textarea-text-curror-color | caret color | `$color-title` |
 | \--nutui-textarea-disabled-color | disabled color | `$color-text-disabled` |
+| \--nutui-textarea-limit-align | text align | `right` |

--- a/src/packages/textarea/doc.md
+++ b/src/packages/textarea/doc.md
@@ -107,3 +107,4 @@ import { TextArea } from '@nutui/nutui-react'
 | \--nutui-textarea-text-color | 文本颜色 | `$color-title` |
 | \--nutui-textarea-text-curror-color | 光标颜色 | `$color-title` |
 | \--nutui-textarea-disabled-color | 禁用颜色 | `$color-text-disabled` |
+| \--nutui-textarea-limit-align | 对齐方式 | `right` |

--- a/src/packages/textarea/doc.taro.md
+++ b/src/packages/textarea/doc.taro.md
@@ -107,3 +107,4 @@ import { TextArea } from '@nutui/nutui-react-taro'
 | \--nutui-textarea-text-color | 文本颜色 | `$color-title` |
 | \--nutui-textarea-text-curror-color | 光标颜色 | `$color-title` |
 | \--nutui-textarea-disabled-color | 禁用颜色 | `$color-text-disabled` |
+| \--nutui-textarea-limit-align | 对齐方式 | `right` |

--- a/src/packages/textarea/doc.zh-TW.md
+++ b/src/packages/textarea/doc.zh-TW.md
@@ -106,3 +106,4 @@ import { TextArea } from '@nutui/nutui-react'
 | \--nutui-textarea-text-color | 文本顏色 | `$color-title` |
 | \--nutui-textarea-text-curror-color | 光標顏色 | `$color-title` |
 | \--nutui-textarea-disabled-color | 禁用顏色 | `$color-text-disabled` |
+| \--nutui-textarea-limit-align | 對齊方式 | `right` |

--- a/src/packages/textarea/textarea.scss
+++ b/src/packages/textarea/textarea.scss
@@ -1,8 +1,9 @@
 .nut-textarea {
+  display: flex;
+  flex-direction: column;
   position: relative;
   width: 100%;
   box-sizing: border-box;
-  display: flex;
   background: $color-background-overlay;
   font-size: $textarea-font;
   padding: $textarea-padding;
@@ -16,11 +17,9 @@
   }
 
   &-limit {
-    position: absolute;
-    right: 15px;
-    bottom: 12px;
     font-size: $textarea-font;
     color: $textarea-limit-color;
+    text-align: $textarea-limit-align;
   }
 
   &-textarea {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -587,6 +587,7 @@ $input-padding: var(--nutui-input-padding, 10px 25px) !default;
 $textarea-font: var(--nutui-textarea-font, $font-size-base) !default;
 $textarea-padding: var(--nutui-textarea-padding, 10px 25px) !default;
 $textarea-limit-color: var(--nutui-textarea-limit-color, $color-text) !default;
+$textarea-limit-align: var(--nutui-textarea-limit-align, right) !default;
 $textarea-text-color: var(--nutui-textarea-text-color, $color-title) !default;
 $textarea-text-curror-color: var(
   --nutui-textarea-text-curror-color,


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为 `TextArea` 组件添加了新的 CSS 变量 `--nutui-textarea-limit-align`，允许自定义字符限制显示的对齐方式。
	- 默认情况下，字符限制文本将右对齐。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->