### PR TITLE
feat(pagination): mode 默认值调整为 lite，与视觉默认类型保持一致

### DIFF
--- a/src/packages/pagination/doc.en-US.md
+++ b/src/packages/pagination/doc.en-US.md
@@ -76,7 +76,7 @@ Pass in a custom method through itemRender, parameters: `{ number: "page number"
 | --- | --- | --- | --- |
 | value | current page number, controlled value | `number` | `-` |
 | defaultValue | default page number, uncontrolled value | `number` | `1` |
-| mode | Display mode | `multi` \| `simple` \| `lite` | `multi` |
+| mode | Display mode | `multi` \| `simple` \| `lite` | `lite` |
 | prev | Customize previous page button content | `ReactNode` | `Previous` |
 | next | Customize next page button content | `ReactNode` | `Next` |
 | total | total | `number` | `50` |

--- a/src/packages/pagination/doc.md
+++ b/src/packages/pagination/doc.md
@@ -76,7 +76,7 @@ import { Pagination } from '@nutui/nutui-react'
 | --- | --- | --- | --- |
 | value | 当前页码，受控值，与 onChange 搭配使用 | `number` | `-` |
 | defaultValue | 默认页码，非受控 | `number` | `1` |
-| mode | 显示模式 | `multi` \| `simple` \| `lite` | `multi` |
+| mode | 显示模式 | `multi` \| `simple` \| `lite` | `lite` |
 | prev | 自定义上一页按钮内容 | `ReactNode` | `上一页` |
 | next | 自定义下一页按钮内容 | `ReactNode` | `下一页` |
 | total | 总记录数 | `number` | `50` |

--- a/src/packages/pagination/doc.taro.md
+++ b/src/packages/pagination/doc.taro.md
@@ -76,7 +76,7 @@ import { Pagination } from '@nutui/nutui-react-taro'
 | --- | --- | --- | --- |
 | value | 当前页码，受控值，与 onChange 搭配使用 | `number` | `-` |
 | defaultValue | 默认页码，非受控值 | `number` | `1` |
-| mode | 显示模式,可选值为：multi，simple, lite | `multi` \| `simple` \| `lite` | `multi` |
+| mode | 显示模式,可选值为：multi，simple, lite | `multi` \| `simple` \| `lite` | `lite` |
 | prev | 自定义上一页按钮内容 | `ReactNode` | `上一页` |
 | next | 自定义下一页按钮内容 | `ReactNode` | `下一页` |
 | total | 总记录数 | `number` | `50` |

--- a/src/packages/pagination/doc.zh-TW.md
+++ b/src/packages/pagination/doc.zh-TW.md
@@ -76,7 +76,7 @@ import { Pagination } from '@nutui/nutui-react'
 | --- | --- | --- | --- |
 | value | 當前頁碼，受控值，與 onChange 搭配使用 | `number` | `-` |
 | defaultValue | 默認頁碼，非受控 | `number` | `1` |
-| mode | 顯示模式 | `multi` \| `simple` \| `lite` | `multi` |
+| mode | 顯示模式 | `multi` \| `simple` \| `lite` | `lite` |
 | prev | 自定義上一頁按鈕內容 | `ReactNode` | `上一頁` |
 | next | 自定義下一頁按鈕內容 | `ReactNode` | `下一頁` |
 | total | 總記錄數 | `number` | `50` |

--- a/src/packages/pagination/pagination.taro.tsx
+++ b/src/packages/pagination/pagination.taro.tsx
@@ -11,7 +11,7 @@ import { TaroPaginationProps } from '@/types'
 const defaultProps = {
   ...ComponentDefaults,
   defaultValue: 1,
-  mode: 'multi',
+  mode: 'lite',
   prev: null,
   next: null,
   total: 50,

--- a/src/packages/pagination/pagination.tsx
+++ b/src/packages/pagination/pagination.tsx
@@ -9,7 +9,7 @@ import { WebPaginationProps } from '@/types'
 const defaultProps = {
   ...ComponentDefaults,
   defaultValue: 1,
-  mode: 'multi',
+  mode: 'lite',
   prev: null,
   next: null,
   total: 50,

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
@@ -132,6 +132,7 @@ plugins: [
 #### Pagination
 
 - `itemRender` 属性类型调整为：`(page: any, index: number) => ReactNode`
+- `mode` 属性默认值调整为 `lite`
 
 #### SideNavBar
 

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
@@ -132,6 +132,7 @@ plugins: [
 #### Pagination
 
 - `itemRender` 属性类型调整为：`(page: any, index: number) => ReactNode`
+- `mode` 属性默认值调整为 `lite`
 
 #### SideNavBar
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 分页组件默认展示模式已由“multi”调整为“lite”，提供更简洁的分页显示，仅显示当前页码和总页数。

- **文档更新**
  - 更新了所有相关文档和迁移指南，确保说明与新版分页显示方式保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->