### PR TITLE
feat(dialog): close和cancel各司其职

### DIFF
--- a/src/packages/dialog/__test__/dialog.spec.tsx
+++ b/src/packages/dialog/__test__/dialog.spec.tsx
@@ -4,9 +4,9 @@ import '@testing-library/jest-dom'
 import { Dialog } from '../dialog'
 
 test('show dialog base info display ', async () => {
-  const onClose = vi.fn()
+  const onCancel = vi.fn()
   const { container } = render(
-    <Dialog title="title" data-testid="test" visible onClose={onClose}>
+    <Dialog title="title" data-testid="test" visible onCancel={onCancel}>
       <div>content</div>
     </Dialog>
   )
@@ -28,7 +28,7 @@ test('show dialog base info display ', async () => {
 
   expect(wrapEle).toBeNull()
   fireEvent.click(footerCancelEle)
-  expect(onClose).toBeCalled()
+  expect(onCancel).toBeCalled()
 })
 
 test('show dialog custom footer-direction ', async () => {
@@ -116,7 +116,6 @@ test('dialog close icon  position adjustment', async () => {
   expect(closeBtn).toBeInTheDocument()
   fireEvent.click(closeBtn)
   expect(onClose).toBeCalled()
-  expect(onCancel).toBeCalled()
 })
 
 test('should display loading when onConfirm returns a promise', async () => {

--- a/src/packages/dialog/demos/h5/demo2.tsx
+++ b/src/packages/dialog/demos/h5/demo2.tsx
@@ -10,7 +10,9 @@ const Demo2 = () => {
         title="基础弹框"
         visible={visible}
         onConfirm={() => setVisible(false)}
-        onCancel={() => setVisible(false)}
+        onCancel={() => {
+          setVisible(false)
+        }}
       >
         支持函数调用和组件调用两种方式。
       </Dialog>

--- a/src/packages/dialog/demos/h5/demo6.tsx
+++ b/src/packages/dialog/demos/h5/demo6.tsx
@@ -22,7 +22,14 @@ const Demo6 = () => {
           '--nutui-dialog-close-color': '#888B94',
         }}
         onConfirm={() => setVisible1(false)}
-        onCancel={() => setVisible1(false)}
+        onClose={() => {
+          setVisible1(false)
+          console.log('onClose')
+        }}
+        onCancel={() => {
+          // do sth else
+          console.log('onCancel')
+        }}
       >
         支持函数调用和组件调用两种方式。
       </Dialog>

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -206,7 +206,6 @@ export const BaseDialog: FunctionComponent<Partial<TaroDialogProps>> & {
   const onHandleClickOverlay = (e: ITouchEvent) => {
     if (closeOnOverlayClick && visible && e.target === e.currentTarget) {
       const closed = onOverlayClick && onOverlayClick(e)
-      closed && onClose()
       closed && onCancel()
     }
   }

--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -101,8 +101,6 @@ export const BaseDialog: FunctionComponent<Partial<TaroDialogProps>> & {
     const handleCancel = (e: ITouchEvent | MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()
       if (!beforeCancel?.()) return
-      if (!beforeClose?.()) return
-      onClose()
       onCancel()
     }
 
@@ -189,11 +187,9 @@ export const BaseDialog: FunctionComponent<Partial<TaroDialogProps>> & {
 
   const renderCloseIcon = () => {
     if (!closeIcon) return null
-    const handleCancel = () => {
-      if (!beforeCancel?.()) return
+    const handleClose = () => {
       if (!beforeClose?.()) return
       onClose()
-      onCancel()
     }
     const closeClasses = classNames({
       [`${classPrefix}-close`]: true,
@@ -201,7 +197,7 @@ export const BaseDialog: FunctionComponent<Partial<TaroDialogProps>> & {
     })
     const systomIcon = closeIconPosition !== 'bottom' ? <Close /> : <Failure />
     return (
-      <View className={closeClasses} onClick={handleCancel}>
+      <View className={closeClasses} onClick={handleClose}>
         {React.isValidElement(closeIcon) ? closeIcon : systomIcon}
       </View>
     )

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -90,8 +90,6 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<WebDialogProps>> = (
     ) => {
       e.stopPropagation()
       if (!beforeCancel?.()) return
-      if (!beforeClose?.()) return
-      onClose()
       onCancel()
     }
 
@@ -179,11 +177,9 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<WebDialogProps>> = (
 
   const renderCloseIcon = () => {
     if (!closeIcon) return null
-    const handleCancel = () => {
-      if (!beforeCancel?.()) return
+    const handleClose = () => {
       if (!beforeClose?.()) return
       onClose()
-      onCancel()
     }
     const closeClasses = classNames({
       [`${classPrefix}-close`]: true,
@@ -191,7 +187,7 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<WebDialogProps>> = (
     })
     const systomIcon = closeIconPosition !== 'bottom' ? <Close /> : <Failure />
     return (
-      <div className={closeClasses} onClick={handleCancel}>
+      <div className={closeClasses} onClick={handleClose}>
         {React.isValidElement(closeIcon) ? closeIcon : systomIcon}
       </div>
     )

--- a/src/packages/dialog/dialog.tsx
+++ b/src/packages/dialog/dialog.tsx
@@ -196,7 +196,6 @@ const BaseDialog: ForwardRefRenderFunction<unknown, Partial<WebDialogProps>> = (
   const onHandleClickOverlay = (e: MouseEvent) => {
     if (closeOnOverlayClick && visible && e.target === e.currentTarget) {
       const closed = onOverlayClick && onOverlayClick(e)
-      closed && onClose()
       closed && onCancel()
     }
   }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 取消按钮和关闭图标的行为现在已区分：取消按钮仅触发取消相关回调，关闭图标仅触发关闭相关回调。
* **优化**
  * 对话框事件处理逻辑更清晰，提升了用户操作的可预测性和一致性。
* **文档**
  * 示例中更新了事件处理方式，便于理解各自的触发效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->