### PR TITLE
docs: correct demoBlock src error

### DIFF
--- a/src/packages/indicator/doc.taro.md
+++ b/src/packages/indicator/doc.taro.md
@@ -22,7 +22,7 @@ import { Indicator } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo5.tsx'></CodeBlock>
+<CodeBlock src='taro/demo5.tsx'></CodeBlock>
 
 :::
 
@@ -30,7 +30,7 @@ import { Indicator } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo6.tsx'></CodeBlock>
+<CodeBlock src='taro/demo6.tsx'></CodeBlock>
 
 :::
 

--- a/src/packages/pickerview/doc.taro.md
+++ b/src/packages/pickerview/doc.taro.md
@@ -14,7 +14,7 @@ import { PickerView } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo1.tsx'></CodeBlock>
+<CodeBlock src='taro/demo1.tsx'></CodeBlock>
 
 :::
 
@@ -22,7 +22,7 @@ import { PickerView } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo4.tsx'></CodeBlock>
+<CodeBlock src='taro/demo4.tsx'></CodeBlock>
 
 :::
 
@@ -30,7 +30,7 @@ import { PickerView } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo2.tsx'></CodeBlock>
+<CodeBlock src='taro/demo2.tsx'></CodeBlock>
 
 :::
 
@@ -38,7 +38,7 @@ import { PickerView } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo3.tsx'></CodeBlock>
+<CodeBlock src='taro/demo3.tsx'></CodeBlock>
 
 :::
 
@@ -46,7 +46,7 @@ import { PickerView } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo5.tsx'></CodeBlock>
+<CodeBlock src='taro/demo5.tsx'></CodeBlock>
 
 :::
 
@@ -54,7 +54,7 @@ import { PickerView } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo6.tsx'></CodeBlock>
+<CodeBlock src='taro/demo6.tsx'></CodeBlock>
 
 :::
 

--- a/src/packages/popover/doc.taro.md
+++ b/src/packages/popover/doc.taro.md
@@ -84,7 +84,7 @@ bottom-end    # 底部右侧位置
 
 :::demo
 
-<CodeBlock src='h5/demo5.tsx'></CodeBlock>
+<CodeBlock src='taro/demo5.tsx'></CodeBlock>
 
 :::
 

--- a/src/packages/segmented/doc.taro.md
+++ b/src/packages/segmented/doc.taro.md
@@ -14,7 +14,7 @@ import { Segmented } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo1.tsx'></CodeBlock>
+<CodeBlock src='taro/demo1.tsx'></CodeBlock>
 
 :::
 
@@ -22,7 +22,7 @@ import { Segmented } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo2.tsx'></CodeBlock>
+<CodeBlock src='taro/demo2.tsx'></CodeBlock>
 
 :::
 
@@ -30,7 +30,7 @@ import { Segmented } from '@nutui/nutui-react-taro'
 
 :::demo
 
-<CodeBlock src='h5/demo3.tsx'></CodeBlock>
+<CodeBlock src='taro/demo3.tsx'></CodeBlock>
 
 :::
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新了 Indicator、PickerView、Popover 和 Segmented 组件文档中示例代码的路径，将原先的 h5/demo 文件路径调整为 taro/demo，从而使示例演示与当前框架保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->