### PR TITLE
fix(form): 修复右侧星星无法展示的问题

### DIFF
--- a/src/packages/form/demos/h5/demo2.tsx
+++ b/src/packages/form/demos/h5/demo2.tsx
@@ -35,6 +35,7 @@ const Demo2 = () => {
       <Form
         divider
         labelPosition="left"
+        starPosition="right"
         onFinish={(values) => submitSucceed(values)}
         onFinishFailed={(values, errors) => submitFailed(errors)}
         footer={

--- a/src/packages/form/demos/taro/demo2.tsx
+++ b/src/packages/form/demos/taro/demo2.tsx
@@ -35,6 +35,7 @@ const Demo2 = () => {
       <Form
         divider
         labelPosition="left"
+        starPosition="right"
         onFinish={(values) => submitSucceed(values)}
         onFinishFailed={(values, errors) => submitFailed(errors)}
         footer={

--- a/src/packages/formitem/formitem.scss
+++ b/src/packages/formitem/formitem.scss
@@ -18,14 +18,20 @@
     word-wrap: break-word;
     text-align: $form-item-label-text-align;
     line-height: unset;
-  }
 
-  &-label-required {
-    color: $form-item-required-color;
-    margin-right: $form-item-required-margin-right;
-    display: block;
-    position: absolute;
-    left: -10px;
+    &-left-required {
+      color: $form-item-required-color;
+      margin-right: $form-item-required-margin-right;
+      position: absolute;
+      left: -10px;
+    }
+
+    &-right-required {
+      color: $form-item-required-color;
+      margin-left: $form-item-required-margin-right;
+      position: absolute;
+      right: -10px;
+    }
   }
 
   .nut-form-item-labeltxt {
@@ -134,13 +140,6 @@
   position: relative;
   padding-left: 12px;
   white-space: nowrap;
-}
-
-.nut-form-item-label-left-required {
-  display: block;
-  line-height: 1.5;
-  position: absolute;
-  left: 0.1em;
 }
 
 .nut-form-item-top {

--- a/src/packages/formitem/formitem.taro.tsx
+++ b/src/packages/formitem/formitem.taro.tsx
@@ -189,15 +189,17 @@ export class FormItem extends React.Component<
 
     const { starPosition } = this.context.formInstance
     const renderStar = (required || requiredInRules) && (
-      <Text className="nut-form-item-label-required required">*</Text>
+      <Text className={`nut-form-item-label-${starPosition}-required required`}>
+        *
+      </Text>
     )
     const renderLabel = (
       <>
         <Text className="nut-form-item-labeltxt">
           {starPosition === 'left' ? renderStar : null}
           {label}
+          {starPosition === 'right' ? renderStar : null}
         </Text>
-        {starPosition === 'right' ? renderStar : null}
       </>
     )
     return (

--- a/src/packages/formitem/formitem.tsx
+++ b/src/packages/formitem/formitem.tsx
@@ -197,15 +197,17 @@ export class FormItem extends React.Component<
 
     const { starPosition } = this.context.formInstance
     const renderStar = (required || requiredInRules) && (
-      <div className="nut-form-item-label-required required">*</div>
+      <span className={`nut-form-item-label-${starPosition}-required required`}>
+        *
+      </span>
     )
     const renderLabel = (
       <>
         <span className="nut-form-item-labeltxt">
           {starPosition === 'left' ? renderStar : null}
           {label}
+          {starPosition === 'right' ? renderStar : null}
         </span>
-        {starPosition === 'right' ? renderStar : null}
       </>
     )
     return (


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 表单组件新增支持设置必填星号位置，可选择显示在标签右侧。

* **样式**
  * 优化必填星号在表单项标签左侧和右侧的样式表现，使其位置和对齐方式更加准确。

* **修复**
  * 统一必填星号的渲染方式，无论在左侧还是右侧，均在标签文本内部显示，提升一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->