### PR TITLE
fix: migrate docs

### DIFF
--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
@@ -41,7 +41,7 @@ plugins: [
       style: 'css',
       camel2DashComponentName: false,
       "customName": (name, file) => {
-        return `@nutui/nutui-react-taro/dist/es/packages/${name.toLowerCase()}`
+        return `@nutui/nutui-react/dist/es/packages/${name.toLowerCase()}`
       }
     },
     "nutui-react",

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
@@ -41,7 +41,7 @@ plugins: [
       style: 'css',
       camel2DashComponentName: false,
       "customName": (name, file) => {
-        return `@nutui/nutui-react-taro/dist/es/packages/${name.toLowerCase()}`
+        return `@nutui/nutui-react/dist/es/packages/${name.toLowerCase()}`
       }
     },
     "nutui-react",

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
@@ -41,7 +41,7 @@ plugins: [
       style: 'css',
       camel2DashComponentName: false,
       "customName": (name, file) => {
-        return `@nutui/nutui-react-taro/dist/es/packages/${name.toLowerCase()}`
+        return `@nutui/nutui-react/dist/es/packages/${name.toLowerCase()}`
       }
     },
     "nutui-react",

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
@@ -41,7 +41,7 @@ plugins: [
       style: 'css',
       camel2DashComponentName: false,
       "customName": (name, file) => {
-        return `@nutui/nutui-react-taro/dist/es/packages/${name.toLowerCase()}`
+        return `@nutui/nutui-react/dist/es/packages/${name.toLowerCase()}`
       }
     },
     "nutui-react",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - 更新了迁移指南，调整了组件样式引用路径，从 Taro 专用版本切换为标准 React 版本，以确保样式一致性和构建稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->