### PR TITLE
fix: correct usages about toast props

### DIFF
--- a/src/packages/icon/demo.taro.tsx
+++ b/src/packages/icon/demo.taro.tsx
@@ -53,7 +53,6 @@ const IconDemo = () => {
         <Toast
           content={state.msg}
           visible={state.visible}
-          type={state.type}
           duration={state.duration}
           icon={state.icon}
           closeOnOverlayClick={state.closeOnOverlayClick}

--- a/src/packages/icon/demos/taro/demo6.tsx
+++ b/src/packages/icon/demos/taro/demo6.tsx
@@ -26,7 +26,7 @@ const Demo6 = () => {
 
   return (
     <>
-      <Toast visible={state.visible} content={state.content} type="text" />
+      <Toast visible={state.visible} content={state.content} />
       {(iconfonts.IconFontConfig as any).data.map((item: any) => {
         return (
           <Cell.Group key={item.name} title={item.name}>

--- a/src/packages/icon/demos/taro/demo7.tsx
+++ b/src/packages/icon/demos/taro/demo7.tsx
@@ -27,7 +27,7 @@ const Demo7 = () => {
 
   return (
     <>
-      <Toast visible={state.visible} content={state.content} type="text" />
+      <Toast visible={state.visible} content={state.content} />
       {(iconfonts.IconFontConfig as any).style.map((item: any) => {
         return (
           <Cell.Group key={item.name} title={item.name}>

--- a/src/packages/infiniteloading/demos/taro/demo2.tsx
+++ b/src/packages/infiniteloading/demos/taro/demo2.tsx
@@ -108,7 +108,6 @@ const Demo2 = () => {
           </InfiniteLoading>
         </View>
         <Toast
-          type="text"
           visible={show}
           content={toastMsg}
           onClose={() => {

--- a/src/packages/inputnumber/demos/taro/demo3.tsx
+++ b/src/packages/inputnumber/demos/taro/demo3.tsx
@@ -3,15 +3,13 @@ import { Cell, InputNumber, Toast } from '@nutui/nutui-react-taro'
 
 const Demo3 = () => {
   const overlimit = () => {
-    toastShow('超出限制事件触发', 'warn')
+    toastShow('超出限制事件触发')
   }
   const [show, SetShow] = useState(false)
   const [toastMsg, SetToastMsg] = useState('')
-  const [toastType, SetToastType] = useState('text')
 
-  const toastShow = (msg: any, type: string) => {
+  const toastShow = (msg: string) => {
     SetToastMsg(msg)
-    SetToastType(type)
     SetShow(true)
   }
 
@@ -29,7 +27,6 @@ const Demo3 = () => {
         />
       </Cell>
       <Toast
-        type={toastType}
         visible={show}
         content={toastMsg}
         onClose={() => {

--- a/src/packages/inputnumber/demos/taro/demo8.tsx
+++ b/src/packages/inputnumber/demos/taro/demo8.tsx
@@ -5,11 +5,9 @@ const Demo8 = () => {
   const [inputValue, setInputValue] = useState(0)
   const [show, setShow] = useState(false)
   const [toastMsg, setToastMsg] = useState('')
-  const [toastType, setToastType] = useState('text')
 
-  const toastShow = (msg: any, type: string) => {
+  const toastShow = (msg: any) => {
     setToastMsg(msg)
-    setToastType(type)
     setShow(true)
   }
   const overlimit = (e: any) => {
@@ -17,7 +15,7 @@ const Demo8 = () => {
   }
 
   const beforeChange = (value: number | string): Promise<boolean> => {
-    toastShow('异步演示 2 秒后更改', 'loading')
+    toastShow('异步演示 2 秒后更改')
 
     return new Promise((resolve) => {
       setTimeout(() => {
@@ -39,7 +37,6 @@ const Demo8 = () => {
         />
       </Cell>
       <Toast
-        type={toastType}
         visible={show}
         content={toastMsg}
         onClose={() => {

--- a/src/packages/inputnumber/demos/taro/demo9.tsx
+++ b/src/packages/inputnumber/demos/taro/demo9.tsx
@@ -1,18 +1,10 @@
-import React, { useState } from 'react'
-import {
-  Cell,
-  InputNumber,
-  Toast,
-  ConfigProvider,
-} from '@nutui/nutui-react-taro'
+import React from 'react'
+import { Cell, InputNumber, ConfigProvider } from '@nutui/nutui-react-taro'
 
 const Demo9 = () => {
   const customTheme3 = {
     nutuiInputnumberInputWidth: '60px',
   }
-  const [toastType, SetToastType] = useState('text')
-  const [show, SetShow] = useState(false)
-  const [toastMsg, SetToastMsg] = useState('')
 
   return (
     <>
@@ -40,14 +32,6 @@ const Demo9 = () => {
           />
         </ConfigProvider>
       </Cell>
-      <Toast
-        type={toastType}
-        visible={show}
-        content={toastMsg}
-        onClose={() => {
-          SetShow(false)
-        }}
-      />
     </>
   )
 }

--- a/src/packages/numberkeyboard/demos/taro/demo6.tsx
+++ b/src/packages/numberkeyboard/demos/taro/demo6.tsx
@@ -32,7 +32,6 @@ const Demo6 = () => {
         }}
       />
       <Toast
-        type="text"
         visible={show}
         content={toastMsg}
         onClose={() => {

--- a/src/packages/progress/demos/taro/demo7.tsx
+++ b/src/packages/progress/demos/taro/demo7.tsx
@@ -12,7 +12,6 @@ const Demo7 = () => {
     <Cell.Group>
       {!harmony() && (
         <Toast
-          type="text"
           visible={show}
           content={toastMsg}
           onClose={() => {

--- a/src/packages/pulltorefresh/demos/taro/demo4.tsx
+++ b/src/packages/pulltorefresh/demos/taro/demo4.tsx
@@ -39,7 +39,6 @@ const Demo4 = () => {
         </PullToRefresh>
       </ScrollView>
       <Toast
-        type="text"
         visible={show}
         content={toastMsg}
         onClose={() => {

--- a/src/packages/searchbar/demos/taro/demo3.tsx
+++ b/src/packages/searchbar/demos/taro/demo3.tsx
@@ -18,7 +18,6 @@ const Demo3 = () => {
         <SearchBar onSearch={() => toastShow()} />
       </ConfigProvider>
       <Toast
-        type="text"
         visible={show}
         content="search callback"
         onClose={() => {

--- a/src/packages/searchbar/demos/taro/demo4.tsx
+++ b/src/packages/searchbar/demos/taro/demo4.tsx
@@ -10,7 +10,6 @@ const Demo4 = () => {
     <>
       <SearchBar left="文本" right="测试" onSearch={() => toastShow()} />
       <Toast
-        type="text"
         visible={show}
         content="search callback"
         onClose={() => {

--- a/src/packages/switch/demos/taro/demo2.tsx
+++ b/src/packages/switch/demos/taro/demo2.tsx
@@ -22,7 +22,6 @@ const Demo2 = () => {
         />
       </Cell>
       <Toast
-        type="text"
         content={`2秒后异步触发 ${value}`}
         visible={showToast}
         onClose={() => {

--- a/src/packages/switch/demos/taro/demo6.tsx
+++ b/src/packages/switch/demos/taro/demo6.tsx
@@ -20,7 +20,6 @@ const Demo6 = () => {
         />
       </Cell>
       <Toast
-        type="text"
         content={`触发了onChange事件，开关状态：${value}`}
         visible={showToast}
         onClose={() => {

--- a/src/packages/table/demo.taro.tsx
+++ b/src/packages/table/demo.taro.tsx
@@ -65,7 +65,6 @@ const TableDemo = () => {
       <Header />
       <ScrollView className={`demo ${Taro.getEnv() === 'WEB' ? 'web' : ''}`}>
         <Toast
-          type="text"
           visible={show}
           content={toastMsg}
           onClose={() => {

--- a/src/packages/toast/demos/taro/demo2.tsx
+++ b/src/packages/toast/demos/taro/demo2.tsx
@@ -13,7 +13,6 @@ const Demo5 = () => {
             title: '函数调用函数调用',
             content: '函数调用函数调用函数调用函数调用函数',
             duration: 2,
-            position: 'center',
             icon: <Jd color="#ffffff" />,
             lockScroll: true,
             onClose: () => {

--- a/src/packages/toast/doc.taro.md
+++ b/src/packages/toast/doc.taro.md
@@ -68,7 +68,6 @@ import { Toast } from '@nutui/nutui-react-taro'
 | size | 文案尺寸，三选一 | `small` \| `base` \| `large` | `base` |
 | closeOnOverlayClick | 是否在点击遮罩层后关闭提示 | `boolean` | `false` |
 | lockScroll | 背景是否锁定 | `boolean` | `false` |
-| type | 弹框类型 可选值（text、success、fail、warn、loading） | `string` | `-` |
 | visible | 弹窗是否显示开关 | `boolean` | `false` |
 | wordBreak | 换行截断方式 | `normal \| break-all \| break-word ` | `break-all` |
 | onClose | 关闭时触发的事件 | `Function` | `null` |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 统一并简化了提示消息的展示，移除了额外的自定义选项，各示例现均采用默认配置，体验更加一致。
	- 部分示例中移除了不再必要的状态管理和逻辑，界面反馈更直观。
- **文档**
	- 更新了组件文档，移除了已废弃的提示类型说明，确保文档内容与最新实现一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->