### PR TITLE
fix(form): item label 未对齐

### DIFF
--- a/src/packages/formitem/formitem.scss
+++ b/src/packages/formitem/formitem.scss
@@ -27,7 +27,6 @@
   }
   .nut-form-item-labeltxt {
     font-size: $form-item-label-font-size;
-    height: 10px;
     position: relative;
   }
   &-body {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

https://github.com/jdf2e/nutui-react/issues/2928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **样式调整**
	- 移除了 `.nut-form-item-labeltxt` 类的固定高度设置，允许更灵活的布局显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->