### PR TITLE
feat(radio): 支持自定义icon的classname

### DIFF
--- a/src/packages/radio/__test__/radio.spec.tsx
+++ b/src/packages/radio/__test__/radio.spec.tsx
@@ -30,11 +30,29 @@ describe('radio', () => {
 
   test('radio custom icon', () => {
     const { container } = render(
-      <Radio icon={<Check />} activeIcon={<Check />}>
+      <Radio
+        icon={<Check className="test-class" />}
+        activeIcon={<Check className="test-active-class" />}
+      >
         自定义图标
       </Radio>
     )
-    expect(container.querySelector('.nut-icon')).toHaveClass('nut-icon-Check')
+    expect(container.querySelector('.nut-icon')).toHaveClass('test-class')
+  })
+
+  test('radio custom icon checked', () => {
+    const { container } = render(
+      <Radio
+        defaultChecked
+        icon={<Check className="test-class" />}
+        activeIcon={<Check className="test-active-class" />}
+      >
+        自定义图标
+      </Radio>
+    )
+    expect(container.querySelector('.nut-icon')).toHaveClass(
+      'test-active-class'
+    )
   })
 
   test('radioGroup onChange toBeCalled', () => {

--- a/src/packages/radio/radio.taro.tsx
+++ b/src/packages/radio/radio.taro.tsx
@@ -84,7 +84,7 @@ export const Radio: FC<
       return React.isValidElement(activeIcon) ? (
         React.cloneElement<any>(activeIcon, {
           ...activeIcon.props,
-          className: classNames(color()),
+          className: classNames(activeIcon.props.className, color()),
         })
       ) : (
         <CheckChecked className={classNames(color())} />
@@ -93,7 +93,7 @@ export const Radio: FC<
     return React.isValidElement(icon) ? (
       React.cloneElement<any>(icon, {
         ...icon.props,
-        className: classNames(color()),
+        className: classNames(icon.props.className, color()),
       })
     ) : (
       <CheckNormal className={classNames(color())} />

--- a/src/packages/radio/radio.tsx
+++ b/src/packages/radio/radio.tsx
@@ -79,7 +79,7 @@ export const Radio: FunctionComponent<
       return React.isValidElement(activeIcon) ? (
         React.cloneElement<any>(activeIcon, {
           ...activeIcon.props,
-          className: classNames(color()),
+          className: classNames(activeIcon.props.className, color()),
         })
       ) : (
         <CheckChecked className={classNames(color())} />
@@ -88,7 +88,7 @@ export const Radio: FunctionComponent<
     return React.isValidElement(icon) ? (
       React.cloneElement<any>(icon, {
         ...icon.props,
-        className: classNames(color()),
+        className: classNames(icon.props.className, color()),
       })
     ) : (
       <CheckNormal className={classNames(color())} />


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了单选框图标的样式问题，现在在切换状态时会保留并合并原有的图标样式类，确保自定义图标的样式不会被覆盖。  
  - 增加了测试用例，验证单选框选中状态下自定义图标样式的正确应用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->