### PR TITLE
fix(inputnumber): value 大于 max 图标应处于禁用态

### DIFF
--- a/src/packages/inputnumber/inputnumber.taro.tsx
+++ b/src/packages/inputnumber/inputnumber.taro.tsx
@@ -188,7 +188,8 @@ export const InputNumber: FunctionComponent<
           className={classNames(
             `${classPrefix}-icon ${classPrefix}-icon-minus`,
             {
-              [`${classPrefix}-icon-disabled`]: shadowValue === min || disabled,
+              [`${classPrefix}-icon-disabled`]:
+                Number(shadowValue) <= Number(min) || disabled,
             }
           )}
         />
@@ -214,7 +215,8 @@ export const InputNumber: FunctionComponent<
           className={classNames(
             `${classPrefix}-icon ${classPrefix}-icon-plus`,
             {
-              [`${classPrefix}-icon-disabled`]: shadowValue === max || disabled,
+              [`${classPrefix}-icon-disabled`]:
+                Number(shadowValue) >= Number(max) || disabled,
             }
           )}
         />

--- a/src/packages/inputnumber/inputnumber.tsx
+++ b/src/packages/inputnumber/inputnumber.tsx
@@ -185,7 +185,8 @@ export const InputNumber: FunctionComponent<
           className={classNames(
             `${classPrefix}-icon ${classPrefix}-icon-minus`,
             {
-              [`${classPrefix}-icon-disabled`]: shadowValue === min || disabled,
+              [`${classPrefix}-icon-disabled`]:
+                Number(shadowValue) <= Number(min) || disabled,
             }
           )}
         />
@@ -208,7 +209,8 @@ export const InputNumber: FunctionComponent<
           className={classNames(
             `${classPrefix}-icon ${classPrefix}-icon-plus`,
             {
-              [`${classPrefix}-icon-disabled`]: shadowValue === max || disabled,
+              [`${classPrefix}-icon-disabled`]:
+                Number(shadowValue) >= Number(max) || disabled,
             }
           )}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 调整了数字输入组件中加减按钮的禁用条件：当数值低于或等于最小值时，“减号”按钮会被禁用；当数值达到或超过最大值时，“加号”按钮会被禁用。这一改进确保组件操作更准确，防止用户超出预期范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->