### PR TITLE
fix(tabs): 修复tabs数量过多时的滚动操作bug

### DIFF
--- a/src/packages/tabs/tabs.taro.tsx
+++ b/src/packages/tabs/tabs.taro.tsx
@@ -160,15 +160,9 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
     to: number,
     direction: 'horizontal' | 'vertical'
   ) => {
-    let count = 0
-    const frames = 1
-
-    function animate() {
-      if (direction === 'horizontal') setScrollLeft(to)
-      else setScrollTop(to)
-      if (++count < frames) raf(animate)
-    }
-    animate()
+    // 使用ScrollView组件此处不需要手动raf scrollLeft
+    if (direction === 'horizontal') setScrollLeft(to)
+    else setScrollTop(to)
   }
   const scrollIntoView = (index: number) => {
     raf(() => {
@@ -190,14 +184,12 @@ export const Tabs: FunctionComponent<Partial<TabsProps>> & {
             .slice(0, index)
             .reduce((prev: number, curr: RectItem) => prev + curr.width, 0)
           to = left - (navRect.width - titleRect.width) / 2
-          // to < 0 说明不需要进行滚动，页面元素已全部显示出来
-          if (to < 0) return
-          to = rtl ? -to : to
         }
+        scrollDirection(to, direction)
+
         nextTick(() => {
           scrollWithAnimation.current = true
         })
-        scrollDirection(to, direction)
       })
     })
   }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

- Fix: 修复 tabs 滚动逻辑（ps:当tabs 滚动到最后一个tab时，此时点击当前范围内可见的第一个tab，此时不会将选中tab滚动于中间显示，导致无法看见当前和之前的tab）
 #2653 
 #2923 
 #2930

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 优化了滚动处理逻辑，取消了原先采用动画过渡的方式，现直接设置滚动位置，实现更迅速、直接的定位。
	- 简化了视图滚动判断，确保内容在滚动时能够稳定、准确地显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->