### PR TITLE
feat(form): resetFields 增加 namepath 参数，用于重置指定的字段

### DIFF
--- a/src/packages/form/__tests__/form.spec.tsx
+++ b/src/packages/form/__tests__/form.spec.tsx
@@ -312,3 +312,56 @@ test('no-style and render function', async () => {
     expect(relatedInput).toBeTruthy()
   })
 })
+
+test('reset usename filed', async () => {
+  const Demo1 = () => {
+    const [form] = Form.useForm()
+    return (
+      <>
+        <Form
+          form={form}
+          labelPosition="right"
+          footer={
+            <>
+              <div
+                id="reset"
+                onClick={() => {
+                  form.resetFields(['username'])
+                }}
+              >
+                Reset
+              </div>
+            </>
+          }
+        >
+          <Form.Item
+            align="center"
+            required
+            label="字段A"
+            name="username"
+            rules={[{ max: 5, message: '字段A不能超过5个字' }]}
+          >
+            <Input placeholder="请输入字段A" type="text" />
+          </Form.Item>
+        </Form>
+      </>
+    )
+  }
+  const { container } = render(<Demo1 />)
+  const input = container.querySelector('input')
+  const reset = container.querySelector('#reset')
+  if (input) {
+    fireEvent.change(input, { target: { value: 'NutUI React Taro' } })
+    await waitFor(() => {
+      expect(
+        container.querySelector('.nut-form-item-body-tips')
+      ).toHaveTextContent('字段A不能超过5个字')
+    })
+  }
+  if (reset) {
+    fireEvent.click(reset)
+    await waitFor(() => {
+      expect(container.querySelector('.nut-form-item-body-tips')).toBeNull()
+    })
+  }
+})

--- a/src/packages/form/doc.en-US.md
+++ b/src/packages/form/doc.en-US.md
@@ -129,7 +129,7 @@ Form.useForm() creates a Form instance, which is used to manage all data states.
 | getFieldsValue | Get values by a set of field names. Return according to the corresponding structure. Default return mounted field value, but you can use getFieldsValue(true) to get all values | `(name: NamePath \| boolean) => any` |
 | setFieldsValue | Set the value of the form (the value will be passed directly to the form store. If you do not want the object passed in to be modified, please copy it and pass it in) | `(values) => void` |
 | setFieldValue | Set the value of the corresponding field name | `<T>(name: NamePath, value: T) => void` |
-| resetFields | Reset form prompt state | `() => void` |
+| resetFields | Reset form prompt state | `(namePaths?: NamePath[]) => void` |
 | submit | method to submit a form for validation | `Promise` |
 
 ## Theming

--- a/src/packages/form/doc.md
+++ b/src/packages/form/doc.md
@@ -128,7 +128,7 @@ Form.useForm()创建 Form 实例，用于管理所有数据状态。
 | getFieldsValue | 获取一组字段名对应的值，会按照对应结构返回。默认返回现存字段值，当调用 getFieldsValue(true) 时返回所有值 | `(name: NamePath \| boolean) => any` |
 | setFieldsValue | 设置表单的值（该值将直接传入 form store 中。如果你不希望传入对象被修改，请克隆后传入） | `(values) => void` |
 | setFieldValue | 设置对应字段名的值 | `<T>(name: NamePath, value: T) => void` |
-| resetFields | 重置表单提示状态 | `() => void` |
+| resetFields | 重置表单提示状态 | `(namePaths?: NamePath[]) => void` |
 | submit | 提交表单进行校验的方法 | `Promise` |
 
 ## 主题定制

--- a/src/packages/form/doc.taro.md
+++ b/src/packages/form/doc.taro.md
@@ -128,7 +128,7 @@ Form.useForm()创建 Form 实例，用于管理所有数据状态。
 | getFieldsValue | 获取一组字段名对应的值，会按照对应结构返回。默认返回现存字段值，当调用 getFieldsValue(true) 时返回所有值 | `(name: NamePath \| boolean) => any` |
 | setFieldsValue | 设置表单的值（该值将直接传入 form store 中。如果你不希望传入对象被修改，请克隆后传入） | `(values) => void` |
 | setFieldValue | 设置对应字段名的值 | `<T>(name: NamePath, value: T) => void` |
-| resetFields | 重置表单提示状态 | `() => void` |
+| resetFields | 重置表单提示状态 | `(namePaths?: NamePath[]) => void` |
 | submit | 提交表单进行校验的方法 | `Promise` |
 
 ## 主题定制

--- a/src/packages/form/doc.zh-TW.md
+++ b/src/packages/form/doc.zh-TW.md
@@ -128,7 +128,7 @@ Form.useForm()創建 Form 實例，用於管理所有數據狀態。
 | getFieldsValue | 获取一组字段名对应的值，会按照对应结构返回。默认返回现存字段值，当调用 getFieldsValue(true) 时返回所有值 | `(name: NamePath \| boolean) => any` |
 | setFieldsValue | 設定表單的值（該值將直接傳入 form store 中。如果你不希望傳入物件被修改，請複製後傳入） | `(values) => void` |
 | setFieldValue | 設定對應欄位名的值 | `<T>(name: NamePath, value: T) => void` |
-| resetFields | 重置錶單提示狀態 | `() => void` |
+| resetFields | 重置錶單提示狀態 | `(namePaths?: NamePath[]) => void` |
 | submit | 提交錶單進行校驗的方法 | `Promise` |
 
 ## 主題定制

--- a/src/packages/form/useform.taro.ts
+++ b/src/packages/form/useform.taro.ts
@@ -174,7 +174,7 @@ class FormStore {
 
   validateFields = async (nameList?: NamePath[]) => {
     let filterEntities = []
-    this.errors.length = 0
+    // this.errors.length = 0
     if (!nameList || nameList.length === 0) {
       filterEntities = this.fieldEntities
     } else {
@@ -200,13 +200,29 @@ class FormStore {
     }
   }
 
-  resetFields = () => {
-    this.errors.length = 0
-    const nextStore = merge({}, this.initialValues)
-    this.updateStore(nextStore)
-    this.fieldEntities.forEach((entity: FormFieldEntity) => {
-      entity.onStoreChange('reset')
-    })
+  resetFields = (namePaths?: NamePath[]) => {
+    if (namePaths) {
+      namePaths.forEach((path) => {
+        this.errors[path] = null
+        this.fieldEntities.forEach((entity: FormFieldEntity) => {
+          const name = entity.props.name
+          if (name === path) {
+            if (path in this.initialValues) {
+              this.updateStore({ [path]: this.initialValues[path] })
+            } else {
+              delete this.store[path]
+            }
+            entity.onStoreChange('reset')
+          }
+        })
+      })
+    } else {
+      const nextStore = merge({}, this.initialValues)
+      this.updateStore(nextStore)
+      this.fieldEntities.forEach((entity: FormFieldEntity) => {
+        entity.onStoreChange('reset')
+      })
+    }
   }
 
   // 监听事件

--- a/src/packages/form/useform.taro.ts
+++ b/src/packages/form/useform.taro.ts
@@ -201,7 +201,7 @@ class FormStore {
   }
 
   resetFields = (namePaths?: NamePath[]) => {
-    if (namePaths) {
+    if (namePaths && namePaths.length) {
       namePaths.forEach((path) => {
         this.errors[path] = null
         this.fieldEntities.forEach((entity: FormFieldEntity) => {

--- a/src/packages/form/useform.ts
+++ b/src/packages/form/useform.ts
@@ -174,7 +174,7 @@ class FormStore {
 
   validateFields = async (nameList?: NamePath[]) => {
     let filterEntities = []
-    this.errors.length = 0
+    // this.errors.length = 0
     if (!nameList || nameList.length === 0) {
       filterEntities = this.fieldEntities
     } else {
@@ -200,13 +200,29 @@ class FormStore {
     }
   }
 
-  resetFields = () => {
-    this.errors.length = 0
-    const nextStore = merge({}, this.initialValues)
-    this.updateStore(nextStore)
-    this.fieldEntities.forEach((entity: FormFieldEntity) => {
-      entity.onStoreChange('reset')
-    })
+  resetFields = (namePaths?: NamePath[]) => {
+    if (namePaths) {
+      namePaths.forEach((path) => {
+        this.errors[path] = null
+        this.fieldEntities.forEach((entity: FormFieldEntity) => {
+          const name = entity.props.name
+          if (name === path) {
+            if (path in this.initialValues) {
+              this.updateStore({ [path]: this.initialValues[path] })
+            } else {
+              delete this.store[path]
+            }
+            entity.onStoreChange('reset')
+          }
+        })
+      })
+    } else {
+      const nextStore = merge({}, this.initialValues)
+      this.updateStore(nextStore)
+      this.fieldEntities.forEach((entity: FormFieldEntity) => {
+        entity.onStoreChange('reset')
+      })
+    }
   }
 
   // 监听事件

--- a/src/packages/form/useform.ts
+++ b/src/packages/form/useform.ts
@@ -201,7 +201,7 @@ class FormStore {
   }
 
   resetFields = (namePaths?: NamePath[]) => {
-    if (namePaths) {
+    if (namePaths && namePaths.length) {
       namePaths.forEach((path) => {
         this.errors[path] = null
         this.fieldEntities.forEach((entity: FormFieldEntity) => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交

### 🔗 相关 Issue


### 💡 需求背景和解决方案

增加 namepath 参数用于重置指定字段的内容

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为表单组件引入了字段重置功能，允许用户精确重置特定输入字段
	- 新增测试用例验证字段重置机制

- **测试**
	- 添加了针对表单字段重置的新测试场景
	- 测试验证了重置功能能够清除字段验证消息并恢复初始状态

- **改进**
	- 优化了 `resetFields` 方法，提供了更灵活的字段重置选项
	- 改进了错误状态管理机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->