### PR TITLE
fix(uploader): 修复官网蒙层层级、demo中ListItem类型的引入并更新文档

### DIFF
--- a/src/packages/uploader/demos/h5/demo1.tsx
+++ b/src/packages/uploader/demos/h5/demo1.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem, Space } from '@nutui/nutui-react'
+import { Uploader, Cell, UploaderFileItem, Space } from '@nutui/nutui-react'
 import { Dongdong } from '@nutui/icons-react'
 
 const Demo1 = () => {
-  const [list, setList] = useState<FileItem[]>([
+  const [list, setList] = useState<UploaderFileItem[]>([
     {
       url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',
       uid: 133,
@@ -23,7 +23,7 @@ const Demo1 = () => {
       url: URL.createObjectURL(file),
     }
   }
-  async function uploadFail(file: File): Promise<FileItem> {
+  async function uploadFail(file: File): Promise<UploaderFileItem> {
     await sleep(2000)
     throw new Error('Fail to upload')
   }

--- a/src/packages/uploader/demos/h5/demo10.tsx
+++ b/src/packages/uploader/demos/h5/demo10.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
 import { Loading, Star } from '@nutui/icons-react'
-import { Uploader, Button, FileItem } from '@nutui/nutui-react'
+import { Uploader, Button, UploaderFileItem } from '@nutui/nutui-react'
 
 const Demo10 = () => {
-  const [list, setList] = useState<FileItem[]>([
+  const [list, setList] = useState<UploaderFileItem[]>([
     {
       name: '文件文件文件文件1文件文件文件文件1文件文件文件文件1.png',
       url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',

--- a/src/packages/uploader/demos/h5/demo2.tsx
+++ b/src/packages/uploader/demos/h5/demo2.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Uploader, FileItem } from '@nutui/nutui-react'
+import { Uploader, UploaderFileItem } from '@nutui/nutui-react'
 import { Dongdong, Loading, Star } from '@nutui/icons-react'
 
 const Demo2 = () => {
-  const defaultList: FileItem[] = [
+  const defaultList: UploaderFileItem[] = [
     {
       uid: 111,
       name: '文件文件文件文件1文件文件文件文件1文件文件文件文件1.png',
@@ -44,7 +44,7 @@ const Demo2 = () => {
       loadingIcon: <Loading className="nut-icon-Loading" color="#fff" />,
     },
   ]
-  const onDelete = (file: FileItem, fileList: FileItem[]) => {
+  const onDelete = (file: UploaderFileItem, fileList: UploaderFileItem[]) => {
     console.log('delete事件触发', file, fileList)
   }
   return (

--- a/src/packages/uploader/demos/h5/demo3.tsx
+++ b/src/packages/uploader/demos/h5/demo3.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem, Space } from '@nutui/nutui-react'
+import { Uploader, Cell, UploaderFileItem, Space } from '@nutui/nutui-react'
 
 const Demo3 = () => {
-  const [list, setList] = useState<FileItem[]>([])
+  const [list, setList] = useState<UploaderFileItem[]>([])
   function sleep(time: number) {
     return new Promise<void>((resolve) => {
       setTimeout(() => {

--- a/src/packages/uploader/demos/h5/demo4.tsx
+++ b/src/packages/uploader/demos/h5/demo4.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem } from '@nutui/nutui-react'
+import { Uploader, Cell, UploaderFileItem } from '@nutui/nutui-react'
 
 const Demo4 = () => {
-  const [list, setList] = useState<FileItem[]>([])
+  const [list, setList] = useState<UploaderFileItem[]>([])
   const onOversize = (files: File[]) => {
     console.log('oversize 触发 文件大小不能超过 50kb', files)
   }

--- a/src/packages/uploader/demos/h5/demo5.tsx
+++ b/src/packages/uploader/demos/h5/demo5.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem } from '@nutui/nutui-react'
+import { Uploader, Cell, UploaderFileItem } from '@nutui/nutui-react'
 
 const Demo5 = () => {
-  const [list, setList] = useState<FileItem[]>([])
+  const [list, setList] = useState<UploaderFileItem[]>([])
   const beforeUpload = async (files: File[]) => {
     const allowedTypes = ['image/png']
     const filteredFiles = Array.from(files).filter((file) =>

--- a/src/packages/uploader/demos/h5/demo7.tsx
+++ b/src/packages/uploader/demos/h5/demo7.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Uploader, Cell, FileItem } from '@nutui/nutui-react'
+import { Uploader, Cell, UploaderFileItem } from '@nutui/nutui-react'
 import { Dongdong, Star } from '@nutui/icons-react'
 
-const defaultFileList: FileItem[] = [
+const defaultFileList: UploaderFileItem[] = [
   {
     name: '文件文件文件文件1文件文件文件文件1文件文件文件文件1.png',
     url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',

--- a/src/packages/uploader/demos/taro/demo1.tsx
+++ b/src/packages/uploader/demos/taro/demo1.tsx
@@ -1,12 +1,17 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem, Space } from '@nutui/nutui-react-taro'
+import {
+  Uploader,
+  Cell,
+  UploaderFileItem,
+  Space,
+} from '@nutui/nutui-react-taro'
 import { Dongdong } from '@nutui/icons-react-taro'
 
 const Demo1 = () => {
   const demoUrl =
     'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif'
 
-  const [list, setList] = useState<FileItem[]>([
+  const [list, setList] = useState<UploaderFileItem[]>([
     {
       url: demoUrl,
       uid: 133,
@@ -24,7 +29,7 @@ const Demo1 = () => {
     await sleep(2000)
     return { url: demoUrl }
   }
-  async function uploadFail(file: File): Promise<FileItem> {
+  async function uploadFail(file: File): Promise<UploaderFileItem> {
     await sleep(2000)
     throw new Error('Fail to upload')
   }

--- a/src/packages/uploader/demos/taro/demo10.tsx
+++ b/src/packages/uploader/demos/taro/demo10.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
 import { Loading, Star } from '@nutui/icons-react'
-import { Uploader, Button, FileItem } from '@nutui/nutui-react-taro'
+import { Uploader, Button, UploaderFileItem } from '@nutui/nutui-react-taro'
 
 const Demo10 = () => {
-  const [list, setList] = useState<FileItem[]>([
+  const [list, setList] = useState<UploaderFileItem[]>([
     {
       name: '文件文件文件文件1文件文件文件文件1文件文件文件文件1.png',
       url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',

--- a/src/packages/uploader/demos/taro/demo2.tsx
+++ b/src/packages/uploader/demos/taro/demo2.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Uploader, FileItem } from '@nutui/nutui-react-taro'
+import { Uploader, UploaderFileItem } from '@nutui/nutui-react-taro'
 import { Dongdong, Loading, Star } from '@nutui/icons-react-taro'
 
 const Demo2 = () => {
-  const defaultList: FileItem[] = [
+  const defaultList: UploaderFileItem[] = [
     {
       uid: 111,
       name: '文件文件文件文件1文件文件文件文件1文件文件文件文件1.png',
@@ -44,7 +44,7 @@ const Demo2 = () => {
       loadingIcon: <Loading className="nut-icon-Loading" color="#fff" />,
     },
   ]
-  const onDelete = (file: FileItem, fileList: FileItem[]) => {
+  const onDelete = (file: UploaderFileItem, fileList: UploaderFileItem[]) => {
     console.log('delete事件触发', file, fileList)
   }
   return (

--- a/src/packages/uploader/demos/taro/demo3.tsx
+++ b/src/packages/uploader/demos/taro/demo3.tsx
@@ -1,11 +1,16 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem, Space } from '@nutui/nutui-react-taro'
+import {
+  Uploader,
+  Cell,
+  UploaderFileItem,
+  Space,
+} from '@nutui/nutui-react-taro'
 
 const Demo3 = () => {
   const demoUrl =
     'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif'
 
-  const [list, setList] = useState<FileItem[]>([])
+  const [list, setList] = useState<UploaderFileItem[]>([])
   function sleep(time: number) {
     return new Promise<void>((resolve) => {
       setTimeout(() => {

--- a/src/packages/uploader/demos/taro/demo4.tsx
+++ b/src/packages/uploader/demos/taro/demo4.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem } from '@nutui/nutui-react-taro'
+import { Uploader, Cell, UploaderFileItem } from '@nutui/nutui-react-taro'
 
 const Demo4 = () => {
   const demoUrl =
     'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif'
 
-  const [list, setList] = useState<FileItem[]>([])
+  const [list, setList] = useState<UploaderFileItem[]>([])
 
   function sleep(time: number) {
     return new Promise<void>((resolve) => {

--- a/src/packages/uploader/demos/taro/demo5.tsx
+++ b/src/packages/uploader/demos/taro/demo5.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import { Uploader, Cell, FileItem } from '@nutui/nutui-react-taro'
+import { Uploader, Cell, UploaderFileItem } from '@nutui/nutui-react-taro'
 
 const Demo5 = () => {
-  const [list, setList] = useState<FileItem[]>([])
+  const [list, setList] = useState<UploaderFileItem[]>([])
   const beforeUpload = async (files: File[]) => {
     const allowedTypes = ['image/png']
     const filteredFiles = Array.from(files).filter((file) =>

--- a/src/packages/uploader/demos/taro/demo7.tsx
+++ b/src/packages/uploader/demos/taro/demo7.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Uploader, Cell, FileItem } from '@nutui/nutui-react-taro'
+import { Uploader, Cell, UploaderFileItem } from '@nutui/nutui-react-taro'
 import { Dongdong, Star } from '@nutui/icons-react-taro'
 
-const defaultFileList: FileItem[] = [
+const defaultFileList: UploaderFileItem[] = [
   {
     name: '文件文件文件文件1文件文件文件文件1文件文件文件文件1.png',
     url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',

--- a/src/packages/uploader/doc.taro.md
+++ b/src/packages/uploader/doc.taro.md
@@ -66,7 +66,7 @@ import { Uploader } from '@nutui/nutui-react-taro'
 
 :::
 
-### 选中文件后，通过按钮手动执行上传
+### 直接调起摄像头（移动端生效）
 
 :::demo
 
@@ -74,11 +74,19 @@ import { Uploader } from '@nutui/nutui-react-taro'
 
 :::
 
-### 基础用法-上传列表展示
+### 选中文件后，通过按钮手动执行上传
 
 :::demo
 
 <CodeBlock src='taro/demo9.tsx'></CodeBlock>
+
+:::
+
+### 基础用法-上传列表展示
+
+:::demo
+
+<CodeBlock src='taro/demo10.tsx'></CodeBlock>
 
 :::
 

--- a/src/packages/uploader/uploader.scss
+++ b/src/packages/uploader/uploader.scss
@@ -87,6 +87,7 @@
       height: 100%;
       background: $uploader-preview-progress-background;
       border-radius: $uploader-image-border-radius;
+      z-index: 10;
 
       i {
         margin-bottom: $uploader-image-icon-margin-bottom;


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
  - Uploader 相关演示组件的类型由 `FileItem` 统一调整为 `UploaderFileItem`，以提升类型一致性和规范性。
  - 部分演示组件的回调参数类型同步更新，无影响实际功能和界面表现。
- **文档**
  - Taro 环境下的 uploader 组件文档中演示示例顺序和标题进行了调整和细分，提升文档结构清晰度。
- **样式**
  - 优化了上传预览进度条的层级显示，确保进度覆盖层正确显示于其他元素之上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->