### PR TITLE
fix(swiper): 设置横向轮播后，手势无法触发页面的滚动

### DIFF
--- a/src/packages/swiper/swiper.scss
+++ b/src/packages/swiper/swiper.scss
@@ -4,8 +4,15 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  touch-action: none;
   position: relative;
+
+  &-canmove-horizontal {
+    touch-action: pan-y;
+  }
+
+  &-canmove-vertical {
+    touch-action: pan-x;
+  }
 
   &-indicator {
     display: flex;
@@ -28,6 +35,7 @@
     z-index: 1;
   }
 }
+
 .nut-swiper-inner {
   width: 100%;
   height: 100%;
@@ -57,6 +65,7 @@
     left: auto;
     right: 50%;
   }
+
   &-indicator-vertical {
     left: auto;
     right: 12px;

--- a/src/packages/swiper/swiper.tsx
+++ b/src/packages/swiper/swiper.tsx
@@ -220,18 +220,17 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
           const y = (springs.y.get() / 100) * slideSize
           return [-x, -y]
         },
-        triggerAllEvents: true,
         bounds: () => {
           if (loop) return {}
           const slideSize = getSlideSize()
-          const swiperSize = getSwiperSize()
           if (isVertical) {
             return { top: 0, bottom: (count - 1) * slideSize }
           }
           return { left: 0, right: (count - 1) * slideSize }
         },
-        preventDefault: true,
         rubberband: true,
+        triggerAllEvents: true,
+        preventScroll: isVertical,
         axis: isVertical ? 'y' : 'x',
         pointer: {
           touch: true,
@@ -288,9 +287,9 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
       return (
         <div
           ref={stageRef}
-          className={classNames('nut-swiper-inner', {
-            'nut-swiper-inner-vertical': isVertical,
-            'nut-swiper-inner-horizontal': !isVertical,
+          className={classNames(`${classPrefix}-inner`, {
+            [`${classPrefix}-inner-vertical`]: isVertical,
+            [`${classPrefix}-inner-horizontal`]: !isVertical,
           })}
           style={{
             ...(props.slideSize
@@ -304,7 +303,11 @@ export const Swiper = React.forwardRef<SwiperRef, Partial<SwiperProps>>(
     }
     return (
       <div
-        className={classNames('nut-swiper', className)}
+        className={classNames(
+          classPrefix,
+          `${classPrefix}-canmove-${direction}`,
+          className
+        )}
         style={style}
         ref={swiperRef}
         {...bind()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了滑动组件的触摸与拖拽交互体验，实现更精准的横向和纵向滑动控制。
- **样式**
  - 更新了轮播组件的视觉表现和指示器定位，优化了适应从右到左布局的显示效果。
- **重构**
  - 改进了事件处理逻辑和动态样式应用，进一步提升了组件的响应性和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->