### PR TITLE
fix: imageSize=0无效

### DIFF
--- a/src/packages/empty/empty.taro.tsx
+++ b/src/packages/empty/empty.taro.tsx
@@ -69,7 +69,7 @@ export const Empty: FunctionComponent<
 
   useEffect(() => {
     setImgStyle(() => {
-      if (!imageSize) {
+      if (typeof imageSize !== 'number' && typeof imageSize !== 'string') {
         return {}
       }
       if (typeof imageSize === 'number') {

--- a/src/packages/empty/empty.tsx
+++ b/src/packages/empty/empty.tsx
@@ -71,7 +71,7 @@ export const Empty: FunctionComponent<
 
   useEffect(() => {
     setImgStyle(() => {
-      if (!imageSize) {
+      if (typeof imageSize !== 'number' && typeof imageSize !== 'string') {
         return {}
       }
       if (typeof imageSize === 'number') {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景： Empty设置imageSize=0无效

解决： 
```
if (typeof imageSize !== 'number' && typeof imageSize !== 'string') {
        return {}
      }
```
判断条件改为`typeof imageSize !== 'number' && typeof imageSize !== 'string'`
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
	- 优化了图像尺寸验证逻辑，确保仅在 `imageSize` 为数字或字符串时正确设置图像样式。
	- 改进了空状态组件中图像尺寸处理的健壮性，防止无效输入导致样式错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->