### PR TITLE
fix(button): taro button cannot be compiled into an h5 tag

### DIFF
--- a/src/packages/button/button.taro.tsx
+++ b/src/packages/button/button.taro.tsx
@@ -1,11 +1,7 @@
-import React, { CSSProperties, useCallback, useMemo } from 'react'
 import type { MouseEvent } from 'react'
+import React, { CSSProperties, useCallback, useMemo } from 'react'
 import classNames from 'classnames'
-import {
-  ButtonProps as MiniProgramButtonProps,
-  View,
-  Button as TaroButton,
-} from '@tarojs/components'
+import { ButtonProps as MiniProgramButtonProps, View } from '@tarojs/components'
 import { Loading } from '@nutui/icons-react-taro'
 import { getEnv } from '@tarojs/taro'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
@@ -148,13 +144,14 @@ export const Button = React.forwardRef<HTMLButtonElement, Partial<ButtonProps>>(
       ;(rest as any).type = rest.formType
     }
     return (
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       // eslint-disable-next-line react/button-has-type
-      <TaroButton
+      <button
         {...rest}
         ref={ref}
-        formType={nativeType}
+        /* eslint-disable-next-line react/no-unknown-property */
+        form-type={nativeType}
+        type={nativeType}
         className={buttonClassNames}
         style={{ ...getStyle, ...style }}
         onClick={(e) => handleClick(e as any)}
@@ -174,7 +171,7 @@ export const Button = React.forwardRef<HTMLButtonElement, Partial<ButtonProps>>(
           )}
           {rightIcon}
         </View>
-      </TaroButton>
+      </button>
     )
   }
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 按钮组件现已使用标准 HTML 按钮实现，确保了跨设备一致性和更稳定的交互体验。
  - 更新了按钮属性命名，使表单交互更加直观，明确了按钮类型定义，同时保持了原有的点击和样式行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->