### PR TITLE
fix(noticebar): first item is not visible when scrolling vertically

### DIFF
--- a/src/packages/noticebar/__test__/noticebar.spec.tsx
+++ b/src/packages/noticebar/__test__/noticebar.spec.tsx
@@ -220,3 +220,43 @@ test('vertical event test', async () => {
   fireEvent.click(box)
   await waitFor(() => expect(handleClick).toBeCalled())
 })
+
+test('vertical container height calculation with children', async () => {
+  const horseLamp1 = [
+    'NoticeBar 公告栏',
+    'Cascader 级联选择',
+    'DatePicker 日期选择器',
+    'CheckBox 复选按钮',
+  ]
+  const height = 50
+  const { container } = render(
+    <NoticeBar direction="vertical" height={height} speed={10} duration={1000}>
+      {horseLamp1.map((item, index) => {
+        return (
+          <div
+            className="custom-item"
+            style={{ height: `${height}px`, lineHeight: `${height}px` }}
+            key={index}
+          >
+            {item}
+          </div>
+        )
+      })}
+    </NoticeBar>
+  )
+
+  await waitFor(
+    () => {
+      const wrapElement = container.querySelector('.nut-noticebar-box-wrap')
+      if (wrapElement) {
+        // 验证容器高度应该是 (childCount + 1) * height
+        // childCount = 4, height = 50, 所以期望高度是 (4 + 1) * 50 = 250px
+        const expectedHeight = `${(horseLamp1.length + 1) * height}px`
+        console.log(wrapElement, 'wrapElement')
+        expect(wrapElement).toHaveStyle(`height: ${expectedHeight}`)
+      }
+    },
+    // 由于init中并不会立刻设置样式，所以需要等待一段时间
+    { timeout: 3000 }
+  )
+})

--- a/src/packages/noticebar/noticebar.taro.tsx
+++ b/src/packages/noticebar/noticebar.taro.tsx
@@ -358,7 +358,7 @@ export const NoticeBar: FunctionComponent<
     target.style.transitionDuration = `${
       swiperRef.current.moving ? 0 : duration
     }ms`
-    target.style.height = `${Number(height) * childCount}px`
+    target.style.height = `${Number(height) * (childCount + 1)}px`
     target.style.transform = `translate3D(0,${_offset}px,0)`
   }
   // 无缝滚动第一个元素位移控制

--- a/src/packages/noticebar/noticebar.tsx
+++ b/src/packages/noticebar/noticebar.tsx
@@ -353,7 +353,7 @@ export const NoticeBar: FunctionComponent<
     target.style.transitionDuration = `${
       swiperRef.current.moving ? 0 : duration
     }ms`
-    target.style.height = `${Number(height) * childCount}px`
+    target.style.height = `${Number(height) * (childCount + 1)}px`
     target.style.transform = `translate3D(0,${_offset}px,0)`
   }
   // 无缝滚动第一个元素位移控制


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/jdf2e/nutui-react/issues/1893
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
复现步骤：
官方文档的Demo中即可复现：NoticeBar 纵向模式：自定义滚动内容
解决方案：
1. 问题原因
![image](https://github.com/user-attachments/assets/f0c2d025-36ba-4c72-b298-78c41fd6a070)

代码中实现无限轮播是通过垂直偏移容器与第一项内容来实现的，但是这里忽略了一个点：当偏移第一项时，其实它已经不在容器中了，虽然在整个视图中它的位置是对的，但并不可见。

2. 解决方法
![image](https://github.com/user-attachments/assets/c026738a-08f6-4b29-a5fd-866c2a4bf175)

可以给容器加一列高度来处理第一项的偏移

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化了公告栏垂直滚动容器的高度计算，提升了滚动的流畅性和视觉连续性。  
- **Tests**
  - 新增公告栏垂直滚动容器高度计算的测试用例，确保样式应用准确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->