### PR TITLE
fix: css transition 引发的在jd和微信小程序下 map 组件重置的问题

### DIFF
--- a/src/packages/overlay/overlay.taro.tsx
+++ b/src/packages/overlay/overlay.taro.tsx
@@ -13,6 +13,7 @@ export const defaultOverlayProps: TaroOverlayProps = {
   closeOnOverlayClick: true,
   visible: false,
   lockScroll: true,
+  animated: true,
   onClick: () => {},
   afterShow: () => {},
   afterClose: () => {},
@@ -30,6 +31,7 @@ export const Overlay: FunctionComponent<
     visible,
     lockScroll,
     style,
+    animated,
     afterShow,
     afterClose,
     onClick,
@@ -70,17 +72,29 @@ export const Overlay: FunctionComponent<
   )
 
   return (
-    <CSSTransition
-      nodeRef={nodeRef}
-      classNames={`${classPrefix}-slide`}
-      unmountOnExit
-      timeout={duration}
-      in={innerVisible}
-      onEntered={afterShow}
-      onExited={afterClose}
-    >
-      {renderOverlay()}
-    </CSSTransition>
+    <>
+      {animated ? (
+        <CSSTransition
+          nodeRef={nodeRef}
+          classNames={`${classPrefix}-slide`}
+          unmountOnExit
+          timeout={duration}
+          in={innerVisible}
+          onEntered={afterShow}
+          onExited={afterClose}
+        >
+          {renderOverlay()}
+        </CSSTransition>
+      ) : (
+        <View
+          ref={nodeRef}
+          className={`${classPrefix}-slide`}
+          style={{ visibility: innerVisible ? 'visible' : 'hidden' }}
+        >
+          {renderOverlay()}
+        </View>
+      )}
+    </>
   )
 }
 

--- a/src/packages/overlay/overlay.tsx
+++ b/src/packages/overlay/overlay.tsx
@@ -18,6 +18,7 @@ export const defaultOverlayProps: WebOverlayProps = {
   closeOnOverlayClick: true,
   visible: false,
   lockScroll: true,
+  animated: true,
   onClick: () => {},
   afterShow: () => {},
   afterClose: () => {},

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -65,6 +65,7 @@ export const Popup: FunctionComponent<
     className,
     destroyOnClose,
     portal,
+    animated,
     onOpen,
     onClose,
     onOverlayClick,
@@ -200,18 +201,30 @@ export const Popup: FunctionComponent<
   }
   const renderPop = () => {
     return (
-      <CSSTransition
-        nodeRef={refObject}
-        classNames={transitionName}
-        mountOnEnter
-        unmountOnExit={destroyOnClose}
-        timeout={duration}
-        in={innerVisible}
-        onEntered={afterShow}
-        onExited={afterClose}
-      >
-        {renderContent()}
-      </CSSTransition>
+      <>
+        {animated ? (
+          <CSSTransition
+            nodeRef={refObject}
+            classNames={transitionName}
+            mountOnEnter
+            unmountOnExit={destroyOnClose}
+            timeout={duration}
+            in={innerVisible}
+            onEntered={afterShow}
+            onExited={afterClose}
+          >
+            {renderContent()}
+          </CSSTransition>
+        ) : (
+          <View
+            ref={refObject}
+            className={transitionName}
+            style={{ visibility: innerVisible ? 'visible' : 'hidden' }}
+          >
+            {renderContent()}
+          </View>
+        )}
+      </>
     )
   }
 
@@ -221,6 +234,7 @@ export const Popup: FunctionComponent<
         {overlay ? (
           <Overlay
             zIndex={index}
+            animated={animated}
             style={overlayStyles}
             className={overlayClassName}
             visible={innerVisible}

--- a/src/types/spec/overlay/base.ts
+++ b/src/types/spec/overlay/base.ts
@@ -6,7 +6,7 @@ export interface BaseOverlay extends BaseProps {
   visible: boolean
   lockScroll: boolean
   closeOnOverlayClick: boolean
-
+  animated: boolean
   afterShow: () => void
   afterClose: () => void
   onClick: (event: any) => void


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

尽管如此，该属性不建议使用。

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 叠加层（Overlay）和弹窗（Popup）组件新增 `animated` 属性，允许用户选择是否启用显示/隐藏动画效果，默认开启动画。
- **优化**
  - 现在可通过设置 `animated` 属性关闭动画，提升组件显示与隐藏的灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->