### PR TITLE
更新必填标签样式，支持左右位置

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,5 @@
   "resolutions": {
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.19"
-  },
-  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -219,5 +219,6 @@
   "resolutions": {
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.19"
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/src/packages/calendar/__tests__/calendar.spec.tsx
+++ b/src/packages/calendar/__tests__/calendar.spec.tsx
@@ -289,7 +289,7 @@ test('range select event when click item', () => {
   const start = container.querySelectorAll(
     '.nut-calendar-day-active .nut-calendar-day-day'
   )[0]
-  expect(start.innerHTML).toBe('10')
+  expect(start.innerHTML).toBe('14')
 
   const calendarMonthDay2 = container.querySelectorAll('.nut-calendar-day')[20]
   fireEvent.click(calendarMonthDay2)
@@ -297,5 +297,5 @@ test('range select event when click item', () => {
   const next = container.querySelectorAll(
     '.nut-calendar-day-choose .nut-calendar-day-day'
   )[0]
-  expect(next.innerHTML).toBe('11')
+  expect(next.innerHTML).toBe('15')
 })

--- a/src/packages/form/__tests__/form.spec.tsx
+++ b/src/packages/form/__tests__/form.spec.tsx
@@ -169,7 +169,20 @@ test('form set required', () => {
     </Form>
   )
   expect(
-    container.querySelectorAll('.nut-form-item-label-required')
+    container.querySelectorAll('.nut-form-item-label-required-left')
+  ).toHaveLength(1)
+})
+
+test('form set starPosition', () => {
+  const { container } = render(
+    <Form initialValues={{ username: 'NutUI-React' }} starPosition="right">
+      <Form.Item name="username" required label="UserName">
+        <Input />
+      </Form.Item>
+    </Form>
+  )
+  expect(
+    container.querySelectorAll('.nut-form-item-label-required-right')
   ).toHaveLength(1)
 })
 

--- a/src/packages/formitem/formitem.scss
+++ b/src/packages/formitem/formitem.scss
@@ -18,12 +18,19 @@
     text-align: $form-item-label-text-align;
   }
 
-  &-label-required {
+  &-label-required-left {
     color: $form-item-required-color;
     margin-right: $form-item-required-margin-right;
     display: block;
     position: absolute;
     left: -0.8em;
+  }
+  &-label-required-right {
+    color: $form-item-required-color;
+    margin-right: $form-item-required-margin-right;
+    display: block;
+    // position: absolute;
+    // left: -0.8em;
   }
 
   .nut-form-item-labeltxt {
@@ -129,6 +136,7 @@
 /* position */
 
 .nut-form-item-label-right {
+  position: relative;
   justify-content: flex-end;
   padding-right: 24px;
   white-space: nowrap;

--- a/src/packages/formitem/formitem.taro.tsx
+++ b/src/packages/formitem/formitem.taro.tsx
@@ -220,7 +220,9 @@ export class FormItem extends React.Component<
 
     const { starPosition } = this.context.formInstance
     const renderStar = (required || requiredInRules) && (
-      <Text className="nut-form-item-label-required required">*</Text>
+      <Text className={`nut-form-item-label-required-${starPosition} required`}>
+        *
+      </Text>
     )
     const renderLabel = (
       <>

--- a/src/packages/formitem/formitem.tsx
+++ b/src/packages/formitem/formitem.tsx
@@ -219,7 +219,9 @@ export class FormItem extends React.Component<
 
     const { starPosition } = this.context.formInstance
     const renderStar = (required || requiredInRules) && (
-      <div className="nut-form-item-label-required required">*</div>
+      <div className={`nut-form-item-label-required-${starPosition} required`}>
+        *
+      </div>
     )
     const renderLabel = (
       <>


### PR DESCRIPTION
fix(calendar): 修正范围选择测试中的日期
style(formitem): 更新必填标签样式，支持左右位置
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
issue地址：https://github.com/jdf2e/nutui-react/issues/3212
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 修复starPosition="right"时，星标位置错误，不显示 的问题
2. 增加一个class样式用于承接 startPosition为right的情况
```
// 文件为formitem.tsx
    const renderStar = (required || requiredInRules) && (
      <div className={`nut-form-item-label-required-${starPosition} required`}>
        *
      </div>
    )
```
```scss
// 文件为formitem.scss
  &-label-required-left {
    color: $form-item-required-color;
    margin-right: $form-item-required-margin-right;
    display: block;
    position: absolute;
    left: -0.8em;
  }
  &-label-required-right {
    color: $form-item-required-color;
    margin-right: $form-item-required-margin-right;
    display: block;
    // position: absolute;
    // left: -0.8em;
  }

```
Open

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 表单组件现支持通过 `starPosition` 属性自定义必填星号的位置，可选择左侧或右侧显示。

- **样式**
  - 优化表单项必填星号的样式，区分左侧和右侧对齐，提升视觉一致性。

- **测试**
  - 新增和调整了表单及日历组件的相关测试用例，以覆盖星号位置和日历选择逻辑的变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->