### PR TITLE
fix(form): 修复 formitem 的值如果是对象会自动重置为空对象的问题

### DIFF
--- a/src/packages/form/__tests__/form.spec.tsx
+++ b/src/packages/form/__tests__/form.spec.tsx
@@ -4,7 +4,6 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Form, { FormInstance } from '@/packages/form'
 import Input from '@/packages/input'
-import { merge } from '@/utils/merge'
 
 beforeAll(() => {
   // @ts-ignore
@@ -311,60 +310,5 @@ test('no-style and render function', async () => {
   waitFor(() => {
     const relatedInput = container.querySelector('.related-input')
     expect(relatedInput).toBeTruthy()
-  })
-})
-
-describe('merge', async () => {
-  it('merges two objects', () => {
-    expect(merge({ a: 1 }, { b: 2 })).toStrictEqual({ a: 1, b: 2 })
-  })
-
-  it('merges nested levels', () => {
-    expect(merge({ a: 1 }, { b: { c: { d: 2 } } })).toStrictEqual({
-      a: 1,
-      b: { c: { d: 2 } },
-    })
-  })
-  it('clones the target', () => {
-    let input = {
-      a: 1,
-      b: {
-        c: {
-          d: 2,
-          e: ['x', 'y', { z: { w: ['k'] } }],
-        },
-      },
-      f: null,
-      g: undefined,
-      h: true,
-    }
-
-    const original = {
-      a: 1,
-      b: {
-        c: {
-          d: 2,
-          e: ['x', 'y', { z: { w: ['k'] } }],
-        },
-      },
-      f: null,
-      g: undefined,
-      h: true,
-    }
-
-    let output = merge(true, input)
-
-    input.b.c.d++
-    ;(input.b.c.e[2] as any).z.w = null
-    ;(input as any).h = null
-
-    expect(output).toStrictEqual(original)
-
-    input = original
-
-    output = merge(true, input, { a: 2 })
-
-    expect(output.a).toBe(2)
-    expect(input.a).toBe(1)
   })
 })

--- a/src/packages/form/__tests__/form.spec.tsx
+++ b/src/packages/form/__tests__/form.spec.tsx
@@ -226,10 +226,10 @@ test('form onFinishFailed', async () => {
   fireEvent.submit(form)
   await waitFor(() => {
     expect(handleFailed).toBeCalled()
-    expect(handleFailed).toBeCalledWith({ username: 'NutUI-React' }, [
+    expect(handleFailed).toBeCalledWith({ username: 'NutUI React Taro' }, [
       {
         field: 'username',
-        fieldValue: 'NutUI-React',
+        fieldValue: 'NutUI React Taro',
         message: 'min 50',
       },
     ])

--- a/src/packages/form/__tests__/form.spec.tsx
+++ b/src/packages/form/__tests__/form.spec.tsx
@@ -226,10 +226,10 @@ test('form onFinishFailed', async () => {
   fireEvent.submit(form)
   await waitFor(() => {
     expect(handleFailed).toBeCalled()
-    expect(handleFailed).toBeCalledWith({ username: 'NutUI React Taro' }, [
+    expect(handleFailed).toBeCalledWith({ username: 'NutUI-React' }, [
       {
         field: 'username',
-        fieldValue: 'NutUI React Taro',
+        fieldValue: 'NutUI-React',
         message: 'min 50',
       },
     ])

--- a/src/packages/form/__tests__/form.spec.tsx
+++ b/src/packages/form/__tests__/form.spec.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Form, { FormInstance } from '@/packages/form'
 import Input from '@/packages/input'
+import { merge } from '@/utils/merge'
 
 beforeAll(() => {
   // @ts-ignore
@@ -310,5 +311,60 @@ test('no-style and render function', async () => {
   waitFor(() => {
     const relatedInput = container.querySelector('.related-input')
     expect(relatedInput).toBeTruthy()
+  })
+})
+
+describe('merge', async () => {
+  it('merges two objects', () => {
+    expect(merge({ a: 1 }, { b: 2 })).toStrictEqual({ a: 1, b: 2 })
+  })
+
+  it('merges nested levels', () => {
+    expect(merge({ a: 1 }, { b: { c: { d: 2 } } })).toStrictEqual({
+      a: 1,
+      b: { c: { d: 2 } },
+    })
+  })
+  it('clones the target', () => {
+    let input = {
+      a: 1,
+      b: {
+        c: {
+          d: 2,
+          e: ['x', 'y', { z: { w: ['k'] } }],
+        },
+      },
+      f: null,
+      g: undefined,
+      h: true,
+    }
+
+    const original = {
+      a: 1,
+      b: {
+        c: {
+          d: 2,
+          e: ['x', 'y', { z: { w: ['k'] } }],
+        },
+      },
+      f: null,
+      g: undefined,
+      h: true,
+    }
+
+    let output = merge(true, input)
+
+    input.b.c.d++
+    ;(input.b.c.e[2] as any).z.w = null
+    ;(input as any).h = null
+
+    expect(output).toStrictEqual(original)
+
+    input = original
+
+    output = merge(true, input, { a: 2 })
+
+    expect(output.a).toBe(2)
+    expect(input.a).toBe(1)
   })
 })

--- a/src/packages/form/__tests__/merge.spec.ts
+++ b/src/packages/form/__tests__/merge.spec.ts
@@ -1,0 +1,263 @@
+import { merge, clone, recursive, isPlainObject } from '@/utils/merge'
+
+describe('merge', () => {
+  it('merges two objects', () => {
+    expect(merge({ a: 1 }, { b: 2 })).toStrictEqual({ a: 1, b: 2 })
+  })
+
+  it('merges nested levels', () => {
+    expect(merge({ a: 1 }, { b: { c: { d: 2 } } })).toStrictEqual({
+      a: 1,
+      b: { c: { d: 2 } },
+    })
+  })
+  it('clones the target', () => {
+    let input = {
+      a: 1,
+      b: {
+        c: {
+          d: 2,
+          e: ['x', 'y', { z: { w: ['k'] } }],
+        },
+      },
+      f: null,
+      g: undefined,
+      h: true,
+    }
+
+    const original = {
+      a: 1,
+      b: {
+        c: {
+          d: 2,
+          e: ['x', 'y', { z: { w: ['k'] } }],
+        },
+      },
+      f: null,
+      g: undefined,
+      h: true,
+    }
+
+    let output = merge(true, input)
+
+    input.b.c.d++
+    ;(input.b.c.e[2] as any).z.w = null
+    ;(input as any).h = null
+
+    expect(output).toStrictEqual(original)
+
+    input = original
+
+    output = merge(true, input, { a: 2 })
+
+    expect(output.a).toBe(2)
+    expect(input.a).toBe(1)
+  })
+
+  it('ignores the sources', () => {
+    const values = createNonPlainObjects()
+    const $merge = vi.fn().mockImplementation(merge)
+
+    for (const value of values) expect($merge(value)).toStrictEqual({})
+
+    expect(values.length).toBeGreaterThan(0)
+    expect($merge).toBeCalledTimes(values.length)
+    expect(
+      merge(...values, [0, 1, 2], ...values, { a: 1 }, ...values, {
+        b: 2,
+      })
+    ).toStrictEqual({ a: 1, b: 2 })
+  })
+
+  it('does not merge non plain objects', () => {
+    const values = createNonPlainObjects()
+    expect(values.length).toBeGreaterThan(0)
+    const input: any = {}
+
+    for (const [index, value] of Object.entries(values)) {
+      input[`value${index}`] = value
+    }
+
+    const output = merge({}, input)
+
+    for (const [index] of Object.entries(values)) {
+      const key = `value${index}`
+      const inputValue = input[key]
+      const outputValue = output[key]
+
+      // eslint-disable-next-line no-restricted-globals
+      if (typeof outputValue === 'number' && isNaN(outputValue)) {
+        // eslint-disable-next-line no-restricted-globals
+        expect(isNaN(inputValue), key).toBeTruthy()
+      } else {
+        expect(inputValue === outputValue, key).toBeTruthy()
+      }
+    }
+  })
+
+  it('is safe', () => {
+    expect(
+      merge({}, JSON.parse('{"__proto__": {"evil": true}}'))
+    ).toStrictEqual({})
+    expect(({} as any).evil).toBeUndefined()
+  })
+})
+
+describe('clone', () => {
+  it('clones the input', () => {
+    const object1 = { a: 1, b: { c: 2 } }
+    const object2 = clone(object1)
+
+    expect(object1).toStrictEqual(object2)
+    expect(object1 === object2).toBeFalsy()
+    expect(object1.b === object2.b).toBeFalsy()
+  })
+
+  it('clones each item of the array', () => {
+    const object1 = [{ a: 1, b: { c: 2 } }]
+    const object2 = clone(object1)
+
+    expect(object1).toStrictEqual(object2)
+    expect(object1 === object2).toBeFalsy()
+    expect(object1[0] === object2[0]).toBeFalsy()
+    expect(object1[0].b === object2[0].b).toBeFalsy()
+  })
+
+  it('returns the same input', () => {
+    const values = createNonPlainObjects()
+    const $clone = vi.fn().mockImplementation(clone)
+    for (const value of values) {
+      const cloned = $clone(value)
+      // eslint-disable-next-line no-restricted-globals
+      if (typeof cloned === 'number' && isNaN(cloned)) {
+        // eslint-disable-next-line no-restricted-globals
+        expect(isNaN(value)).toBeTruthy()
+      } else if (Array.isArray(cloned)) {
+        expect(Array.isArray(value)).toBeTruthy()
+      } else {
+        expect(cloned === value).toBeTruthy()
+      }
+    }
+    expect(values.length).toBeGreaterThan(0)
+    expect($clone).toBeCalledTimes(values.length)
+  })
+})
+
+describe('recursive', () => {
+  it('merges recursively', () => {
+    expect(recursive({ a: { b: 1 } }, { a: { c: 1 } })).toStrictEqual({
+      a: { b: 1, c: 1 },
+    })
+
+    expect(recursive({ a: { b: 1, c: 1 } }, { a: { b: 2 } })).toStrictEqual({
+      a: { b: 2, c: 1 },
+    })
+
+    expect(
+      recursive({ a: { b: [1, 2, 3], c: 1 } }, { a: { b: ['a'] } })
+    ).toStrictEqual({ a: { b: ['a'], c: 1 } })
+
+    expect(
+      recursive({ a: { b: { b: 2 }, c: 1 } }, { a: { b: 2 } })
+    ).toStrictEqual({
+      a: { b: 2, c: 1 },
+    })
+  })
+
+  it('clones recursively', () => {
+    const test1 = { a: { b: 1 } }
+
+    expect(recursive(true, test1, { a: { c: 1 } })).toStrictEqual({
+      a: { b: 1, c: 1 },
+    })
+
+    expect(test1).toStrictEqual({ a: { b: 1 } })
+
+    const test2 = { a: { b: 1, c: 1 } }
+
+    expect(recursive(true, test2, { a: { b: 2 } })).toStrictEqual({
+      a: { b: 2, c: 1 },
+    })
+
+    expect(test2).toStrictEqual({ a: { b: 1, c: 1 } })
+
+    const test3 = { a: { b: [1, 2, 3], c: 1 } }
+
+    expect(recursive(true, test3, { a: { b: ['a'] } })).toStrictEqual({
+      a: { b: ['a'], c: 1 },
+    })
+
+    expect(test3).toStrictEqual({ a: { b: [1, 2, 3], c: 1 } })
+
+    const test4 = { a: { b: { b: 2 }, c: 1 } }
+
+    expect(recursive(true, test4, { a: { b: 2 } })).toStrictEqual({
+      a: { b: 2, c: 1 },
+    })
+
+    expect(test4).toStrictEqual({ a: { b: { b: 2 }, c: 1 } })
+  })
+
+  it('does not merge non plain objects', () => {
+    const object = recursive({ map: { length: 1 } }, { map: new Map() })
+    expect(object.map).toBeInstanceOf(Map)
+  })
+
+  it('is safe', () => {
+    const payload = '{"__proto__": {"a": true}}'
+    expect(recursive({}, JSON.parse(payload))).toStrictEqual({})
+    expect(({} as any).a).toBeUndefined()
+    expect(recursive({ deep: {} }, JSON.parse(payload))).toStrictEqual({
+      deep: {},
+    })
+    expect(({} as any).b).toBeUndefined()
+  })
+})
+
+describe('isPlainObject', () => {
+  it('returns true', () => {
+    expect(isPlainObject({})).toBeTruthy()
+    expect(isPlainObject({ v: 1 })).toBeTruthy()
+    expect(isPlainObject(Object.create(null))).toBeTruthy()
+    expect(isPlainObject({})).toBeTruthy()
+  })
+  it('returns false', () => {
+    const values = createNonPlainObjects()
+    const $isPlainObject = vi.fn().mockImplementation(isPlainObject)
+    for (const value of values) expect($isPlainObject(value)).toBeFalsy()
+    expect(values.length).toBeGreaterThan(0)
+    expect($isPlainObject).toBeCalledTimes(values.length)
+  })
+})
+
+function createNonPlainObjects(): any[] {
+  class SubObject extends Object {}
+
+  return [
+    null,
+    undefined,
+    1,
+    '',
+    'str',
+    [],
+    [1],
+    () => {},
+    function () {},
+    true,
+    false,
+    NaN,
+    Infinity,
+    class {},
+    new (class {})(),
+    new Map(),
+    new Set(),
+    new Date(),
+    [],
+    new Date(),
+    /./,
+    /./,
+    SubObject,
+    new SubObject(),
+    Symbol(''),
+  ]
+}

--- a/src/packages/form/useform.taro.ts
+++ b/src/packages/form/useform.taro.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
 import Schema from 'async-validator'
-import { merge } from '@/utils/merge'
+import { merge, recursive } from '@/utils/merge'
 import {
   Callbacks,
   FormFieldEntity,
@@ -98,7 +98,7 @@ class FormStore {
    * @param newStore { [name]: newValue }
    */
   setFieldsValue = (newStore: any) => {
-    const nextStore = merge(this.store, newStore)
+    const nextStore = recursive(true, this.store, newStore)
     this.updateStore(nextStore)
     this.fieldEntities.forEach((entity: FormFieldEntity) => {
       const { name } = entity.props

--- a/src/packages/form/useform.ts
+++ b/src/packages/form/useform.ts
@@ -202,9 +202,7 @@ class FormStore {
 
   resetFields = () => {
     this.errors.length = 0
-    console.log('xxx', this.initialValues)
     const nextStore = merge({}, this.initialValues)
-    console.log(nextStore)
     this.updateStore(nextStore)
     this.fieldEntities.forEach((entity: FormFieldEntity) => {
       entity.onStoreChange('reset')

--- a/src/packages/form/useform.ts
+++ b/src/packages/form/useform.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
 import Schema from 'async-validator'
-import { merge } from '@/utils/merge'
+import { merge, recursive } from '@/utils/merge'
 import {
   Callbacks,
   FormFieldEntity,
@@ -98,7 +98,7 @@ class FormStore {
    * @param newStore { [name]: newValue }
    */
   setFieldsValue = (newStore: any) => {
-    const nextStore = merge(this.store, newStore)
+    const nextStore = recursive(true, this.store, newStore)
     this.updateStore(nextStore)
     this.fieldEntities.forEach((entity: FormFieldEntity) => {
       const { name } = entity.props
@@ -202,7 +202,9 @@ class FormStore {
 
   resetFields = () => {
     this.errors.length = 0
+    console.log('xxx', this.initialValues)
     const nextStore = merge({}, this.initialValues)
+    console.log(nextStore)
     this.updateStore(nextStore)
     this.fieldEntities.forEach((entity: FormFieldEntity) => {
       entity.onStoreChange('reset')

--- a/src/utils/merge.ts
+++ b/src/utils/merge.ts
@@ -1,29 +1,89 @@
-export function merge(...objects: any[]) {
-  const result: any = Array.isArray(objects[0]) ? [] : {}
+export default main
 
-  function mergeHelper(obj: any, path: string[] = []) {
-    for (const [key, value] of Object.entries(obj)) {
-      const newPath = [...path, key]
+export function main(clone: boolean, ...items: any[]): any
+export function main(...items: any[]): any
+export function main(...items: any[]) {
+  return merge(...items)
+}
 
-      if (Array.isArray(value)) {
-        // Arrays are always overridden
-        result[key] = [...value]
-      } else if (typeof value === 'object' && value !== null) {
-        // Check for circular references
-        // eslint-disable-next-line no-continue
-        if (path.some((p: any) => p === value)) continue
+main.clone = clone
+main.isPlainObject = isPlainObject
+main.recursive = recursive
 
-        // Recursively merge objects
-        if (!result[key]) result[key] = {}
-        mergeHelper(value, newPath)
-      } else {
-        // Set primitive values
-        result[key] = value
-      }
-    }
+export function merge(clone: boolean, ...items: any[]): any
+export function merge(...items: any[]): any
+export function merge(...items: any[]) {
+  return _merge(items[0] === true, false, items)
+}
+
+export function recursive(clone: boolean, ...items: any[]): any
+export function recursive(...items: any[]): any
+export function recursive(...items: any[]) {
+  return _merge(items[0] === true, true, items)
+}
+
+export function clone<T>(input: T): T {
+  if (Array.isArray(input)) {
+    const output = []
+
+    for (let index = 0; index < input.length; ++index)
+      output.push(clone(input[index]))
+
+    return output as any
+  }
+  if (isPlainObject(input)) {
+    const output: any = {}
+
+    // eslint-disable-next-line guard-for-in
+    for (const index in input) output[index] = clone((input as any)[index])
+
+    return output as any
+  }
+  return input
+}
+
+export function isPlainObject(input: unknown): input is NonNullable<any> {
+  if (input === null || typeof input !== 'object') return false
+  if (Object.getPrototypeOf(input) === null) return true
+  let ref = input
+  while (Object.getPrototypeOf(ref) !== null) ref = Object.getPrototypeOf(ref)
+  return Object.getPrototypeOf(input) === ref
+}
+
+function _recursiveMerge(base: any, extend: any) {
+  if (!isPlainObject(base) || !isPlainObject(extend)) return extend
+  for (const key in extend) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype')
+      // eslint-disable-next-line no-continue
+      continue
+    base[key] =
+      isPlainObject(base[key]) && isPlainObject(extend[key])
+        ? _recursiveMerge(base[key], extend[key])
+        : extend[key]
   }
 
-  objects.filter((obj) => !!obj).forEach((obj) => mergeHelper(obj))
+  return base
+}
+
+function _merge(isClone: boolean, isRecursive: boolean, items: any[]) {
+  let result
+
+  if (isClone || !isPlainObject((result = items.shift()))) result = {}
+
+  for (let index = 0; index < items.length; ++index) {
+    const item = items[index]
+
+    // eslint-disable-next-line no-continue
+    if (!isPlainObject(item)) continue
+
+    for (const key in item) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype')
+        // eslint-disable-next-line no-continue
+        continue
+      const value = isClone ? clone(item[key]) : item[key]
+      result[key] = isRecursive ? _recursiveMerge(result[key], value) : value
+    }
+  }
 
   return result
 }


### PR DESCRIPTION


### 🤔 这个变动的性质是？


- [x] 日常 bug 修复

### 🔗 相关 Issue

#2870 

### 💡 需求背景和解决方案

merge 方法存在 bug 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 增强了对象合并和克隆的实用函数
	- 提供更灵活的数据合并选项

- **改进**
	- 优化了 `merge` 和 `recursive` 函数的实现
	- 新增了深度克隆和对象类型检测功能

- **Bug 修复**
	- 改进了对象合并的安全性
	- 防止原型污染风险

- **测试**
	- 添加了全面的单元测试，覆盖合并、克隆和类型检测函数的各种场景
<!-- end of auto-generated comment: release notes by coderabbit.ai -->