### PR TITLE
fix(overlay): 移除overlay-zIndex，避免zIndex props具备默认值导致css变量无效的使用困惑

### DIFF
--- a/src/packages/overlay/doc.en-US.md
+++ b/src/packages/overlay/doc.en-US.md
@@ -82,7 +82,6 @@ The component provides the following CSS variables, which can be used to customi
 | Name | Description | Default Value |
 | --- | --- | --- |
 | \--nutui-overlay-bg-color | Overlay background color | `$color-mask` |
-| \--nutui-overlay-zIndex | z-index | `1000` |
 | \--nutui-overlay-content-bg-color | Mask layer nested content background color | `$white` |
 | \--nutui-overlay-content-color | Mask layer nested content font color | `$color-title` |
 | \--nutui-overlay-animation-duration | Mask layer nested content animation duration | `0.3s` |

--- a/src/packages/overlay/doc.md
+++ b/src/packages/overlay/doc.md
@@ -82,7 +82,6 @@ import { Overlay } from '@nutui/nutui-react'
 | 名称 | 说明 | 默认值 |
 | --- | --- | --- |
 | \--nutui-overlay-bg-color | 遮罩层背景颜色 | `$color-mask` |
-| \--nutui-overlay-zIndex | overlay 的 z-index | `1000` |
 | \--nutui-overlay-content-bg-color | 遮罩层嵌套内容背景颜色 | `$white` |
 | \--nutui-overlay-content-color | 遮罩层嵌套内容字体颜色 | `$color-title` |
 | \--nutui-overlay-animation-duration | 遮罩层动画延时的时长 | `0.3s` |

--- a/src/packages/overlay/doc.taro.md
+++ b/src/packages/overlay/doc.taro.md
@@ -82,7 +82,6 @@ import { Overlay } from '@nutui/nutui-react-taro'
 | 名称 | 说明 | 默认值 |
 | --- | --- | --- |
 | \--nutui-overlay-bg-color | 遮罩层背景颜色 | `$color-mask` |
-| \--nutui-overlay-zIndex | overlay 的 z-index | `1000` |
 | \--nutui-overlay-content-bg-color | 遮罩层嵌套内容背景颜色 | `$white` |
 | \--nutui-overlay-content-color | 遮罩层嵌套内容字体颜色 | `$color-title` |
 | \--nutui-overlay-animation-duration | 遮罩层动画延时的时长 | `0.3s` |

--- a/src/packages/overlay/doc.zh-TW.md
+++ b/src/packages/overlay/doc.zh-TW.md
@@ -82,7 +82,6 @@ import { Overlay } from '@nutui/nutui-react'
 | 名稱 | 說明 | 默認值 |
 | --- | --- | --- |
 | \--nutui-overlay-bg-color | 遮罩層背景顏色 | `$color-mask` |
-| \--nutui-overlay-zIndex | overlay 的 z-index | `1000` |
 | \--nutui-overlay-content-bg-color | 遮罩層嵌套內容背景顏色 | `$white` |
 | \--nutui-overlay-content-color | 遮罩層嵌套內容字體顏色 | `$color-title` |
 | \--nutui-overlay-animation-duration | 遮罩層動畫延時的時長 | `0.3s` |

--- a/src/packages/overlay/overlay.scss
+++ b/src/packages/overlay/overlay.scss
@@ -7,7 +7,6 @@
   width: 100%;
   height: 100%;
   background-color: $overlay-bg-color;
-  z-index: $overlay-zIndex;
 }
 
 .nut-overflow-hidden {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1061,7 +1061,6 @@ $hoverbutton-item-icon-color-active: var(
 
 //overlay（✅）
 $overlay-bg-color: var(--nutui-overlay-bg-color, $color-mask) !default;
-$overlay-zIndex: var(--nutui-overlay-zIndex, 1000) !default;
 $overlay-content-bg-color: var(
   --nutui-overlay-content-bg-color,
   $color-background-overlay


### PR DESCRIPTION
…lue confusion

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 移除了 Overlay 组件文档中关于 `--nutui-overlay-zIndex` CSS 变量的说明。
- **样式**
  - 移除了 Overlay 组件相关的 z-index 样式变量及对应样式设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->