### PR TITLE
fix(form): label无法修改字号

### DIFF
--- a/src/packages/form/doc.en-US.md
+++ b/src/packages/form/doc.en-US.md
@@ -153,7 +153,7 @@ The component provides the following CSS Variables, which can be used for custom
 | \--nutui-form-item-error-line-color | Error message border color | `$color-primary` |
 | \--nutui-form-item-required-color | font color of required logo | `$color-primary` |
 | \--nutui-form-item-error-message-color | text color of error message | `$color-primary` |
-| \--nutui-form-item-label-font-size | label font size | `14px` |
+| \--nutui-form-item-label-font-size | label font size | `12px` |
 | \--nutui-form-item-label-width | label width | `90px` |
 | \--nutui-form-item-label-margin-right | label right margin | `10px` |
 | \--nutui-form-item-label-text-align | label text alignment | `left` |

--- a/src/packages/form/doc.md
+++ b/src/packages/form/doc.md
@@ -152,7 +152,7 @@ import { Form } from '@nutui/nutui-react'
 | \--nutui-form-item-error-line-color | 错误信息边框颜色 | `$color-primary` |
 | \--nutui-form-item-required-color | 必选标识的字体颜色 | `$color-primary` |
 | \--nutui-form-item-error-message-color | 错误信息的文本颜色 | `$color-primary` |
-| \--nutui-form-item-label-font-size | label 字号 | `14px` |
+| \--nutui-form-item-label-font-size | label 字号 | `12px` |
 | \--nutui-form-item-label-width | label 宽度 | `90px` |
 | \--nutui-form-item-label-margin-right | label 右外边距 | `10px` |
 | \--nutui-form-item-label-text-align | label 文本对齐方式 | `left` |

--- a/src/packages/form/doc.taro.md
+++ b/src/packages/form/doc.taro.md
@@ -152,7 +152,7 @@ import { Form } from '@nutui/nutui-react-taro'
 | \--nutui-form-item-error-line-color | 错误信息边框颜色 | `$color-primary` |
 | \--nutui-form-item-required-color | 必选标识的字体颜色 | `$color-primary` |
 | \--nutui-form-item-error-message-color | 错误信息的文本颜色 | `$color-primary` |
-| \--nutui-form-item-label-font-size | label 字号 | `14px` |
+| \--nutui-form-item-label-font-size | label 字号 | `12px` |
 | \--nutui-form-item-label-width | label 宽度 | `90px` |
 | \--nutui-form-item-label-margin-right | label 右外边距 | `10px` |
 | \--nutui-form-item-label-text-align | label 文本对齐方式 | `left` |

--- a/src/packages/form/doc.zh-TW.md
+++ b/src/packages/form/doc.zh-TW.md
@@ -152,7 +152,7 @@ import { Form } from '@nutui/nutui-react'
 | \--nutui-form-item-error-line-color | 錯誤信息邊框顏色 | `$color-primary` |
 | \--nutui-form-item-required-color | 必選標識的字體顏色 | `$color-primary` |
 | \--nutui-form-item-error-message-color | 錯誤信息的文本顏色 | `$color-primary` |
-| \--nutui-form-item-label-font-size | label 字號 | `14px` |
+| \--nutui-form-item-label-font-size | label 字號 | `12px` |
 | \--nutui-form-item-label-width | label 寬度 | `90px` |
 | \--nutui-form-item-label-margin-right | label 右外邊距 | `10px` |
 | \--nutui-form-item-label-text-align | label 文本對齊方式 | `left` |

--- a/src/packages/formitem/formitem.scss
+++ b/src/packages/formitem/formitem.scss
@@ -30,7 +30,7 @@
 
   .nut-form-item-labeltxt {
     position: relative;
-    font-size: 12px;
+    font-size: $form-item-label-font-size;
   }
 
   &-body {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -2133,7 +2133,7 @@ $form-item-error-message-color: var(
 ) !default;
 $form-item-label-font-size: var(
   --nutui-form-item-label-font-size,
-  $font-size-base
+  $font-size-s
 ) !default;
 $form-item-label-width: var(--nutui-form-item-label-width, 90px) !default;
 $form-item-label-margin-right: var(


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式**
  * 表单项标签的默认字体大小由14px调整为12px，视觉上更为紧凑。
  * 字体大小现可通过变量灵活配置，提升自定义能力。

* **文档**
  * 更新了表单组件文档中的标签字体大小默认值说明，保持与实际样式一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->