### PR TITLE
feat(Textarea): 增加 ref 属性

### DIFF
--- a/src/packages/input/doc.en-US.md
+++ b/src/packages/input/doc.en-US.md
@@ -148,6 +148,17 @@ import { Input } from '@nutui/nutui-react'
 | onClear | Triggered when the clear button is clicked | `(value: string) => void` | `-` |
 | onClick | Triggered when the input container is clicked | `(value: MouseEvent<HTMLDivElement>) => void` | `-` |
 
+### Ref
+
+You can get Ref of Input.
+
+| Event | Description | Arguments |
+| --- | --- | --- |
+| clear | clear the value of input | `-` |
+| focus | focus the input | `-` |
+| blur | blur the input | `-` |
+| get | get the input ref | `-` |
+
 ## Theming
 
 ### CSS Variables

--- a/src/packages/input/doc.md
+++ b/src/packages/input/doc.md
@@ -151,6 +151,17 @@ import { Input } from '@nutui/nutui-react'
 
 此外还支持以下原生属性：`onCompositionStart` `onCompositionEnd`
 
+### Ref
+
+通过 ref 可以获取到 Input 实例并调用实例方法。
+
+| 方法名 | 说明 | 参数 |
+| --- | --- | --- |
+| clear | 清除容器中的数据 | `-` |
+| focus | 使容器获取焦点 | `-` |
+| blur | 使容器失去焦点 | `-` |
+| get | 获取当前容器 | `-` |
+
 ## 主题定制
 
 ### 样式变量

--- a/src/packages/input/doc.taro.md
+++ b/src/packages/input/doc.taro.md
@@ -151,6 +151,17 @@ import { Input } from '@nutui/nutui-react-taro'
 
 此外还支持 Taro 中的 [Input 属性](https://docs.taro.zone/docs/components/forms/input/)
 
+### Ref
+
+通过 ref 可以获取到 Input 实例并调用实例方法。
+
+| 方法名 | 说明 | 参数 |
+| --- | --- | --- |
+| clear | 清除容器中的数据 | `-` |
+| focus | 使容器获取焦点 | `-` |
+| blur | 使容器失去焦点 | `-` |
+| get | 获取当前容器 | `-` |
+
 ## 主题定制
 
 ### 样式变量

--- a/src/packages/input/doc.zh-TW.md
+++ b/src/packages/input/doc.zh-TW.md
@@ -148,6 +148,17 @@ import { Input } from '@nutui/nutui-react'
 | onClear | 点击清空按钮时触发 | `(value: string) => void` | `-` |
 | onClick | 点击 input 容器触发 | `(value: MouseEvent<HTMLDivElement>) => void` | `-` |
 
+### Ref
+
+通過 ref 可以獲取到 Input 實例並調用實例方法。
+
+| 方法名 | 說明 | 參數 |
+| --- | --- | --- |
+| clear | 清除容器中的數據 | `-` |
+| focus | 使容器獲取焦點 | `-` |
+| blur | 使容器失去焦點 | `-` |
+| get | 獲取當前容器 | `-` |
+
 ## 主题定制
 
 ### 样式变量

--- a/src/packages/input/input.taro.tsx
+++ b/src/packages/input/input.taro.tsx
@@ -88,6 +88,7 @@ export const Input = forwardRef((props: Partial<TaroInputProps>, ref) => {
       blur: () => {
         inputRef.current?.blur()
       },
+      get: () => inputRef.current,
       get nativeElement() {
         return inputRef.current
       },

--- a/src/packages/input/input.tsx
+++ b/src/packages/input/input.tsx
@@ -85,6 +85,7 @@ export const Input = forwardRef(
       clear: () => setValue(''),
       focus: () => inputRef.current?.focus(),
       blur: () => inputRef.current?.blur(),
+      get: () => inputRef.current,
       get nativeElement() {
         return inputRef.current
       },

--- a/src/packages/textarea/doc.en-US.md
+++ b/src/packages/textarea/doc.en-US.md
@@ -95,6 +95,17 @@ import { TextArea } from '@nutui/nutui-react'
 | onFocus | Triggered when focusing | `(event: FocusEvent<HTMLTextAreaElement>) => void` | `-` |
 | onBlur | Triggered when out of focus | `(event: FocusEvent<HTMLTextAreaElement>) => void` | `-` |
 
+### Ref
+
+You can get Ref of Textarea.
+
+| Event | Description | Arguments |
+| --- | --- | --- |
+| clear | clear the value of textarea | `-` |
+| focus | focus the textarea | `-` |
+| blur | blur the textarea | `-` |
+| get | get the textarea ref | `-` |
+
 ## Theming
 
 ### CSS Variables

--- a/src/packages/textarea/doc.en-US.md
+++ b/src/packages/textarea/doc.en-US.md
@@ -104,7 +104,7 @@ You can get Ref of Textarea.
 | clear | clear the value of textarea | `-` |
 | focus | focus the textarea | `-` |
 | blur | blur the textarea | `-` |
-| get | get the textarea ref | `-` |
+| nativeElement | get the textarea ref | `-` |
 
 ## Theming
 

--- a/src/packages/textarea/doc.md
+++ b/src/packages/textarea/doc.md
@@ -95,6 +95,17 @@ import { TextArea } from '@nutui/nutui-react'
 | onFocus | 聚焦时触发 | `(event: FocusEvent<HTMLTextAreaElement>) => void` | `-` |
 | onBlur | 失焦时触发 | `(event: FocusEvent<HTMLTextAreaElement>) => void` | `-` |
 
+### Ref
+
+通过 ref 可以获取到 Textarea 实例并调用实例方法。
+
+| 方法名 | 说明 | 参数 |
+| --- | --- | --- |
+| clear | 清除容器中的数据 | `-` |
+| focus | 使容器获取焦点 | `-` |
+| blur | 使容器失去焦点 | `-` |
+| get | 获取当前容器 | `-` |
+
 ## 主题定制
 
 ### 样式变量

--- a/src/packages/textarea/doc.md
+++ b/src/packages/textarea/doc.md
@@ -104,7 +104,7 @@ import { TextArea } from '@nutui/nutui-react'
 | clear | 清除容器中的数据 | `-` |
 | focus | 使容器获取焦点 | `-` |
 | blur | 使容器失去焦点 | `-` |
-| get | 获取当前容器 | `-` |
+| nativeElement | 获取当前容器 | `-` |
 
 ## 主题定制
 

--- a/src/packages/textarea/doc.taro.md
+++ b/src/packages/textarea/doc.taro.md
@@ -95,6 +95,17 @@ import { TextArea } from '@nutui/nutui-react-taro'
 | onFocus | 聚焦时触发 | `(event) => void` | `-` |
 | onBlur | 失焦时触发 | `(event) => void` | `-` |
 
+### Ref
+
+通过 ref 可以获取到 Textarea 实例并调用实例方法。
+
+| 方法名 | 说明 | 参数 |
+| --- | --- | --- |
+| clear | 清除容器中的数据 | `-` |
+| focus | 使容器获取焦点 | `-` |
+| blur | 使容器失去焦点 | `-` |
+| get | 获取当前容器 | `-` |
+
 ## 主题定制
 
 ### 样式变量

--- a/src/packages/textarea/doc.taro.md
+++ b/src/packages/textarea/doc.taro.md
@@ -104,7 +104,7 @@ import { TextArea } from '@nutui/nutui-react-taro'
 | clear | 清除容器中的数据 | `-` |
 | focus | 使容器获取焦点 | `-` |
 | blur | 使容器失去焦点 | `-` |
-| get | 获取当前容器 | `-` |
+| nativeElement | 获取当前容器 | `-` |
 
 ## 主题定制
 

--- a/src/packages/textarea/doc.zh-TW.md
+++ b/src/packages/textarea/doc.zh-TW.md
@@ -103,7 +103,7 @@ import { TextArea } from '@nutui/nutui-react'
 | clear | 清除容器中的數據 | `-` |
 | focus | 使容器獲取焦點 | `-` |
 | blur | 使容器失去焦點 | `-` |
-| get | 獲取當前容器 | `-` |
+| nativeElement | 獲取當前容器 | `-` |
 
 ## 主題定制
 

--- a/src/packages/textarea/doc.zh-TW.md
+++ b/src/packages/textarea/doc.zh-TW.md
@@ -94,6 +94,17 @@ import { TextArea } from '@nutui/nutui-react'
 | onFocus | 聚焦時觸發 | `(event) => void` | `-` |
 | onBlur | 失焦時觸發 | `(event) => void` | `-` |
 
+### Ref
+
+通過 ref 可以獲取到 Textarea 實例並調用實例方法。
+
+| 方法名 | 說明 | 參數 |
+| --- | --- | --- |
+| clear | 清除容器中的數據 | `-` |
+| focus | 使容器獲取焦點 | `-` |
+| blur | 使容器失去焦點 | `-` |
+| get | 獲取當前容器 | `-` |
+
 ## 主題定制
 
 ### 樣式變量

--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -89,7 +89,6 @@ export const TextArea = forwardRef((props: Partial<TaroTextAreaProps>, ref) => {
       },
       focus: () => textareaRef.current?.focus(),
       blur: () => textareaRef.current?.blur(),
-      get: () => textareaRef.current,
       get nativeElement() {
         return textareaRef.current
       },

--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -87,12 +87,9 @@ export const TextArea = forwardRef((props: Partial<TaroTextAreaProps>, ref) => {
       clear: () => {
         setInnerValue('')
       },
-      focus: () => {
-        textareaRef.current?.focus()
-      },
-      blur: () => {
-        textareaRef.current?.blur()
-      },
+      focus: () => textareaRef.current?.focus(),
+      blur: () => textareaRef.current?.blur(),
+      get: () => textareaRef.current,
       get nativeElement() {
         return textareaRef.current
       },

--- a/src/packages/textarea/textarea.taro.tsx
+++ b/src/packages/textarea/textarea.taro.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useRef } from 'react'
+import React, { forwardRef, useRef, useImperativeHandle } from 'react'
 import classNames from 'classnames'
 import Taro from '@tarojs/taro'
 import { BaseEventOrig, Textarea, View } from '@tarojs/components'
@@ -19,9 +19,7 @@ const defaultProps = {
   plain: false,
   status: 'default',
 } as TaroTextAreaProps
-export const TextArea: FunctionComponent<Partial<TaroTextAreaProps>> = (
-  props
-) => {
+export const TextArea = forwardRef((props: Partial<TaroTextAreaProps>, ref) => {
   const { locale } = useConfig()
   const {
     className,
@@ -54,20 +52,21 @@ export const TextArea: FunctionComponent<Partial<TaroTextAreaProps>> = (
     return value
   }
 
-  const [inputValue, setInputValue] = usePropsValue<string>({
+  const [innerValue, setInnerValue] = usePropsValue<string>({
     value,
     defaultValue,
     finalValue: format(defaultValue),
     onChange,
   })
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const handleChange = (event: BaseEventOrig) => {
     const text = event?.detail?.value
     if (text) {
       const value = compositionRef.current ? text : format(text)
-      setInputValue(value)
+      setInnerValue(value)
     } else {
-      setInputValue('')
+      setInnerValue('')
     }
   }
 
@@ -82,6 +81,23 @@ export const TextArea: FunctionComponent<Partial<TaroTextAreaProps>> = (
     if (isDisabled()) return
     onBlur?.(event)
   }
+
+  useImperativeHandle(ref, () => {
+    return {
+      clear: () => {
+        setInnerValue('')
+      },
+      focus: () => {
+        textareaRef.current?.focus()
+      },
+      blur: () => {
+        textareaRef.current?.blur()
+      },
+      get nativeElement() {
+        return textareaRef.current
+      },
+    }
+  })
 
   return (
     <>
@@ -101,6 +117,7 @@ export const TextArea: FunctionComponent<Partial<TaroTextAreaProps>> = (
       >
         <Textarea
           {...rest}
+          ref={textareaRef}
           nativeProps={{
             style,
             readOnly,
@@ -118,7 +135,7 @@ export const TextArea: FunctionComponent<Partial<TaroTextAreaProps>> = (
           style={Taro.getEnv() === 'WEB' ? undefined : style}
           disabled={Taro.getEnv() === 'WEB' ? disabled : disabled || readOnly}
           // @ts-ignore
-          value={inputValue}
+          value={innerValue}
           onInput={handleChange}
           onBlur={handleBlur}
           onFocus={handleFocus}
@@ -134,12 +151,12 @@ export const TextArea: FunctionComponent<Partial<TaroTextAreaProps>> = (
               [`${classPrefix}-limit-disabled`]: disabled,
             })}
           >
-            {inputValue.length}/{maxLength < 0 ? 0 : maxLength}
+            {innerValue.length}/{maxLength < 0 ? 0 : maxLength}
           </View>
         )}
       </View>
     </>
   )
-}
+})
 
 TextArea.displayName = 'NutTextArea'

--- a/src/packages/textarea/textarea.tsx
+++ b/src/packages/textarea/textarea.tsx
@@ -1,5 +1,10 @@
 import type { ChangeEvent, FocusEvent } from 'react'
-import React, { FunctionComponent, useEffect, useRef } from 'react'
+import React, {
+  useEffect,
+  useRef,
+  forwardRef,
+  useImperativeHandle,
+} from 'react'
 import classNames from 'classnames'
 import { useConfig, useRtl } from '@/packages/configprovider'
 import { ComponentDefaults } from '@/utils/typings'
@@ -19,139 +24,152 @@ const defaultProps = {
   plain: false,
   status: 'default',
 } as WebTextAreaProps
-export const TextArea: FunctionComponent<
-  Partial<WebTextAreaProps> &
-    Omit<
-      React.HTMLAttributes<HTMLTextAreaElement>,
-      'onChange' | 'onBlur' | 'onFocus'
-    >
-> = (props) => {
-  const { locale } = useConfig()
-  const {
-    className,
-    value,
-    defaultValue,
-    showCount,
-    maxLength,
-    rows,
-    placeholder,
-    readOnly,
-    disabled,
-    autoSize,
-    style,
-    plain,
-    status,
-    onChange,
-    onBlur,
-    onFocus,
-    ...rest
-  } = { ...defaultProps, ...props }
 
-  const classPrefix = 'nut-textarea'
-  const textareaRef = useRef<any>(null)
-  const compositionRef = useRef(false)
-  const rtl = useRtl()
+export const TextArea = forwardRef(
+  (
+    props: Partial<WebTextAreaProps> &
+      Omit<
+        React.HTMLAttributes<HTMLTextAreaElement>,
+        'onChange' | 'onBlur' | 'onFocus'
+      >,
+    ref
+  ) => {
+    const { locale } = useConfig()
+    const {
+      className,
+      value,
+      defaultValue,
+      showCount,
+      maxLength,
+      rows,
+      placeholder,
+      readOnly,
+      disabled,
+      autoSize,
+      style,
+      plain,
+      status,
+      onChange,
+      onBlur,
+      onFocus,
+      ...rest
+    } = { ...defaultProps, ...props }
 
-  const format = (value: string) => {
-    if (maxLength !== -1 && value.length > maxLength) {
-      return value.substring(0, maxLength)
+    const classPrefix = 'nut-textarea'
+    const textareaRef = useRef<any>(null)
+    const compositionRef = useRef(false)
+    const rtl = useRtl()
+
+    const format = (value: string) => {
+      if (maxLength !== -1 && value.length > maxLength) {
+        return value.substring(0, maxLength)
+      }
+      return value
     }
-    return value
-  }
 
-  const [inputValue, setInputValue] = usePropsValue<string>({
-    value,
-    defaultValue,
-    finalValue: format(defaultValue),
-    onChange,
-  })
+    const [innerValue, setInnerValue] = usePropsValue<string>({
+      value,
+      defaultValue,
+      finalValue: format(defaultValue),
+      onChange,
+    })
 
-  useEffect(() => {
-    if (autoSize) setContentHeight()
-  }, [autoSize, defaultValue, inputValue])
+    useEffect(() => {
+      if (autoSize) setContentHeight()
+    }, [autoSize, defaultValue, innerValue])
 
-  const setContentHeight = () => {
-    const textarea: any = textareaRef.current
-    if (textarea) {
-      textarea.style.height = 'auto'
-      const height = textarea?.scrollHeight
-      if (height) {
-        textarea.style.height = `${height}px`
+    const setContentHeight = () => {
+      const textarea: any = textareaRef.current
+      if (textarea) {
+        textarea.style.height = 'auto'
+        const height = textarea?.scrollHeight
+        if (height) {
+          textarea.style.height = `${height}px`
+        }
       }
     }
-  }
 
-  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    const text = event.target
-    const value = compositionRef.current ? text.value : format(text.value)
-    setInputValue(value)
-  }
+    const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const text = event.target
+      const value = compositionRef.current ? text.value : format(text.value)
+      setInnerValue(value)
+    }
 
-  const isDisabled = () => disabled || readOnly
+    const isDisabled = () => disabled || readOnly
 
-  const handleFocus = (event: FocusEvent<HTMLTextAreaElement>) => {
-    if (isDisabled()) return
-    onFocus?.(event)
-  }
+    const handleFocus = (event: FocusEvent<HTMLTextAreaElement>) => {
+      if (isDisabled()) return
+      onFocus?.(event)
+    }
 
-  const handleBlur = (event: FocusEvent<HTMLTextAreaElement>) => {
-    if (isDisabled()) return
-    onBlur?.(event)
-  }
+    const handleBlur = (event: FocusEvent<HTMLTextAreaElement>) => {
+      if (isDisabled()) return
+      onBlur?.(event)
+    }
 
-  return (
-    <>
-      <div
-        className={classNames(
-          classPrefix,
-          {
-            [`${classPrefix}-disabled`]: disabled,
-            [`${classPrefix}-readonly`]: readOnly,
-            [`${classPrefix}-rtl`]: rtl,
-            [`${classPrefix}-plain`]: plain,
-            [`${classPrefix}-container`]: !plain,
-            [`${classPrefix}-${status}`]: status,
-          },
-          className
-        )}
-      >
-        <textarea
-          {...rest}
-          ref={textareaRef}
-          className={classNames(`${classPrefix}-textarea`, {
-            [`${classPrefix}-textarea-disabled`]: disabled,
-          })}
-          style={style}
-          disabled={disabled}
-          readOnly={readOnly}
-          value={inputValue}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          onFocus={handleFocus}
-          onCompositionEnd={() => {
-            compositionRef.current = false
-          }}
-          onCompositionStart={() => {
-            compositionRef.current = true
-          }}
-          rows={rows}
-          maxLength={maxLength === -1 ? undefined : maxLength}
-          placeholder={
-            placeholder !== undefined ? placeholder : locale.placeholder
-          }
-        />
-        {showCount && (
-          <div
-            className={classNames(`${classPrefix}-limit`, {
-              [`${classPrefix}-limit-disabled`]: disabled,
+    useImperativeHandle(ref, () => ({
+      clear: () => setInnerValue(''),
+      focus: () => textareaRef.current?.focus(),
+      blur: () => textareaRef.current?.blur(),
+      get nativeElement() {
+        return textareaRef.current
+      },
+    }))
+
+    return (
+      <>
+        <div
+          className={classNames(
+            classPrefix,
+            {
+              [`${classPrefix}-disabled`]: disabled,
+              [`${classPrefix}-readonly`]: readOnly,
+              [`${classPrefix}-rtl`]: rtl,
+              [`${classPrefix}-plain`]: plain,
+              [`${classPrefix}-container`]: !plain,
+              [`${classPrefix}-${status}`]: status,
+            },
+            className
+          )}
+        >
+          <textarea
+            {...rest}
+            ref={textareaRef}
+            className={classNames(`${classPrefix}-textarea`, {
+              [`${classPrefix}-textarea-disabled`]: disabled,
             })}
-          >
-            {inputValue.length}/{maxLength < 0 ? 0 : maxLength}
-          </div>
-        )}
-      </div>
-    </>
-  )
-}
+            style={style}
+            disabled={disabled}
+            readOnly={readOnly}
+            value={innerValue}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            onFocus={handleFocus}
+            onCompositionEnd={() => {
+              compositionRef.current = false
+            }}
+            onCompositionStart={() => {
+              compositionRef.current = true
+            }}
+            rows={rows}
+            maxLength={maxLength === -1 ? undefined : maxLength}
+            placeholder={
+              placeholder !== undefined ? placeholder : locale.placeholder
+            }
+          />
+          {showCount && (
+            <div
+              className={classNames(`${classPrefix}-limit`, {
+                [`${classPrefix}-limit-disabled`]: disabled,
+              })}
+            >
+              {innerValue.length}/{maxLength < 0 ? 0 : maxLength}
+            </div>
+          )}
+        </div>
+      </>
+    )
+  }
+)
 
 TextArea.displayName = 'NutTextArea'

--- a/src/packages/textarea/textarea.tsx
+++ b/src/packages/textarea/textarea.tsx
@@ -111,7 +111,6 @@ export const TextArea = forwardRef(
       clear: () => setInnerValue(''),
       focus: () => textareaRef.current?.focus(),
       blur: () => textareaRef.current?.blur(),
-      get: () => textareaRef.current,
       get nativeElement() {
         return textareaRef.current
       },

--- a/src/packages/textarea/textarea.tsx
+++ b/src/packages/textarea/textarea.tsx
@@ -111,6 +111,7 @@ export const TextArea = forwardRef(
       clear: () => setInnerValue(''),
       focus: () => textareaRef.current?.focus(),
       blur: () => textareaRef.current?.blur(),
+      get: () => textareaRef.current,
       get nativeElement() {
         return textareaRef.current
       },

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
@@ -180,7 +180,7 @@ If your project uses these components, please read the documentation carefully a
 
 - Added a plain attribute to mark it as a plain text type. The default value is false, indicating it is a container type.
 - Added a status attribute, with possible values of default | error, to define the state of the input box.
-- Add `ref`，and apis `clear` `focus` `blur` `get`.
+- Add `ref`，and apis `clear` `focus` `blur` `nativeElement`.
 - Removed some basic style variables and recommended using foundational style variables, such as $textarea-font, $textarea-limit-color, and $textarea-disabled-color.
 
 #### Uploader

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
@@ -180,6 +180,7 @@ If your project uses these components, please read the documentation carefully a
 
 - Added a plain attribute to mark it as a plain text type. The default value is false, indicating it is a container type.
 - Added a status attribute, with possible values of default | error, to define the state of the input box.
+- Add `ref`，and apis `clear` `focus` `blur` `get`.
 - Removed some basic style variables and recommended using foundational style variables, such as $textarea-font, $textarea-limit-color, and $textarea-disabled-color.
 
 #### Uploader

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
@@ -197,7 +197,7 @@ plugins: [
 
 - 新增 `plain` 属性，标记为 纯文本型；该值默认为false，标记为 container 容器型
 - 新增 `status` 属性，值为 `default` | `error`，可定义输入框的状态
-- 新增 `ref` 属性，支持 `clear` `focus` `blur` `get` 等方法
+- 新增 `ref` 属性，支持 `clear` `focus` `blur` `nativeElement` 等方法
 - 删掉一些可使用基础样式变量，并且建议使用基础样式变量的样式变量，比如 `$textarea-font` `$textarea-limit-color` `$textarea-disabled-color`
 
 #### Uploader

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
@@ -197,6 +197,7 @@ plugins: [
 
 - 新增 `plain` 属性，标记为 纯文本型；该值默认为false，标记为 container 容器型
 - 新增 `status` 属性，值为 `default` | `error`，可定义输入框的状态
+- 新增 `ref` 属性，支持 `clear` `focus` `blur` `get` 等方法
 - 删掉一些可使用基础样式变量，并且建议使用基础样式变量的样式变量，比如 `$textarea-font` `$textarea-limit-color` `$textarea-disabled-color`
 
 #### Uploader

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
@@ -180,7 +180,7 @@ If your project uses these components, please read the documentation carefully a
 
 - Added a plain attribute to mark it as a plain text type. The default value is false, indicating it is a container type.
 - Added a status attribute, with possible values of default | error, to define the state of the input box.
-- Add `ref`，and apis `clear` `focus` `blur` `get`.
+- Add `ref`，and apis `clear` `focus` `blur` `nativeElement`.
 - Removed some basic style variables and recommended using foundational style variables, such as $textarea-font, $textarea-limit-color, and $textarea-disabled-color.
 
 #### Uploader

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
@@ -180,6 +180,7 @@ If your project uses these components, please read the documentation carefully a
 
 - Added a plain attribute to mark it as a plain text type. The default value is false, indicating it is a container type.
 - Added a status attribute, with possible values of default | error, to define the state of the input box.
+- Add `ref`，and apis `clear` `focus` `blur` `get`.
 - Removed some basic style variables and recommended using foundational style variables, such as $textarea-font, $textarea-limit-color, and $textarea-disabled-color.
 
 #### Uploader

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
@@ -196,7 +196,7 @@ plugins: [
 
 - 新增 `plain` 属性，标记为 纯文本型；该值默认为false，标记为 container 容器型
 - 新增 `status` 属性，值为 `default` | `error`，可定义输入框的状态
-- 新增 `ref` 属性，支持 `clear` `focus` `blur` `get` 等方法
+- 新增 `ref` 属性，支持 `clear` `focus` `blur` `nativeElement` 等方法
 - 删掉一些可使用基础样式变量，并且建议使用基础样式变量的样式变量，比如 `$textarea-font` `$textarea-limit-color` `$textarea-disabled-color`
 
 #### Uploader

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
@@ -196,6 +196,7 @@ plugins: [
 
 - 新增 `plain` 属性，标记为 纯文本型；该值默认为false，标记为 container 容器型
 - 新增 `status` 属性，值为 `default` | `error`，可定义输入框的状态
+- 新增 `ref` 属性，支持 `clear` `focus` `blur` `get` 等方法
 - 删掉一些可使用基础样式变量，并且建议使用基础样式变量的样式变量，比如 `$textarea-font` `$textarea-limit-color` `$textarea-disabled-color`
 
 #### Uploader


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - TextArea 组件现支持通过 ref 调用 `clear`、`focus`、`blur` 和 `nativeElement` 方法，便于实现内容清空、聚焦、失焦及获取原生元素等操作。
  - Input 组件新增通过 ref 调用 `clear`、`focus`、`blur` 和 `get` 方法，提升交互控制能力。

- **文档**
  - Input 和 TextArea 组件文档新增 “Ref” 部分，详细说明如何通过 ref 使用实例方法。
  - 迁移指南文档补充了 TextArea 组件 ref 相关 API 的说明，便于从 v2 升级到 v3 的用户了解新特性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->