### PR TITLE
fix(tabs): correct tabpane-background-color css variables

### DIFF
--- a/src/packages/image/image.taro.tsx
+++ b/src/packages/image/image.taro.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, useCallback, useState } from 'react'
+import React, {
+  CSSProperties,
+  FunctionComponent,
+  useCallback,
+  useState,
+} from 'react'
 import Taro from '@tarojs/taro'
 import {
   Image as TImage,
@@ -54,6 +59,7 @@ export const Image: FunctionComponent<Partial<TaroImageProps>> = (props) => {
   }
 
   const containerStyle = {
+    ...(style as CSSProperties),
     ...(height ? { height: pxCheck(height) } : {}),
     ...(width ? { width: pxCheck(width) } : {}),
     ...(radius !== undefined && radius !== null

--- a/src/packages/image/image.taro.tsx
+++ b/src/packages/image/image.taro.tsx
@@ -1,9 +1,4 @@
-import React, {
-  CSSProperties,
-  FunctionComponent,
-  useCallback,
-  useState,
-} from 'react'
+import React, { FunctionComponent, useCallback, useState } from 'react'
 import Taro from '@tarojs/taro'
 import {
   Image as TImage,
@@ -59,7 +54,6 @@ export const Image: FunctionComponent<Partial<TaroImageProps>> = (props) => {
   }
 
   const containerStyle = {
-    ...(style as CSSProperties),
     ...(height ? { height: pxCheck(height) } : {}),
     ...(width ? { width: pxCheck(width) } : {}),
     ...(radius !== undefined && radius !== null

--- a/src/packages/tabpane/tabpane.scss
+++ b/src/packages/tabpane/tabpane.scss
@@ -2,7 +2,7 @@
   width: 100%;
   flex-shrink: 0;
   display: block;
-  background-color: $tabs-tabpane-backgroundColor;
+  background-color: $tabs-tabpane-background-color;
   color: $color-title;
   padding: $tabs-tabpane-padding;
   box-sizing: border-box;

--- a/src/packages/tabs/doc.en-US.md
+++ b/src/packages/tabs/doc.en-US.md
@@ -259,6 +259,6 @@ The component provides the following CSS variables, which can be used to customi
 | \--nutui-tabs-vertical-tab-line-width | Vertical title line width | `3px` |
 | \--nutui-tabs-vertical-tab-line-height | The height of the vertical title line | `12px` |
 | \--nutui-tabs-tabpane-padding | Padding of the Tabpane content | `24px 20px` |
-| \--nutui-tabs-tabpane-backgroundColor | BackgroundColor of the Tabpane content | `#fff` |
+| \--nutui-tabs-tabpane-background-color | BackgroundColor of the Tabpane content | `#fff` |
 
 <Contribution name="Tabs" />

--- a/src/packages/tabs/doc.md
+++ b/src/packages/tabs/doc.md
@@ -259,6 +259,6 @@ import { Tabs } from '@nutui/nutui-react'
 | \--nutui-tabs-vertical-tab-line-width | 垂直方向标题线条的宽度 | `3px` |
 | \--nutui-tabs-vertical-tab-line-height | 垂直方向标题线条的高度 | `12px` |
 | \--nutui-tabs-tabpane-padding | Tabpane 的内边距 | `24px 20px` |
-| \--nutui-tabs-tabpane-backgroundColor | Tabpane 的背景色 | `#fff` |
+| \--nutui-tabs-tabpane-background-color | Tabpane 的背景色 | `#fff` |
 
 <Contribution name="Tabs" />

--- a/src/packages/tabs/doc.taro.md
+++ b/src/packages/tabs/doc.taro.md
@@ -257,6 +257,6 @@ import { Tabs } from '@nutui/nutui-react-taro'
 | \--nutui-tabs-vertical-tab-line-width | 垂直方向标题线条的宽度 | `3px` |
 | \--nutui-tabs-vertical-tab-line-height | 垂直方向标题线条的高度 | `12px` |
 | \--nutui-tabs-tabpane-padding | Tabpane 的内边距 | `24px 20px` |
-| \--nutui-tabs-tabpane-backgroundColor | Tabpane 的背景色 | `#fff` |
+| \--nutui-tabs-tabpane-background-color | Tabpane 的背景色 | `#fff` |
 
 <Contribution name="Tabs" />

--- a/src/packages/tabs/doc.zh-TW.md
+++ b/src/packages/tabs/doc.zh-TW.md
@@ -257,6 +257,6 @@ import { Tabs } from '@nutui/nutui-react'
 | \--nutui-tabs-vertical-tab-line-width | 垂直方向標題線條的寬度 | `3px` |
 | \--nutui-tabs-vertical-tab-line-height | 垂直方向標題線條的高度 | `12px` |
 | \--nutui-tabs-tabpane-padding | Tabpane 的內邊距 | `24px 20px` |
-| \--nutui-tabs-tabpane-backgroundColor | Tabpane 的背景色 | `#fff` |
+| \--nutui-tabs-tabpane-background-color | Tabpane 的背景色 | `#fff` |
 
 <Contribution name="Tabs" />

--- a/src/styles/variables-jmapp.scss
+++ b/src/styles/variables-jmapp.scss
@@ -1981,8 +1981,8 @@ $tabs-titles-item-smile-bottom: var(
   -10px
 ) !default;
 $tabs-tabpane-padding: var(--nutui-tabs-tabpane-padding, 24px 20px) !default;
-$tabs-tabpane-backgroundColor: var(
-  --nutui-tabs-tabpane-backgroundColor,
+$tabs-tabpane-background-color: var(
+  --nutui-tabs-tabpane-background-color,
   #fff
 ) !default;
 // indicator（✅）

--- a/src/styles/variables-jrkf.scss
+++ b/src/styles/variables-jrkf.scss
@@ -2084,8 +2084,8 @@ $tabs-titles-item-smile-bottom: var(
   -10px
 ) !default;
 $tabs-tabpane-padding: var(--nutui-tabs-tabpane-padding, 24px 20px) !default;
-$tabs-tabpane-backgroundColor: var(
-  --nutui-tabs-tabpane-backgroundColor,
+$tabs-tabpane-background-color: var(
+  --nutui-tabs-tabpane-background-color,
   #fff
 ) !default;
 // indicator（✅）

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1876,8 +1876,8 @@ $tabs-titles-item-smile-bottom: var(
   -10%
 ) !default;
 $tabs-tabpane-padding: var(--nutui-tabs-tabpane-padding, 24px 20px) !default;
-$tabs-tabpane-backgroundColor: var(
-  --nutui-tabs-tabpane-backgroundColor,
+$tabs-tabpane-background-color: var(
+  --nutui-tabs-tabpane-background-color,
   #fff
 ) !default;
 // indicator（✅）


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 统一并修正 Tabpane 背景色相关的 CSS 变量命名，全部采用小写加连字符（kebab-case）格式，提升命名规范性和一致性。
- **样式**
  - 更新 Tabpane 背景色的 SCSS 变量及其引用，保持与文档描述一致，视觉效果无变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->