### PR TITLE
fix(configprovider): 修订路径别名

### DIFF
--- a/packages/nutui-taro-demo/config/index.js
+++ b/packages/nutui-taro-demo/config/index.js
@@ -93,7 +93,6 @@ const config = {
         __dirname,
         '../../../src/packages/lottie/animation/light/pulltorefresh.json'
       ),
-
     '@nutui/nutui-react-taro/dist/es/lottie/animation/dark/loading.json':
       path.resolve(
         __dirname,
@@ -114,7 +113,6 @@ const config = {
         __dirname,
         '../../../src/packages/lottie/animation/dark/pulltorefresh-white.json'
       ),
-
     '@nutui/nutui-react-taro/dist/es/locales/en-US': path.resolve(
       __dirname,
       '../../../src/locales/en-US.ts'

--- a/src/packages/configprovider/types.ts
+++ b/src/packages/configprovider/types.ts
@@ -349,7 +349,6 @@ export type NutCSSVariables =
   | 'nutuiHoverbuttonItemIconColor'
   | 'nutuiHoverbuttonItemIconColorActive'
   | 'nutuiOverlayBgColor'
-  | 'nutuiOverlayZIndex'
   | 'nutuiOverlayContentBgColor'
   | 'nutuiOverlayContentColor'
   | 'nutuiOverlayAnimationDuration'

--- a/vite.config.demo.ts
+++ b/vite.config.demo.ts
@@ -63,7 +63,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
           ),
         },
         {
-          find: '@nutui/nutui-react/dist/es/locale/en-US',
+          find: '@nutui/nutui-react/dist/es/locales/en-US',
           replacement: resolve(__dirname, './src/locales/en-US.ts'),
         },
         {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -72,7 +72,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
           ),
         },
         {
-          find: '@nutui/nutui-react/dist/es/locale/en-US',
+          find: '@nutui/nutui-react/dist/es/locales/en-US',
           replacement: resolve(__dirname, './src/locales/en-US.ts'),
         },
         {


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 移除了配置文件中多余的空行，提升了文件整洁度。

* **类型调整**
  * 移除了 `NutCSSVariables` 类型中的 `'nutuiOverlayZIndex'` 字面量。

* **修复**
  * 修正了 Vite 配置中英文语言包的路径别名，将目录名由 "locale" 更正为 "locales"。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->