### PR TITLE
fix(noticebar): 适配鸿蒙样式修复

### DIFF
--- a/src/packages/noticebar/noticebar.scss
+++ b/src/packages/noticebar/noticebar.scss
@@ -51,6 +51,9 @@
       min-width: $noticebar-left-icon-width;
       margin-right: $noticebar-icon-gap;
       background-size: 100% 100%;
+      .nut-icon {
+        color: $noticebar-color;
+      }
     }
 
     &-right-icon {
@@ -63,12 +66,14 @@
       .nut-icon {
         width: 12px;
         height: 12px;
+        color: $noticebar-color;
       }
     }
 
     &-wrap {
       display: flex;
       flex: 1;
+      align-items: center;
       height: $noticebar-line-height;
       line-height: $noticebar-line-height;
       overflow: hidden;
@@ -77,6 +82,7 @@
       .nut-noticebar-box-wrap-content {
         position: absolute;
         white-space: nowrap;
+        color: $noticebar-color;
 
         &.nut-ellipsis {
           max-width: 100%;


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 统一公告栏左右图标与内容文字的主题色，使图标与文本颜色与通知条颜色保持一致。
  * 为公告栏内容容器新增垂直居中对齐（align-items: center），提升排版和可读性。
  * 调整内容区颜色继承与应用，确保 .nut-icon 与内容文本使用同一主题色配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->