### PR TITLE
docs: 补充web 设置 px 转 rem时的文档

### DIFF
--- a/src/sites/sites-react/doc/docs/react/start-react.en-US.md
+++ b/src/sites/sites-react/doc/docs/react/start-react.en-US.md
@@ -151,7 +151,7 @@ babel config：
 ## Usage Notes
 
 - NutUI-React is built on top of [react@^18.0.0](https://www.npmjs.com/package/react)
-- The CSS units used in the components are px. If your project requires rem units, you can use some tools for conversion, such as [webpack](https://www.webpackjs.com/) with the [px2rem-loader](https://www.npmjs.com/package/px2rem-loader), or the [postcss](https://github.com/postcss/postcss) plugin [postcss-plugin-px2rem](https://www.npmjs.com/package/postcss-plugin-px2rem). Be attention, when you want to change **px** to **rem**, you should set classnames about **NutUI** in the black list, e.g:
+- The CSS units used in the components are px. If your project requires rem units, you can use some tools for conversion, such as [webpack](https://www.webpackjs.com/) with the [px2rem-loader](https://www.npmjs.com/package/px2rem-loader), or the [postcss](https://github.com/postcss/postcss) plugin [postcss-plugin-px2rem](https://www.npmjs.com/package/postcss-plugin-px2rem). Be attention, when you want to change **px** to **rem**, you should set classnames about **NutUI** in the black list, such as:
 
 ```
 module.exports = {

--- a/src/sites/sites-react/doc/docs/react/start-react.en-US.md
+++ b/src/sites/sites-react/doc/docs/react/start-react.en-US.md
@@ -151,7 +151,18 @@ babel config：
 ## Usage Notes
 
 - NutUI-React is built on top of [react@^18.0.0](https://www.npmjs.com/package/react)
-- The CSS units used in the components are px. If your project requires rem units, you can use some tools for conversion, such as [webpack](https://www.webpackjs.com/) with the [px2rem-loader](https://www.npmjs.com/package/px2rem-loader), or the [postcss](https://github.com/postcss/postcss) plugin [postcss-plugin-px2rem](https://www.npmjs.com/package/postcss-plugin-px2rem).
+- The CSS units used in the components are px. If your project requires rem units, you can use some tools for conversion, such as [webpack](https://www.webpackjs.com/) with the [px2rem-loader](https://www.npmjs.com/package/px2rem-loader), or the [postcss](https://github.com/postcss/postcss) plugin [postcss-plugin-px2rem](https://www.npmjs.com/package/postcss-plugin-px2rem). Be attention, when you want to change **px** to **rem**, you should set classnames about **NutUI** in the black list, e.g:
+
+```
+module.exports = {
+  plugins: {
+    'postcss-pxtorem': {
+      propList: ['*'],
+      selectorBlackList: ['nut-'] // ignore items
+    }
+  }
+}
+```
 
 ## Templates
 

--- a/src/sites/sites-react/doc/docs/react/start-react.md
+++ b/src/sites/sites-react/doc/docs/react/start-react.md
@@ -151,7 +151,18 @@ babel 配置：
 ## 使用注意事项
 
 - NutUI-React 基于 [react@^18.0.0](https://www.npmjs.com/package/react) 构建
-- 组件 CSS 单位使用的是 **px**，如果你的项目中需要 **rem** 单位，可借助一些工具进行转换，比如 [webpack](https://www.webpackjs.com/) 的 [px2rem-loader](https://www.npmjs.com/package/px2rem-loader)、[postcss](https://github.com/postcss/postcss) 的 [postcss-plugin-px2rem](https://www.npmjs.com/package/postcss-plugin-px2rem) 插件等
+- 组件 CSS 单位使用的是 **px**，如果你的项目中需要 **rem** 单位，可借助一些工具进行转换，比如 [webpack](https://www.webpackjs.com/) 的 [px2rem-loader](https://www.npmjs.com/package/px2rem-loader)、[postcss](https://github.com/postcss/postcss) 的 [postcss-plugin-px2rem](https://www.npmjs.com/package/postcss-plugin-px2rem) 插件等。需要注意的是，在转化 **rem** 时，对 **NutUI** 相关的样式设置在黑名单里，如：
+
+```
+module.exports = {
+  plugins: {
+    'postcss-pxtorem': {
+      propList: ['*'],
+      selectorBlackList: ['nut-'] // 忽略类名
+    }
+  }
+}
+```
 
 ## 示例
 

--- a/src/sites/sites-react/doc/docs/taro/start-react.en-US.md
+++ b/src/sites/sites-react/doc/docs/taro/start-react.en-US.md
@@ -193,3 +193,23 @@ config = {
 ```
 
 :::
+
+#### 4、CSS units
+
+The CSS units used in the components are px. However, during the Taro compilation, Taro will help you perform size conversion operations on styles. It is important to note that you should add styles related to NutUI to the blacklist, such as:
+
+:::demo
+
+```js
+// config/index.js
+config = {
+  postcss: {
+    pxtransform: {
+      enable: true,
+      config: { selectorBlackList: ['nut-'] },
+    },
+  },
+}
+```
+
+:::

--- a/src/sites/sites-react/doc/docs/taro/start-react.md
+++ b/src/sites/sites-react/doc/docs/taro/start-react.md
@@ -197,3 +197,24 @@ config = {
 ```
 
 :::
+
+#### 4、样式单位转化
+
+组件 CSS 单位使用的是 **px**，但是在 `Taro` 编译时，Taro 会帮你对样式做尺寸转换操作，需要注意的是，要对 **NutUI** 相关的样式设置在黑名单里，如：
+
+:::demo
+
+```js
+// config/index.js
+config = {
+  postcss: {
+    pxtransform: {
+      enable: true,
+      // 包含 `nut-` 的类名选择器中的 px 单位不会被解析
+      config: { selectorBlackList: ['nut-'] },
+    },
+  },
+}
+```
+
+:::


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 更新了 NutUI-React 的 CSS 单位转换说明，新增提示：为避免将 NutUI 相关样式转换，从 px 到 rem 的过程中应在 PostCSS 配置中排除以 "nut-" 开头的选择器，并提供了配置示例。
  - 新增关于 Taro 中 CSS 单位使用的说明，强调在编译过程中需要将 NutUI 相关样式排除在转换之外，并提供了相关配置示例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->