### PR TITLE
fix: 修复日历只有一个月的情况

### DIFF
--- a/src/packages/calendaritem/calendaritem.taro.tsx
+++ b/src/packages/calendaritem/calendaritem.taro.tsx
@@ -285,7 +285,7 @@ export const CalendarItem = React.forwardRef<
     if (yearNum > 0) {
       monthNum += 12 * yearNum
     }
-    if (monthNum <= 0) {
+    if (monthNum < 0) {
       monthNum = 1
     }
     setMonthsNum(monthNum)

--- a/src/packages/calendaritem/calendaritem.tsx
+++ b/src/packages/calendaritem/calendaritem.tsx
@@ -284,7 +284,7 @@ export const CalendarItem = React.forwardRef<
     if (yearNum > 0) {
       monthNum += 12 * yearNum
     }
-    if (monthNum <= 0) {
+    if (monthNum < 0) {
       monthNum = 1
     }
     setMonthsNum(monthNum)


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修正了日历组件中月份差为零时的处理逻辑，现在当开始和结束日期在同一个月时，月份数可为零，不再强制设为1。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->