### PR TITLE
fix(swiper): duration属性透传

### DIFF
--- a/src/packages/swiper/swiper.taro.tsx
+++ b/src/packages/swiper/swiper.taro.tsx
@@ -141,6 +141,7 @@ export const Swiper = React.forwardRef(
             autoplay={autoplay || autoPlay}
             vertical={direction === 'vertical' || vertical}
             indicatorDots={false}
+            duration={duration || 500}
             onChange={(e) => {
               handleOnChange(e)
               props.onChange?.(e)

--- a/src/packages/swiper/swiper.taro.tsx
+++ b/src/packages/swiper/swiper.taro.tsx
@@ -41,7 +41,6 @@ export const Swiper = React.forwardRef(
       circular,
       autoPlay,
       autoplay,
-      duration,
       vertical,
       direction,
       defaultValue,
@@ -141,7 +140,6 @@ export const Swiper = React.forwardRef(
             autoplay={autoplay || autoPlay}
             vertical={direction === 'vertical' || vertical}
             indicatorDots={false}
-            duration={duration || 500}
             onChange={(e) => {
               handleOnChange(e)
               props.onChange?.(e)


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/jdf2e/nutui-react/issues/3336

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
在属性解构的时候把duration单独解构出来，但是最终给TaroSwiper赋值的时候没有传递进去。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **修复**
  - 轮播组件现在会将传入的 duration 生效并转发到底层控件，切换动画时长按传入值使用；默认行为与对外接口不变，其他交互（切换事件、指示器、方法）未受影响，提升动画一致性与可控性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->