### PR TITLE
fix(navbar): 居左展示时，副标题居左

### DIFF
--- a/src/packages/navbar/demos/h5/demo2.tsx
+++ b/src/packages/navbar/demos/h5/demo2.tsx
@@ -52,7 +52,13 @@ const Demo2 = () => {
             back={<ArrowLeft />}
             onBackClick={(e) => Toast.show('返回')}
           >
-            <div style={{ ...styles.flexCenter, flexDirection: 'column' }}>
+            <div
+              style={{
+                ...styles.flexCenter,
+                alignItems: 'flex-start',
+                flexDirection: 'column',
+              }}
+            >
               <span style={styles.title} onClick={(e) => Toast.show('标题')}>
                 页面标题
               </span>

--- a/src/packages/navbar/demos/taro/demo2.tsx
+++ b/src/packages/navbar/demos/taro/demo2.tsx
@@ -73,7 +73,13 @@ const Demo2 = () => {
             onBackClick={(e) => Taro.showToast({ title: '返回' })}
           >
             <View>
-              <View style={{ ...styles.flexCenter, flexDirection: 'column' }}>
+              <View
+                style={{
+                  ...styles.flexCenter,
+                  alignItems: 'flex-start',
+                  flexDirection: 'column',
+                }}
+              >
                 <View
                   style={styles.title}
                   onClick={(e) => Taro.showToast({ title: '标题' })}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 更新导航栏示例中子元素的对齐方式，从居中对齐调整为左侧对齐，改善了布局展示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->