### PR TITLE
feat(Popup): 新增弹层可上下滑动

### DIFF
--- a/src/packages/popup/__tests__/popup.spec.tsx
+++ b/src/packages/popup/__tests__/popup.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Popup } from '../popup'
 
@@ -87,12 +87,6 @@ test('pop minHeight', () => {
   expect(node).toHaveStyle({ minHeight: '30%' })
 })
 
-test('pop resizable', () => {
-  const { container } = render(<Popup resizable visible position="bottom" />)
-  const node = container.querySelector('.nut-popup') as HTMLElement
-  // expect(node).toHaveStyle({ minHeight: '30%' })
-})
-
 test('should render close icon when using closeable prop', () => {
   const { container } = render(<Popup visible closeable />)
   const closeIcon = container.querySelector(
@@ -155,7 +149,7 @@ test('should emit open event when prop visible is set to true', async () => {
       test
     </Popup>
   )
-  expect(onOpen).toBeCalled()
+  await waitFor(() => expect(onOpen).toBeCalled())
 })
 
 test('event click-overlay test', async () => {

--- a/src/packages/popup/__tests__/popup.spec.tsx
+++ b/src/packages/popup/__tests__/popup.spec.tsx
@@ -1,34 +1,22 @@
 import * as React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { Popup } from '../popup'
 
-test('should change z-index when using z-index prop', () => {
-  const { container } = render(<Popup visible zIndex={99} />)
-  const element = container.querySelector('.nut-popup') as HTMLElement
-  expect(element.style.zIndex).toEqual('99')
+test('renders without crashing', () => {
+  render(<Popup visible>Test Content</Popup>)
+  expect(screen.getByText('Test Content')).toBeInTheDocument()
 })
 
-test('prop overlay-class test', async () => {
-  const { container } = render(<Popup visible overlayClassName="testclas" />)
-  const overlay = container.querySelector('.nut-overlay') as HTMLElement
-  expect(overlay).toHaveClass('testclas')
-})
+test('opens and closes correctly', () => {
+  const { rerender } = render(<Popup visible={false}>Test Content</Popup>)
 
-test('prop overlay-style test', async () => {
-  const { container } = render(
-    <Popup visible overlayStyle={{ color: 'red' }} />
-  )
-  const overlay = container.querySelector('.nut-overlay') as HTMLElement
-  expect(overlay).toHaveStyle({
-    color: 'red',
-  })
-})
+  // Initially, it should not be visible
+  expect(screen.queryByText('Test Content')).not.toBeInTheDocument()
 
-test('should lock scroll when showed', async () => {
-  const { rerender } = render(<Popup visible={false} />)
-  rerender(<Popup visible />)
-  expect(document.body.classList.contains('nut-overflow-hidden')).toBe(true)
+  // Rerender with visible true
+  rerender(<Popup visible>Test Content</Popup>)
+  expect(screen.getByText('Test Content')).toBeInTheDocument()
 })
 
 test('should not render overlay when overlay prop is false', () => {
@@ -91,6 +79,20 @@ test('pop description', () => {
   expect(title).toHaveTextContent('副标题')
 })
 
+test('pop minHeight', () => {
+  const { container } = render(
+    <Popup minHeight="30%" visible position="bottom" />
+  )
+  const node = container.querySelector('.nut-popup') as HTMLElement
+  expect(node).toHaveStyle({ minHeight: '30%' })
+})
+
+test('pop resizable', () => {
+  const { container } = render(<Popup resizable visible position="bottom" />)
+  const node = container.querySelector('.nut-popup') as HTMLElement
+  // expect(node).toHaveStyle({ minHeight: '30%' })
+})
+
 test('should render close icon when using closeable prop', () => {
   const { container } = render(<Popup visible closeable />)
   const closeIcon = container.querySelector(
@@ -145,10 +147,14 @@ test('event click-title-right icon and keep overlay test ', () => {
   expect(overlay2).toBeNull()
 })
 
-test('should emit open event when prop visible is set to true', () => {
+test('should emit open event when prop visible is set to true', async () => {
   const onOpen = vi.fn()
   const { rerender } = render(<Popup visible={false} onOpen={onOpen} />)
-  rerender(<Popup visible onOpen={onOpen} />)
+  rerender(
+    <Popup visible onOpen={onOpen} closeOnOverlayClick>
+      test
+    </Popup>
+  )
   expect(onOpen).toBeCalled()
 })
 
@@ -170,4 +176,39 @@ test('pop destroyOnClose', () => {
   const overlay = container.querySelector('.nut-overlay') as Element
   fireEvent.click(overlay)
   expect(onClose).toBeCalled()
+})
+
+test('handles touch events correctly', () => {
+  const handleTouchStart = vi.fn()
+  const handleTouchMove = vi.fn()
+  const handleTouchEnd = vi.fn()
+
+  render(
+    <Popup
+      visible
+      resizable
+      position="bottom"
+      // minHeight="400px"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      Test Content
+    </Popup>
+  )
+
+  const popup = document.body.querySelector('.nut-popup') as HTMLElement
+
+  // Simulate touch events
+  fireEvent.touchStart(popup, { touches: [{ pageY: 400 }] })
+  expect(handleTouchStart).toHaveBeenCalled()
+
+  fireEvent.touchMove(popup, { touches: [{ pageY: 50 }] })
+  expect(handleTouchMove).toHaveBeenCalled()
+
+  fireEvent.touchMove(popup, { touches: [{ pageY: 450 }] })
+  expect(handleTouchMove).toHaveBeenCalled()
+
+  fireEvent.touchEnd(popup)
+  expect(handleTouchEnd).toHaveBeenCalled()
 })

--- a/src/packages/popup/demos/h5/demo1.tsx
+++ b/src/packages/popup/demos/h5/demo1.tsx
@@ -2,24 +2,53 @@ import React, { useState } from 'react'
 import { Popup, Cell } from '@nutui/nutui-react'
 
 const Demo = () => {
-  const [showIcon, setShowIcon] = useState(false)
+  const [showPopup, setShowPopup] = useState(false)
+  const [showPopupResiable, setShowPopupResiable] = useState(false)
 
   return (
     <>
       <Cell
         title="基础弹框"
         onClick={() => {
-          setShowIcon(true)
+          setShowPopup(true)
+        }}
+      />
+      <Cell
+        title="基础弹框：可上下滑动"
+        onClick={() => {
+          setShowPopupResiable(true)
         }}
       />
       <Popup
         closeable
-        visible={showIcon}
+        visible={showPopup}
         title="标题"
         description="这里是副标题这是副标题"
         position="bottom"
         onClose={() => {
-          setShowIcon(false)
+          setShowPopup(false)
+        }}
+      />
+      <Popup
+        closeable
+        resizable
+        minHeight="10%"
+        style={{ height: '60%' }}
+        visible={showPopupResiable}
+        title="上下滑动"
+        description="弹层区域滑动起来"
+        position="bottom"
+        onClose={() => {
+          setShowPopupResiable(false)
+        }}
+        onTouchMove={(height, e, direction) => {
+          console.log('onTouchMove', height, e, direction)
+        }}
+        onTouchStart={(height, e) => {
+          console.log('onTouchStart', height, e)
+        }}
+        onTouchEnd={(height, e) => {
+          console.log('onTouchEnd', height, e)
         }}
       />
     </>

--- a/src/packages/popup/demos/h5/demo2.tsx
+++ b/src/packages/popup/demos/h5/demo2.tsx
@@ -44,6 +44,7 @@ const Demo2 = () => {
         visible={showTop}
         destroyOnClose
         position="top"
+        resizable
         onClose={() => {
           setShowTop(false)
         }}

--- a/src/packages/popup/demos/taro/demo1.tsx
+++ b/src/packages/popup/demos/taro/demo1.tsx
@@ -2,24 +2,53 @@ import React, { useState } from 'react'
 import { Popup, Cell } from '@nutui/nutui-react-taro'
 
 const Demo = () => {
-  const [showIcon, setShowIcon] = useState(false)
+  const [showPopup, setShowPopup] = useState(false)
+  const [showPopupResiable, setShowPopupResiable] = useState(false)
 
   return (
     <>
       <Cell
         title="基础弹框"
         onClick={() => {
-          setShowIcon(true)
+          setShowPopup(true)
+        }}
+      />
+      <Cell
+        title="基础弹框：可上下滑动"
+        onClick={() => {
+          setShowPopupResiable(true)
         }}
       />
       <Popup
         closeable
-        visible={showIcon}
+        visible={showPopup}
         title="标题"
         description="这里是副标题这是副标题"
         position="bottom"
         onClose={() => {
-          setShowIcon(false)
+          setShowPopup(false)
+        }}
+      />
+      <Popup
+        closeable
+        resizable
+        minHeight="10%"
+        style={{ height: '60%' }}
+        visible={showPopupResiable}
+        title="上下滑动"
+        description="弹层区域滑动起来"
+        position="bottom"
+        onClose={() => {
+          setShowPopupResiable(false)
+        }}
+        onTouchMove={(height, e, direction) => {
+          console.log('onTouchMove', height, e, direction)
+        }}
+        onTouchStart={(height, e) => {
+          console.log('onTouchStart', height, e)
+        }}
+        onTouchEnd={(height, e) => {
+          console.log('onTouchEnd', height, e)
         }}
       />
     </>

--- a/src/packages/popup/doc.en-US.md
+++ b/src/packages/popup/doc.en-US.md
@@ -87,7 +87,7 @@ import { Popup } from '@nutui/nutui-react'
 | closeable | whether to show the close button | `boolean` | `false` |
 | closeIconPosition | close button position | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | `top-right` |
 | closeIcon | Custom Icon | `ReactNode` | `close` |
-| resizable | you can resize the height of popup | `boolean` | `false` |
+| resizable | you can resize the height of popup, just used by position from bottom | `boolean` | `false` |
 | minHeight | The minHeight of popup | `string` | `26%` |
 | left | The left of title | `ReactNode` | `-` |
 | title | The center of title | `ReactNode` | `-` |

--- a/src/packages/popup/doc.en-US.md
+++ b/src/packages/popup/doc.en-US.md
@@ -87,8 +87,8 @@ import { Popup } from '@nutui/nutui-react'
 | closeable | whether to show the close button | `boolean` | `false` |
 | closeIconPosition | close button position | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | `top-right` |
 | closeIcon | Custom Icon | `ReactNode` | `close` |
-| resizable | you can resize the height of popup, just used by position from bottom | `boolean` | `false` |
-| minHeight | The minHeight of popup | `string` | `26%` |
+| resizable | Enable vertical resizing of the popup | `boolean` | `false` |
+| minHeight | Minimum height of the popup | `string` | `26%` |
 | left | The left of title | `ReactNode` | `-` |
 | title | The center of title | `ReactNode` | `-` |
 | description | The subtitle/description | `ReactNode` | `-` |
@@ -102,9 +102,9 @@ import { Popup } from '@nutui/nutui-react'
 | onOpen | Triggered when the popup is opened | `-` | `-` |
 | onClose | Fired when the popup is closed | `-` | `-` |
 | onOverlayClick | Click on the mask to trigger | `event: MouseEvent` | `-` |
-| onTouchStart | triggered when starting to touch | `height: number, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
-| onTouchMove | triggered when starting to move | `(height: number, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
-| onTouchEnd | triggered when finishing to touch | `height: number, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchStart | triggered when starting to touch | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | triggered while moving | `(height: number, event: TouchEvent<HTMLDivElement>, direction: 'up' \| 'down') => void` | `-` |
+| onTouchEnd | triggered when finishing to touch | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## Theming
 

--- a/src/packages/popup/doc.en-US.md
+++ b/src/packages/popup/doc.en-US.md
@@ -87,19 +87,24 @@ import { Popup } from '@nutui/nutui-react'
 | closeable | whether to show the close button | `boolean` | `false` |
 | closeIconPosition | close button position | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | `top-right` |
 | closeIcon | Custom Icon | `ReactNode` | `close` |
+| resizable | you can resize the height of popup | `boolean` | `false` |
+| minHeight | The minHeight of popup | `string` | `26%` |
 | left | The left of title | `ReactNode` | `-` |
 | title | The center of title | `ReactNode` | `-` |
 | description | The subtitle/description | `ReactNode` | `-` |
 | destroyOnClose | Whether to close after the component is destroyed | `boolean` | `false` |
 | round | Whether to show rounded corners | `boolean` | `false` |
 | portal | Mount the specified node | `HTMLElement` \| `(() => HTMLElement)` \| null` | `null` |
+| afterShow | afterShow from `Overlay`, Fired when the mask opening animation ends | `event: HTMLElement` | `-` |
+| afterClose | afterClose from `Overlay`, Fired when the mask closing animation ends | `event: HTMLElement` | `-` |
 | onClick | Triggered when the popup is clicked | `event: MouseEvent` | `-` |
 | onCloseIconClick | Fired when the close icon is clicked | `event: MouseEvent` | `-` |
 | onOpen | Triggered when the popup is opened | `-` | `-` |
 | onClose | Fired when the popup is closed | `-` | `-` |
-| afterShow | afterShow from `Overlay`, Fired when the mask opening animation ends | `event: HTMLElement` | `-` |
-| afterClose | afterClose from `Overlay`, Fired when the mask closing animation ends | `event: HTMLElement` | `-` |
 | onOverlayClick | Click on the mask to trigger | `event: MouseEvent` | `-` |
+| onTouchStart | triggered when starting to touch | `height:string, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | triggered when starting to move | `(height:string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | triggered when finishing to touch | `height:string, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## Theming
 

--- a/src/packages/popup/doc.en-US.md
+++ b/src/packages/popup/doc.en-US.md
@@ -102,9 +102,9 @@ import { Popup } from '@nutui/nutui-react'
 | onOpen | Triggered when the popup is opened | `-` | `-` |
 | onClose | Fired when the popup is closed | `-` | `-` |
 | onOverlayClick | Click on the mask to trigger | `event: MouseEvent` | `-` |
-| onTouchStart | triggered when starting to touch | `height:string, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
-| onTouchMove | triggered when starting to move | `(height:string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
-| onTouchEnd | triggered when finishing to touch | `height:string, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchStart | triggered when starting to touch | `height: number, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | triggered when starting to move | `(height: number, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | triggered when finishing to touch | `height: number, (event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## Theming
 

--- a/src/packages/popup/doc.md
+++ b/src/packages/popup/doc.md
@@ -87,7 +87,7 @@ import { Popup } from '@nutui/nutui-react'
 | closeable | 是否显示关闭按钮 | `boolean` | `false` |
 | closeIconPosition | 关闭按钮位置 | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | `top-right` |
 | closeIcon | 自定义 Icon | `ReactNode` | `close` |
-| resizable | 上下滑动调整高度 | `boolean` | `false` |
+| resizable | 上下滑动调整高度，当前只支持从底部弹出 | `boolean` | `false` |
 | minHeight | 设置最小高度 | `string` | `26%` |
 | left | 标题左侧部分 | `ReactNode` | `-` |
 | title | 标题中间部分 | `ReactNode` | `-` |

--- a/src/packages/popup/doc.md
+++ b/src/packages/popup/doc.md
@@ -87,19 +87,24 @@ import { Popup } from '@nutui/nutui-react'
 | closeable | 是否显示关闭按钮 | `boolean` | `false` |
 | closeIconPosition | 关闭按钮位置 | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | `top-right` |
 | closeIcon | 自定义 Icon | `ReactNode` | `close` |
+| resizable | 上下滑动调整高度 | `boolean` | `false` |
+| minHeight | 设置最小高度 | `string` | `26%` |
 | left | 标题左侧部分 | `ReactNode` | `-` |
 | title | 标题中间部分 | `ReactNode` | `-` |
 | description | 子标题/描述部分 | `ReactNode` | `-` |
 | destroyOnClose | 组件不可见时，卸载内容 | `boolean` | `false` |
 | round | 是否显示圆角 | `boolean` | `false` |
 | portal | 指定节点挂载 | `HTMLElement` \| `(() => HTMLElement)` \| null` | `null` |
+| afterShow | 继承于`Overlay`, 遮罩打开动画结束时触发 | `event: HTMLElement` | `-` |
+| afterClose | 继承于`Overlay`, 遮罩关闭动画结束时触发 | `event: HTMLElement` | `-` |
 | onClick | 点击弹框时触发 | `event: MouseEvent` | `-` |
 | onCloseIconClick | 点击关闭图标时触发 | `event: MouseEvent` | `-` |
 | onOpen | 打开弹框时触发 | `-` | `-` |
 | onClose | 关闭弹框时触发 | `-` | `-` |
-| afterShow | 继承于`Overlay`, 遮罩打开动画结束时触发 | `event: HTMLElement` | `-` |
-| afterClose | 继承于`Overlay`, 遮罩关闭动画结束时触发 | `event: HTMLElement` | `-` |
 | onOverlayClick | 点击遮罩触发 | `event: MouseEvent` | `-` |
+| onTouchStart | 开始触碰时触发 | `(height:string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | 滑动时触发 | `(height:string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | 结束触碰时触发 | `(height:string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## 主题定制
 

--- a/src/packages/popup/doc.md
+++ b/src/packages/popup/doc.md
@@ -103,7 +103,7 @@ import { Popup } from '@nutui/nutui-react'
 | onClose | 关闭弹框时触发 | `-` | `-` |
 | onOverlayClick | 点击遮罩触发 | `event: MouseEvent` | `-` |
 | onTouchStart | 开始触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
-| onTouchMove | 滑动时触发 | `(height: number, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchMove | 滑动时触发 | `(height: number, event: TouchEvent<HTMLDivElement>, direction: 'up' \| 'down') => void` | `-` |
 | onTouchEnd | 结束触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## 主题定制

--- a/src/packages/popup/doc.md
+++ b/src/packages/popup/doc.md
@@ -102,9 +102,9 @@ import { Popup } from '@nutui/nutui-react'
 | onOpen | 打开弹框时触发 | `-` | `-` |
 | onClose | 关闭弹框时触发 | `-` | `-` |
 | onOverlayClick | 点击遮罩触发 | `event: MouseEvent` | `-` |
-| onTouchStart | 开始触碰时触发 | `(height:string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
-| onTouchMove | 滑动时触发 | `(height:string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
-| onTouchEnd | 结束触碰时触发 | `(height:string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchStart | 开始触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | 滑动时触发 | `(height: number, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | 结束触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## 主题定制
 

--- a/src/packages/popup/doc.taro.md
+++ b/src/packages/popup/doc.taro.md
@@ -97,7 +97,7 @@ import { Popup } from '@nutui/nutui-react-taro'
 | closeable | 是否显示关闭按钮 | `boolean` | `false` |
 | closeIconPosition | 关闭按钮位置 | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | `top-right` |
 | closeIcon | 自定义 Icon | `ReactNode` | `close` |
-| resizable | 上下滑动调整高度 | `boolean` | `false` |
+| resizable | 上下滑动调整高度，当前只支持从底部弹出 | `boolean` | `false` |
 | minHeight | 设置最小高度 | `string` | `26%` |
 | left | 标题左侧部分 | `ReactNode` | `-` |
 | title | 标题中间部分 | `ReactNode` | `-` |

--- a/src/packages/popup/doc.taro.md
+++ b/src/packages/popup/doc.taro.md
@@ -112,9 +112,9 @@ import { Popup } from '@nutui/nutui-react-taro'
 | onOpen | 打开弹框时触发 | `-` | `-` |
 | onClose | 关闭弹框时触发 | `-` | `-` |
 | onOverlayClick | 点击遮罩触发 | `event: MouseEvent` | `-` |
-| onTouchStart | 开始触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
-| onTouchMove | 滑动时触发 | `(height: number, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
-| onTouchEnd | 结束触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchStart | 开始触碰时触发 | `(height: number, event: ITouchEvent) => void` | `-` |
+| onTouchMove | 滑动时触发 | `(height: number, event: ITouchEvent, direction: 'up' \| 'down') => void` | `-` |
+| onTouchEnd | 结束触碰时触发 | `(height: number, event: ITouchEvent) => void` | `-` |
 
 ## 主题定制
 

--- a/src/packages/popup/doc.taro.md
+++ b/src/packages/popup/doc.taro.md
@@ -97,19 +97,24 @@ import { Popup } from '@nutui/nutui-react-taro'
 | closeable | 是否显示关闭按钮 | `boolean` | `false` |
 | closeIconPosition | 关闭按钮位置 | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | `top-right` |
 | closeIcon | 自定义 Icon | `ReactNode` | `close` |
+| resizable | 上下滑动调整高度 | `boolean` | `false` |
+| minHeight | 设置最小高度 | `string` | `26%` |
 | left | 标题左侧部分 | `ReactNode` | `-` |
 | title | 标题中间部分 | `ReactNode` | `-` |
 | description | 子标题/描述部分 | `ReactNode` | `-` |
 | destroyOnClose | 组件不可见时，卸载内容 | `boolean` | `false` |
 | round | 是否显示圆角 | `boolean` | `false` |
 | portal | 指定节点挂载 | ``HTMLElement` \| `(() => HTMLElement)` \| null`` | `null` |
+| afterShow | 继承于`Overlay`, 遮罩打开动画结束时触发 | `event: HTMLElement` | `-` |
+| afterClose | 继承于`Overlay`, 遮罩关闭动画结束时触发 | `event: HTMLElement` | `-` |
 | onClick | 点击弹框时触发 | `event: MouseEvent` | `-` |
 | onCloseIconClick | 点击关闭图标时触发 | `event: MouseEvent` | `-` |
 | onOpen | 打开弹框时触发 | `-` | `-` |
 | onClose | 关闭弹框时触发 | `-` | `-` |
-| afterShow | 继承于`Overlay`, 遮罩打开动画结束时触发 | `event: HTMLElement` | `-` |
-| afterClose | 继承于`Overlay`, 遮罩关闭动画结束时触发 | `event: HTMLElement` | `-` |
 | onOverlayClick | 点击遮罩触发 | `event: MouseEvent` | `-` |
+| onTouchStart | 开始触碰时触发 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | 滑动时触发 | `(height: string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | 结束触碰时触发 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## 主题定制
 

--- a/src/packages/popup/doc.taro.md
+++ b/src/packages/popup/doc.taro.md
@@ -112,9 +112,9 @@ import { Popup } from '@nutui/nutui-react-taro'
 | onOpen | 打开弹框时触发 | `-` | `-` |
 | onClose | 关闭弹框时触发 | `-` | `-` |
 | onOverlayClick | 点击遮罩触发 | `event: MouseEvent` | `-` |
-| onTouchStart | 开始触碰时触发 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
-| onTouchMove | 滑动时触发 | `(height: string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
-| onTouchEnd | 结束触碰时触发 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchStart | 开始触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | 滑动时触发 | `(height: number, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | 结束触碰时触发 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## 主题定制
 

--- a/src/packages/popup/doc.zh-TW.md
+++ b/src/packages/popup/doc.zh-TW.md
@@ -102,9 +102,9 @@ import { Popup } from '@nutui/nutui-react'
 | onOpen | 打開彈框時觸發 | `-` | `-` |
 | onClose | 關閉彈框時觸發 | `-` | `-` |
 | onOverlayClick | 點擊遮罩觸發 | `event: MouseEvent` | `-` |
-| onTouchStart | 開始觸碰時觸發 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
-| onTouchMove | 滑動時觸發 | `(height: string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
-| onTouchEnd | 結束觸碰時觸發 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchStart | 開始觸碰時觸發 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | 滑動時觸發 | `(height: number, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | 結束觸碰時觸發 | `(height: number, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## 主題定制
 

--- a/src/packages/popup/doc.zh-TW.md
+++ b/src/packages/popup/doc.zh-TW.md
@@ -87,19 +87,24 @@ import { Popup } from '@nutui/nutui-react'
 | closeable | 是否顯示關閉按鈕 | `boolean` | `false` |
 | closeIconPosition | 關閉按鈕位置（top-left,top-right,bottom-left,bottom-right） | `string` | `top-right` |
 | closeIcon | 自定義 Icon | `ReactNode` | `close` |
+| resizable | 上下滑動調整高度 | `boolean` | `false` |
+| minHeight | 設定最小高度 | `string` | `26%` |
 | left | 标题左侧部分 | `ReactNode` | `-` |
 | title | 标题中间部分 | `ReactNode` | `-` |
 | description | 子標題/描述部分 | `ReactNode` | `-` |
 | destroyOnClose | 组件不可见时，卸载内容 | `boolean` | `false` |
 | round | 是否顯示圓角 | `boolean` | `false` |
 | portal | 指定節點掛載 | `HTMLElement` \| `(() => HTMLElement)` \| null` | `null` |
+| afterShow | 继承于`Overlay`, 遮罩打開動畫結束時觸發 | `event: HTMLElement` | `-` |
+| afterClose | 继承于`Overlay`, 遮罩關閉動畫結束時觸發 | `event: HTMLElement` | `-` |
 | onClick | 點擊彈框時觸發 | `event: MouseEvent` | `-` |
 | onCloseIconClick | 點擊關閉圖標時觸發 | `event: MouseEvent` | `-` |
 | onOpen | 打開彈框時觸發 | `-` | `-` |
 | onClose | 關閉彈框時觸發 | `-` | `-` |
-| afterShow | 继承于`Overlay`, 遮罩打開動畫結束時觸發 | `event: HTMLElement` | `-` |
-| afterClose | 继承于`Overlay`, 遮罩關閉動畫結束時觸發 | `event: HTMLElement` | `-` |
 | onOverlayClick | 點擊遮罩觸發 | `event: MouseEvent` | `-` |
+| onTouchStart | 開始觸碰時觸發 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
+| onTouchMove | 滑動時觸發 | `(height: string, event: TouchEvent<HTMLDivElement>, 'up' \| 'down') => void` | `-` |
+| onTouchEnd | 結束觸碰時觸發 | `(height: string, event: TouchEvent<HTMLDivElement>) => void` | `-` |
 
 ## 主題定制
 

--- a/src/packages/popup/doc.zh-TW.md
+++ b/src/packages/popup/doc.zh-TW.md
@@ -87,7 +87,7 @@ import { Popup } from '@nutui/nutui-react'
 | closeable | 是否顯示關閉按鈕 | `boolean` | `false` |
 | closeIconPosition | 關閉按鈕位置（top-left,top-right,bottom-left,bottom-right） | `string` | `top-right` |
 | closeIcon | 自定義 Icon | `ReactNode` | `close` |
-| resizable | 上下滑動調整高度 | `boolean` | `false` |
+| resizable | 上下滑動調整高度，目前只支援從底部彈出 | `boolean` | `false` |
 | minHeight | 設定最小高度 | `string` | `26%` |
 | left | 标题左侧部分 | `ReactNode` | `-` |
 | title | 标题中间部分 | `ReactNode` | `-` |

--- a/src/packages/popup/popup.scss
+++ b/src/packages/popup/popup.scss
@@ -90,11 +90,6 @@
     }
   }
 
-  &-bottom,
-  &-top {
-    max-height: 87%;
-  }
-
   &-bottom {
     bottom: 0;
     left: 0;

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -120,7 +120,12 @@ export const Popup: FunctionComponent<
   const open = () => {
     if (!innerVisible) {
       // 当高度改变后，再次打开时，将高度置为初始高度
-      if (resizable && nodeRef.current && heightRef.current) {
+      if (
+        position === 'bottom' &&
+        resizable &&
+        nodeRef.current &&
+        heightRef.current
+      ) {
         nodeRef.current.style.height = `${heightRef.current}px`
       }
       setInnerVisible(true)
@@ -208,7 +213,7 @@ export const Popup: FunctionComponent<
   }
 
   const handleTouchStart = async (event: ITouchEvent) => {
-    if (!resizable || !nodeRef.current) return
+    if (position !== 'bottom' || !resizable || !nodeRef.current) return
     // 开始touch，记录下touch的pageY，用以判断是向上滑动还是向下滑动
     touchStartRef.current = event.touches[0].pageY
     // 标记开始滑动
@@ -230,7 +235,13 @@ export const Popup: FunctionComponent<
   }
 
   const handleTouchMove = (event: ITouchEvent) => {
-    if (!resizable || !nodeRef.current || !rootRect.current) return
+    if (
+      position !== 'bottom' ||
+      !resizable ||
+      !nodeRef.current ||
+      !rootRect.current
+    )
+      return
     event.stopPropagation()
 
     // move过程中，当前的pageY 与 start值比较
@@ -259,7 +270,13 @@ export const Popup: FunctionComponent<
   }
 
   const handleTouchEnd = (event: ITouchEvent) => {
-    if (!resizable || !nodeRef.current || !rootRect.current) return
+    if (
+      position !== 'bottom' ||
+      !resizable ||
+      !nodeRef.current ||
+      !rootRect.current
+    )
+      return
     console.log('touchend', event)
     isTouching.current = false
     const currentHeight = heightRef.current - touchMoveDistanceRef.current

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -33,7 +33,7 @@ const defaultProps: TaroPopupProps = {
   overlay: true,
   round: false,
   resizable: false,
-  minHeight: '26%',
+  minHeight: '',
   onOpen: () => {},
   onClose: () => {},
   onOverlayClick: () => true,

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -4,17 +4,20 @@ import React, {
   useEffect,
   ReactElement,
   ReactPortal,
+  useRef,
 } from 'react'
 import { createPortal } from 'react-dom'
 import { CSSTransition } from 'react-transition-group'
 import classNames from 'classnames'
 import { Close } from '@nutui/icons-react-taro'
 import { View, ITouchEvent } from '@tarojs/components'
+import { getRectInMultiPlatform } from '@/utils/taro/get-rect'
 import { defaultOverlayProps } from '@/packages/overlay/overlay.taro'
 import Overlay from '@/packages/overlay/index.taro'
 import { useLockScrollTaro } from '@/hooks/taro/use-lock-scoll'
 import { TaroPopupProps } from '@/types'
 import { harmony } from '@/utils/taro/platform'
+import { pxTransform } from '@/utils/taro/px-transform'
 
 const defaultProps: TaroPopupProps = {
   ...defaultOverlayProps,
@@ -29,10 +32,15 @@ const defaultProps: TaroPopupProps = {
   portal: null,
   overlay: true,
   round: false,
+  resizable: false,
+  minHeight: '26%',
   onOpen: () => {},
   onClose: () => {},
   onOverlayClick: () => true,
   onCloseIconClick: () => true,
+  onTouchStart: () => {},
+  onTouchMove: () => {},
+  onTouchEnd: () => {},
 }
 
 // 默认1000，参看variables
@@ -40,7 +48,10 @@ const _zIndex = 1100
 
 export const Popup: FunctionComponent<
   Partial<TaroPopupProps> &
-    Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick' | 'title'>
+    Omit<
+      React.HTMLAttributes<HTMLDivElement>,
+      'onClick' | 'title' | 'onTouchStart' | 'onTouchMove' | 'onTouchEnd'
+    >
 > = (props) => {
   const {
     children,
@@ -65,6 +76,8 @@ export const Popup: FunctionComponent<
     className,
     destroyOnClose,
     portal,
+    resizable,
+    minHeight,
     onOpen,
     onClose,
     onOverlayClick,
@@ -72,21 +85,29 @@ export const Popup: FunctionComponent<
     afterShow,
     afterClose,
     onClick,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
   } = { ...defaultProps, ...props }
-
   let innerIndex = zIndex || _zIndex
   const [index, setIndex] = useState(innerIndex)
   const [innerVisible, setInnerVisible] = useState(visible)
   const [showChildren, setShowChildren] = useState(true)
   const [transitionName, setTransitionName] = useState('')
-  const refObject = useLockScrollTaro(innerVisible && lockScroll)
-  const classPrefix = 'nut-popup'
+  const nodeRef = useLockScrollTaro(innerVisible && lockScroll)
 
+  const rootRect = useRef<any>(null)
+  const touchStartRef = useRef(0)
+  const touchMoveDistanceRef = useRef(0)
+  const heightRef = useRef(0)
+  const isTouching = useRef(false)
+
+  const classPrefix = 'nut-popup'
   const overlayStyles = {
     ...overlayStyle,
   }
   const contentZIndex = harmony() ? index + 1 : index // 解决harmony层级问题
-  const popStyles = { zIndex: contentZIndex, ...style }
+  const popStyles = { zIndex: contentZIndex, minHeight, ...style }
   const popClassName = classNames(
     classPrefix,
     {
@@ -98,6 +119,10 @@ export const Popup: FunctionComponent<
 
   const open = () => {
     if (!innerVisible) {
+      // 当高度改变后，再次打开时，将高度置为初始高度
+      if (resizable && nodeRef.current && heightRef.current) {
+        nodeRef.current.style.height = `${heightRef.current}px`
+      }
       setInnerVisible(true)
       setIndex(++innerIndex)
     }
@@ -182,26 +207,80 @@ export const Popup: FunctionComponent<
     }
   }
 
+  const handleTouchStart = async (event: ITouchEvent) => {
+    if (!resizable || !nodeRef.current) return
+    // 开始touch，记录下touch的pageY，用以判断是向上滑动还是向下滑动
+    touchStartRef.current = event.touches[0].pageY
+    // 标记开始滑动
+    isTouching.current = true
+    // 标记当前popup的高度
+    const rect = await getRectInMultiPlatform(nodeRef.current)
+    rootRect.current = rect
+    heightRef.current =
+      rootRect.current?.height || nodeRef.current?.offsetHeight || 0
+    // console.log(
+    //   'touchstart',
+    //   touchStartRef.current,
+    //   heightRef.current,
+    //   rootRect.current,
+    //   nodeRef.current?.offsetHeight
+    // )
+    onTouchStart?.(rootRect.current.height, event)
+  }
+
+  const handleTouchMove = (event: ITouchEvent) => {
+    if (!resizable || !nodeRef.current || !rootRect.current) return
+    event.stopPropagation()
+
+    // console.log('向下', rootRect.current.height)
+
+    // move过程中，当前的pageY 与 start值比较
+    touchMoveDistanceRef.current =
+      event.touches[0].pageY - touchStartRef.current
+    // 向下滑动
+    if (touchMoveDistanceRef.current > 0 && isTouching.current) {
+      nodeRef.current.style.height = `${heightRef.current - touchMoveDistanceRef.current}px`
+      onTouchMove?.(nodeRef.current.style.height, event, 'down')
+      // console.log('向下', nodeRef.current.style.height)
+    } else {
+      // 向上滑动
+      nodeRef.current.style.height = pxTransform(
+        heightRef.current - touchMoveDistanceRef.current
+      )
+      onTouchMove?.(nodeRef.current.style.height, event, 'up')
+      // console.log('向上', nodeRef.current.style.height)
+    }
+  }
+
+  const handleTouchEnd = (event: ITouchEvent) => {
+    if (!resizable || !nodeRef.current || !rootRect.current) return
+    console.log('touchend', event)
+    isTouching.current = false
+    onTouchEnd?.(nodeRef.current.style.height, event)
+  }
+
   const renderContent = () => {
     return (
-      <>
-        <View
-          ref={refObject}
-          style={popStyles}
-          className={popClassName}
-          onClick={onClick}
-          catchMove={lockScroll}
-        >
-          {renderTitle()}
-          {showChildren ? children : null}
-        </View>
-      </>
+      <View
+        ref={nodeRef}
+        style={popStyles}
+        className={popClassName}
+        onClick={onClick}
+        catchMove={lockScroll}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
+      >
+        {renderTitle()}
+        {showChildren ? children : null}
+      </View>
     )
   }
   const renderPop = () => {
     return (
       <CSSTransition
-        nodeRef={refObject}
+        nodeRef={nodeRef}
         classNames={transitionName}
         mountOnEnter
         unmountOnExit={destroyOnClose}

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -10,7 +10,8 @@ import { createPortal } from 'react-dom'
 import { CSSTransition } from 'react-transition-group'
 import classNames from 'classnames'
 import { Close } from '@nutui/icons-react-taro'
-import { View, ITouchEvent } from '@tarojs/components'
+import { View } from '@tarojs/components'
+import type { ITouchEvent, CommonEventFunction } from '@tarojs/components'
 import { getRectInMultiPlatformWithoutCache } from '@/utils/taro/get-rect'
 import { defaultOverlayProps } from '@/packages/overlay/overlay.taro'
 import Overlay from '@/packages/overlay/index.taro'
@@ -94,12 +95,15 @@ export const Popup: FunctionComponent<
   const [innerVisible, setInnerVisible] = useState(visible)
   const [showChildren, setShowChildren] = useState(true)
   const [transitionName, setTransitionName] = useState('')
-  const nodeRef = useLockScrollTaro(innerVisible && lockScroll)
+  const nodeRef = useLockScrollTaro(
+    innerVisible && lockScroll
+  ) as React.MutableRefObject<any>
 
   const rootRect = useRef<any>(null)
   const touchStartRef = useRef(0)
   const touchMoveDistanceRef = useRef(0)
   const heightRef = useRef(0)
+  const defaultHeightRef = useRef(0)
   const isTouching = useRef(false)
 
   const classPrefix = 'nut-popup'
@@ -116,6 +120,14 @@ export const Popup: FunctionComponent<
     },
     className
   )
+  const [popupHeight, setPopupHeight] = useState('')
+  const resizeStyles = () => {
+    if (popupHeight !== '') {
+      return {
+        height: popupHeight,
+      }
+    }
+  }
 
   const open = () => {
     if (!innerVisible) {
@@ -126,7 +138,7 @@ export const Popup: FunctionComponent<
         nodeRef.current &&
         heightRef.current
       ) {
-        nodeRef.current.style.height = `${heightRef.current}px`
+        setPopupHeight(pxTransform(defaultHeightRef.current))
       }
       setInnerVisible(true)
       setIndex(++innerIndex)
@@ -212,10 +224,11 @@ export const Popup: FunctionComponent<
     }
   }
 
-  const handleTouchStart = async (event: ITouchEvent) => {
+  const handleTouchStart: CommonEventFunction = async (event) => {
     if (position !== 'bottom' || !resizable || !nodeRef.current) return
+    const e = event as ITouchEvent
     // 开始touch，记录下touch的pageY，用以判断是向上滑动还是向下滑动
-    touchStartRef.current = event.touches[0].pageY
+    touchStartRef.current = e.touches[0].pageY
     // 标记开始滑动
     isTouching.current = true
     // 标记当前popup的高度
@@ -223,18 +236,11 @@ export const Popup: FunctionComponent<
     rootRect.current = rect
     heightRef.current =
       nodeRef.current?.offsetHeight || rootRect.current?.height || 0
-    // console.log(
-    //   'touchstart',
-    //   touchStartRef.current,
-    //   heightRef.current, //
-    //   rootRect.current,
-    //   nodeRef.current?.offsetHeight, //
-    //   nodeRef.current.style.height //
-    // )
-    onTouchStart?.(heightRef.current, event)
+    if (!defaultHeightRef.current) defaultHeightRef.current = heightRef.current
+    onTouchStart?.(heightRef.current, e)
   }
 
-  const handleTouchMove = (event: ITouchEvent) => {
+  const handleTouchMove: CommonEventFunction = (event) => {
     if (
       position !== 'bottom' ||
       !resizable ||
@@ -242,34 +248,28 @@ export const Popup: FunctionComponent<
       !rootRect.current
     )
       return
-    event.stopPropagation()
 
-    // move过程中，当前的pageY 与 start值比较
-    touchMoveDistanceRef.current =
-      event.touches[0].pageY - touchStartRef.current
+    const e = event as ITouchEvent
+    e.stopPropagation()
+
+    // 计算位移：move过程中，当前的pageY 与 start值比较
+    touchMoveDistanceRef.current = e.touches[0].pageY - touchStartRef.current
 
     const handleMove = () => {
       const currentHeight = heightRef.current - touchMoveDistanceRef.current
-      nodeRef.current.style.height = pxTransform(currentHeight)
+      setPopupHeight(pxTransform(currentHeight))
       if (touchMoveDistanceRef.current > 0 && isTouching.current) {
         // 向下滑动
-        onTouchMove?.(currentHeight, event, 'down')
-        // console.log('向下', nodeRef.current.style.height)
+        onTouchMove?.(currentHeight, e, 'down')
       } else {
         // 向上滑动
-        onTouchMove?.(currentHeight, event, 'up')
-        console.log(
-          '向上',
-          heightRef.current,
-          touchMoveDistanceRef.current,
-          currentHeight
-        )
+        onTouchMove?.(currentHeight, e, 'up')
       }
     }
     requestAnimationFrame(handleMove)
   }
 
-  const handleTouchEnd = (event: ITouchEvent) => {
+  const handleTouchEnd: CommonEventFunction = (event) => {
     if (
       position !== 'bottom' ||
       !resizable ||
@@ -277,17 +277,21 @@ export const Popup: FunctionComponent<
       !rootRect.current
     )
       return
-    console.log('touchend', event)
+    const e = event as ITouchEvent
     isTouching.current = false
     const currentHeight = heightRef.current - touchMoveDistanceRef.current
-    onTouchEnd?.(currentHeight, event)
+    onTouchEnd?.(currentHeight, e)
   }
 
   const renderContent = () => {
     return (
       <View
         ref={nodeRef}
-        style={popStyles}
+        style={{
+          ...popStyles,
+          display: innerVisible ? 'block' : 'none',
+          ...resizeStyles(),
+        }}
         className={popClassName}
         onClick={onClick}
         catchMove={lockScroll}

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -256,7 +256,14 @@ export const Popup: FunctionComponent<
     touchMoveDistanceRef.current = e.touches[0].pageY - touchStartRef.current
 
     const handleMove = () => {
-      const currentHeight = heightRef.current - touchMoveDistanceRef.current
+      const min =
+        typeof minHeight === 'number'
+          ? minHeight
+          : parseInt(String(minHeight || 0), 10) || 0
+      const currentHeight = Math.max(
+        min,
+        heightRef.current - touchMoveDistanceRef.current
+      )
       setPopupHeight(pxTransform(currentHeight))
       if (touchMoveDistanceRef.current > 0 && isTouching.current) {
         // 向下滑动
@@ -279,7 +286,14 @@ export const Popup: FunctionComponent<
       return
     const e = event as ITouchEvent
     isTouching.current = false
-    const currentHeight = heightRef.current - touchMoveDistanceRef.current
+    const min =
+      typeof minHeight === 'number'
+        ? minHeight
+        : parseInt(String(minHeight || 0), 10) || 0
+    const currentHeight = Math.max(
+      min,
+      heightRef.current - touchMoveDistanceRef.current
+    )
     onTouchEnd?.(currentHeight, e)
   }
 

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -11,7 +11,7 @@ import { CSSTransition } from 'react-transition-group'
 import classNames from 'classnames'
 import { Close } from '@nutui/icons-react-taro'
 import { View, ITouchEvent } from '@tarojs/components'
-import { getRectInMultiPlatform } from '@/utils/taro/get-rect'
+import { getRectInMultiPlatformWithoutCache } from '@/utils/taro/get-rect'
 import { defaultOverlayProps } from '@/packages/overlay/overlay.taro'
 import Overlay from '@/packages/overlay/index.taro'
 import { useLockScrollTaro } from '@/hooks/taro/use-lock-scoll'
@@ -214,49 +214,56 @@ export const Popup: FunctionComponent<
     // 标记开始滑动
     isTouching.current = true
     // 标记当前popup的高度
-    const rect = await getRectInMultiPlatform(nodeRef.current)
+    const rect = await getRectInMultiPlatformWithoutCache(nodeRef.current)
     rootRect.current = rect
     heightRef.current =
-      rootRect.current?.height || nodeRef.current?.offsetHeight || 0
+      nodeRef.current?.offsetHeight || rootRect.current?.height || 0
     // console.log(
     //   'touchstart',
     //   touchStartRef.current,
-    //   heightRef.current,
+    //   heightRef.current, //
     //   rootRect.current,
-    //   nodeRef.current?.offsetHeight
+    //   nodeRef.current?.offsetHeight, //
+    //   nodeRef.current.style.height //
     // )
-    onTouchStart?.(rootRect.current.height, event)
+    onTouchStart?.(heightRef.current, event)
   }
 
   const handleTouchMove = (event: ITouchEvent) => {
     if (!resizable || !nodeRef.current || !rootRect.current) return
     event.stopPropagation()
 
-    // console.log('向下', rootRect.current.height)
-
     // move过程中，当前的pageY 与 start值比较
     touchMoveDistanceRef.current =
       event.touches[0].pageY - touchStartRef.current
-    // 向下滑动
-    if (touchMoveDistanceRef.current > 0 && isTouching.current) {
-      nodeRef.current.style.height = `${heightRef.current - touchMoveDistanceRef.current}px`
-      onTouchMove?.(nodeRef.current.style.height, event, 'down')
-      // console.log('向下', nodeRef.current.style.height)
-    } else {
-      // 向上滑动
-      nodeRef.current.style.height = pxTransform(
-        heightRef.current - touchMoveDistanceRef.current
-      )
-      onTouchMove?.(nodeRef.current.style.height, event, 'up')
-      // console.log('向上', nodeRef.current.style.height)
+
+    const handleMove = () => {
+      const currentHeight = heightRef.current - touchMoveDistanceRef.current
+      nodeRef.current.style.height = pxTransform(currentHeight)
+      if (touchMoveDistanceRef.current > 0 && isTouching.current) {
+        // 向下滑动
+        onTouchMove?.(currentHeight, event, 'down')
+        // console.log('向下', nodeRef.current.style.height)
+      } else {
+        // 向上滑动
+        onTouchMove?.(currentHeight, event, 'up')
+        console.log(
+          '向上',
+          heightRef.current,
+          touchMoveDistanceRef.current,
+          currentHeight
+        )
+      }
     }
+    requestAnimationFrame(handleMove)
   }
 
   const handleTouchEnd = (event: ITouchEvent) => {
     if (!resizable || !nodeRef.current || !rootRect.current) return
     console.log('touchend', event)
     isTouching.current = false
-    onTouchEnd?.(nodeRef.current.style.height, event)
+    const currentHeight = heightRef.current - touchMoveDistanceRef.current
+    onTouchEnd?.(currentHeight, event)
   }
 
   const renderContent = () => {

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -235,7 +235,15 @@ export const Popup: FunctionComponent<
     touchMoveDistanceRef.current =
       event.touches[0].pageY - touchStartRef.current
 
-    const currentHeight = heightRef.current - touchMoveDistanceRef.current
+    const min =
+      typeof minHeight === 'number'
+        ? minHeight
+        : parseInt(String(minHeight || 0), 10) || 0
+    const currentHeight = Math.max(
+      min,
+      heightRef.current - touchMoveDistanceRef.current
+    )
+
     nodeRef.current.style.height = `${currentHeight}px`
     // 向下滑动
     if (touchMoveDistanceRef.current > 0) {
@@ -249,7 +257,14 @@ export const Popup: FunctionComponent<
   const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
     if (position !== 'bottom' || !resizable || !nodeRef.current) return
     isTouching.current = false
-    const currentHeight = heightRef.current - touchMoveDistanceRef.current
+    const min =
+      typeof minHeight === 'number'
+        ? minHeight
+        : parseInt(String(minHeight || 0), 10) || 0
+    const currentHeight = Math.max(
+      min,
+      heightRef.current - touchMoveDistanceRef.current
+    )
     onTouchEnd?.(currentHeight, event)
   }
 

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -217,7 +217,7 @@ export const Popup: FunctionComponent<
     // 标记当前popup的高度
     heightRef.current = nodeRef.current?.offsetHeight || 0
     console.log('touchstart', touchStartRef.current, heightRef.current)
-    onTouchStart?.(nodeRef.current.style.height, event)
+    onTouchStart?.(heightRef.current, event)
   }
 
   const handleTouchMove = (event: TouchEvent<HTMLDivElement>) => {
@@ -228,20 +228,14 @@ export const Popup: FunctionComponent<
     touchMoveDistanceRef.current =
       event.touches[0].pageY - touchStartRef.current
 
-    // console.log(
-    //   'touchMoveDistanceRef.current',
-    //   touchMoveDistanceRef.current,
-    //   event.touches[0].pageY,
-    //   touchStartRef.current
-    // )
+    const currentHeight = heightRef.current - touchMoveDistanceRef.current
+    nodeRef.current.style.height = `${currentHeight}px`
     // 向下滑动
     if (touchMoveDistanceRef.current > 0) {
-      nodeRef.current.style.height = `${heightRef.current - touchMoveDistanceRef.current}px`
-      onTouchMove?.(nodeRef.current.style.height, event, 'down')
+      onTouchMove?.(currentHeight, event, 'down')
     } else {
       // 向上滑动
-      nodeRef.current.style.height = `${heightRef.current - touchMoveDistanceRef.current}px`
-      onTouchMove?.(nodeRef.current.style.height, event, 'up')
+      onTouchMove?.(currentHeight, event, 'up')
     }
   }
 
@@ -249,7 +243,8 @@ export const Popup: FunctionComponent<
     if (!resizable || !nodeRef.current) return
     console.log('touchend', event)
     isTouching.current = false
-    onTouchEnd?.(nodeRef.current.style.height, event)
+    const currentHeight = heightRef.current - touchMoveDistanceRef.current
+    onTouchEnd?.(currentHeight, event)
   }
 
   const renderPop = () => {

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -123,7 +123,12 @@ export const Popup: FunctionComponent<
   const open = () => {
     if (!innerVisible) {
       // 当高度改变后，再次打开时，将高度置为初始高度
-      if (resizable && nodeRef.current && heightRef.current) {
+      if (
+        position === 'bottom' &&
+        resizable &&
+        nodeRef.current &&
+        heightRef.current
+      ) {
         nodeRef.current.style.height = `${heightRef.current}px`
       }
       setInnerVisible(true)
@@ -209,7 +214,7 @@ export const Popup: FunctionComponent<
   }
 
   const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
-    if (!resizable || !nodeRef.current) return
+    if (position !== 'bottom' || !resizable || !nodeRef.current) return
     // 开始touch，记录下touch的pageY，用以判断是向上滑动还是向下滑动
     touchStartRef.current = event.touches[0].pageY
     // 标记开始滑动
@@ -221,7 +226,7 @@ export const Popup: FunctionComponent<
   }
 
   const handleTouchMove = (event: TouchEvent<HTMLDivElement>) => {
-    if (!resizable || !nodeRef.current) return
+    if (position !== 'bottom' || !resizable || !nodeRef.current) return
     event.stopPropagation()
 
     // move过程中，当前的pageY 与 start值比较
@@ -240,7 +245,7 @@ export const Popup: FunctionComponent<
   }
 
   const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
-    if (!resizable || !nodeRef.current) return
+    if (position !== 'bottom' || !resizable || !nodeRef.current) return
     console.log('touchend', event)
     isTouching.current = false
     const currentHeight = heightRef.current - touchMoveDistanceRef.current

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -31,7 +31,7 @@ const defaultProps: WebPopupProps = {
   overlay: true,
   round: false,
   resizable: false,
-  minHeight: '26%',
+  minHeight: '',
   onOpen: () => {},
   onClose: () => {},
   onOverlayClick: () => true,

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -4,7 +4,10 @@ import React, {
   ReactPortal,
   useEffect,
   useState,
+  useRef,
 } from 'react'
+import type { TouchEvent } from 'react'
+
 import { createPortal } from 'react-dom'
 import { CSSTransition } from 'react-transition-group'
 import classNames from 'classnames'
@@ -27,17 +30,26 @@ const defaultProps: WebPopupProps = {
   portal: null,
   overlay: true,
   round: false,
+  resizable: false,
+  minHeight: '26%',
   onOpen: () => {},
   onClose: () => {},
   onOverlayClick: () => true,
   onCloseIconClick: () => true,
+  onTouchStart: () => {},
+  onTouchMove: () => {},
+  onTouchEnd: () => {},
 }
 
 // 默认1000，参看variables
 const _zIndex = 1100
 
 export const Popup: FunctionComponent<
-  Partial<WebPopupProps> & Omit<React.HTMLAttributes<HTMLDivElement>, 'title'>
+  Partial<WebPopupProps> &
+    Omit<
+      React.HTMLAttributes<HTMLDivElement>,
+      'title' | 'onTouchStart' | 'onTouchMove' | 'onTouchEnd'
+    >
 > = (props) => {
   const {
     children,
@@ -62,6 +74,8 @@ export const Popup: FunctionComponent<
     className,
     destroyOnClose,
     portal,
+    resizable,
+    minHeight,
     onOpen,
     onClose,
     onOverlayClick,
@@ -69,6 +83,9 @@ export const Popup: FunctionComponent<
     afterShow,
     afterClose,
     onClick,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
   } = { ...defaultProps, ...props }
   const nodeRef = React.useRef<HTMLDivElement | null>(null)
   let innerIndex = zIndex || _zIndex
@@ -77,13 +94,23 @@ export const Popup: FunctionComponent<
   const [showChildren, setShowChildren] = useState(true)
   const [transitionName, setTransitionName] = useState('')
 
+  const touchStartRef = useRef(0)
+  const touchMoveDistanceRef = useRef(0)
+  const heightRef = useRef(0)
+  const isTouching = useRef(false)
+
   useLockScroll(nodeRef, innerVisible && lockScroll)
 
   const classPrefix = 'nut-popup'
   const overlayStyles = {
     ...overlayStyle,
   }
-  const popStyles = { ...style, zIndex: index }
+  const popStyles = {
+    ...style,
+    zIndex: index,
+    minHeight,
+  }
+
   const popClassName = classNames(
     classPrefix,
     {
@@ -95,6 +122,10 @@ export const Popup: FunctionComponent<
 
   const open = () => {
     if (!innerVisible) {
+      // 当高度改变后，再次打开时，将高度置为初始高度
+      if (resizable && nodeRef.current && heightRef.current) {
+        nodeRef.current.style.height = `${heightRef.current}px`
+      }
       setInnerVisible(true)
       setIndex(++innerIndex)
     }
@@ -176,6 +207,51 @@ export const Popup: FunctionComponent<
       return renderCloseIcon()
     }
   }
+
+  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    if (!resizable || !nodeRef.current) return
+    // 开始touch，记录下touch的pageY，用以判断是向上滑动还是向下滑动
+    touchStartRef.current = event.touches[0].pageY
+    // 标记开始滑动
+    isTouching.current = true
+    // 标记当前popup的高度
+    heightRef.current = nodeRef.current?.offsetHeight || 0
+    console.log('touchstart', touchStartRef.current, heightRef.current)
+    onTouchStart?.(nodeRef.current.style.height, event)
+  }
+
+  const handleTouchMove = (event: TouchEvent<HTMLDivElement>) => {
+    if (!resizable || !nodeRef.current) return
+    event.stopPropagation()
+
+    // move过程中，当前的pageY 与 start值比较
+    touchMoveDistanceRef.current =
+      event.touches[0].pageY - touchStartRef.current
+
+    // console.log(
+    //   'touchMoveDistanceRef.current',
+    //   touchMoveDistanceRef.current,
+    //   event.touches[0].pageY,
+    //   touchStartRef.current
+    // )
+    // 向下滑动
+    if (touchMoveDistanceRef.current > 0) {
+      nodeRef.current.style.height = `${heightRef.current - touchMoveDistanceRef.current}px`
+      onTouchMove?.(nodeRef.current.style.height, event, 'down')
+    } else {
+      // 向上滑动
+      nodeRef.current.style.height = `${heightRef.current - touchMoveDistanceRef.current}px`
+      onTouchMove?.(nodeRef.current.style.height, event, 'up')
+    }
+  }
+
+  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    if (!resizable || !nodeRef.current) return
+    console.log('touchend', event)
+    isTouching.current = false
+    onTouchEnd?.(nodeRef.current.style.height, event)
+  }
+
   const renderPop = () => {
     return (
       <CSSTransition
@@ -193,6 +269,10 @@ export const Popup: FunctionComponent<
           style={popStyles}
           className={popClassName}
           onClick={onClick}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          onTouchCancel={handleTouchEnd}
         >
           {renderTitle()}
           {showChildren && children}

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -221,7 +221,6 @@ export const Popup: FunctionComponent<
     isTouching.current = true
     // 标记当前popup的高度
     heightRef.current = nodeRef.current?.offsetHeight || 0
-    console.log('touchstart', touchStartRef.current, heightRef.current)
     onTouchStart?.(heightRef.current, event)
   }
 
@@ -246,7 +245,6 @@ export const Popup: FunctionComponent<
 
   const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
     if (position !== 'bottom' || !resizable || !nodeRef.current) return
-    console.log('touchend', event)
     isTouching.current = false
     const currentHeight = heightRef.current - touchMoveDistanceRef.current
     onTouchEnd?.(currentHeight, event)

--- a/src/packages/popup/popup.tsx
+++ b/src/packages/popup/popup.tsx
@@ -97,6 +97,8 @@ export const Popup: FunctionComponent<
   const touchStartRef = useRef(0)
   const touchMoveDistanceRef = useRef(0)
   const heightRef = useRef(0)
+  // 首次可调整时记录的默认高度
+  const defaultHeightRef = useRef(0)
   const isTouching = useRef(false)
 
   useLockScroll(nodeRef, innerVisible && lockScroll)
@@ -129,7 +131,7 @@ export const Popup: FunctionComponent<
         nodeRef.current &&
         heightRef.current
       ) {
-        nodeRef.current.style.height = `${heightRef.current}px`
+        nodeRef.current.style.height = `${defaultHeightRef.current}px`
       }
       setInnerVisible(true)
       setIndex(++innerIndex)
@@ -221,6 +223,7 @@ export const Popup: FunctionComponent<
     isTouching.current = true
     // 标记当前popup的高度
     heightRef.current = nodeRef.current?.offsetHeight || 0
+    if (!defaultHeightRef.current) defaultHeightRef.current = heightRef.current
     onTouchStart?.(heightRef.current, event)
   }
 

--- a/src/packages/range/range.tsx
+++ b/src/packages/range/range.tsx
@@ -2,6 +2,7 @@ import type { TouchEvent } from 'react'
 import React, {
   FunctionComponent,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -21,6 +22,7 @@ const defaultProps = {
   max: 100,
   step: 1,
   vertical: false,
+  marks: {},
 } as WebRangeProps
 
 const classPrefix = 'nut-range'
@@ -28,6 +30,13 @@ const verticalClassPrefix = `${classPrefix}-vertical`
 
 const isSameValue = (newValue: RangeValue, oldValue: RangeValue) => {
   return JSON.stringify(newValue) === JSON.stringify(oldValue)
+}
+
+const handleOverlap = (value: number[]) => {
+  if (value[0] > value[1]) {
+    return value.slice(0).reverse()
+  }
+  return value
 }
 
 export const Range: FunctionComponent<
@@ -41,7 +50,14 @@ export const Range: FunctionComponent<
   const {
     className,
     style,
+    range,
+    disabled,
+    button,
     vertical,
+    marks,
+    minDescription,
+    maxDescription,
+    currentDescription,
     min,
     max,
     step,
@@ -52,9 +68,15 @@ export const Range: FunctionComponent<
     onEnd,
   } = { ...defaultProps, ...props }
 
+  const rtlClassPrefix = useMemo(
+    () => `rtl-${vertical ? verticalClassPrefix : classPrefix}`,
+    [vertical]
+  )
+  const [buttonIndex, setButtonIndex] = useState(0)
   const [dragStatus, setDragStatus] = useState('start')
   const touch = useTouch()
-  const nodeRef = useRef<HTMLDivElement>(null)
+  const root = useRef<HTMLDivElement>(null)
+  const [marksList, setMarksList] = useState<number[]>([])
   const [startValue, setStartValue] = useState<any>(0)
   const scope = useMemo(() => {
     if (max < min || max === min) {
@@ -72,8 +94,33 @@ export const Range: FunctionComponent<
     finalValue: 0,
     onChange: handleChange,
   })
-
+  const [exactValue, setExactValue] = useState<RangeValue>(
+    () => value || defaultValue || 0
+  )
+  const marksRef = useRef<{ [key: string]: any }>({})
+  useEffect(() => {
+    if (marks) {
+      if (Array.isArray(marks)) {
+        const list = marks
+          .sort((a, b) => a.value - b.value)
+          .filter((point) => point.value >= min && point.value <= max)
+        setMarksList(list.map((mark) => mark.value))
+        list.forEach((mark) => {
+          marksRef.current[mark.value] =
+            mark.label !== undefined ? mark.label : mark.value
+        })
+      } else {
+        const marksKeys = Object.keys(marks)
+        const list: any = marksKeys
+          .map(parseFloat)
+          .sort((a, b) => a - b)
+          .filter((point) => point >= min && point <= max)
+        setMarksList(list)
+      }
+    }
+  }, [marks, max, min])
   const classes = classNames(classPrefix, {
+    [`${classPrefix}-disabled`]: disabled,
     [verticalClassPrefix]: vertical,
   })
 
@@ -84,15 +131,57 @@ export const Range: FunctionComponent<
     },
     className
   )
+  const markClassName = useCallback(
+    (mark: any) => {
+      const classPrefix = 'nut-range-mark'
+      const verticalClassPrefix = 'nut-range-vertical-mark'
+      let lowerBound = min
+      let upperBound = max
+      if (range && Array.isArray(current)) {
+        lowerBound = current[0]
+        upperBound = current[1]
+      } else {
+        upperBound = current as number
+      }
+      const isActive = mark <= upperBound && mark >= lowerBound
+      const classNames = [
+        `${classPrefix}-text-wrapper`,
+        `${isActive ? `${classPrefix}-text-wrapper-active` : ''}`,
+      ]
+
+      if (vertical) {
+        classNames.push(`${verticalClassPrefix}-text-wrapper`)
+        isActive &&
+          classNames.push(`${verticalClassPrefix}-text-active-wrapper`)
+      }
+
+      if (rtl) {
+        classNames.push(`${rtlClassPrefix}-mark-text-wrapper`)
+      }
+
+      return classNames.join(' ')
+    },
+    [min, max, range, current, vertical, rtl, rtlClassPrefix]
+  )
+
+  const isRange = useCallback(
+    (val: any) => {
+      return !!range && Array.isArray(val)
+    },
+    [range]
+  )
 
   const calcMainAxis = useCallback(() => {
     const modelVal = current as any
-    return `${((modelVal - min) * 100) / scope}%`
-  }, [current, min, scope])
+    return isRange(modelVal)
+      ? `${((modelVal[1] - modelVal[0]) * 100) / scope}%`
+      : `${((modelVal - min) * 100) / scope}%`
+  }, [current, isRange, min, scope])
 
   const calcOffset = useCallback(() => {
-    return `0%`
-  }, [])
+    const modelVal = current as any
+    return isRange(modelVal) ? `${((modelVal[0] - min) * 100) / scope}%` : `0%`
+  }, [current, isRange, min, scope])
 
   const barStyle = useCallback(() => {
     if (vertical) {
@@ -110,6 +199,32 @@ export const Range: FunctionComponent<
     }
   }, [calcMainAxis, calcOffset, dragStatus, rtl, vertical])
 
+  const marksStyle = useCallback(
+    (mark: any) => {
+      const dir = rtl ? 'right' : 'left'
+      let style: any = {
+        [dir]: `${((mark - min) / scope) * 100}%`,
+      }
+      if (vertical) {
+        style = {
+          top: `${((mark - min) / scope) * 100}%`,
+        }
+      }
+      return style
+    },
+    [min, rtl, scope, vertical]
+  )
+
+  const tickClass = useCallback(
+    (mark: any) => {
+      if (range && Array.isArray(current)) {
+        return mark <= current[1] && mark >= current[0]
+      }
+      return mark <= current
+    },
+    [current, range]
+  )
+
   const format = useCallback(
     (value: number) => {
       value = Math.max(+min, Math.min(value, +max))
@@ -120,29 +235,67 @@ export const Range: FunctionComponent<
 
   const updateValue = useCallback(
     (value: any, end?: boolean) => {
-      value = format(value)
+      if (isRange(value)) {
+        value = handleOverlap(value).map(format)
+      } else {
+        value = format(value)
+      }
       if (!isSameValue(value, current)) {
         setCurrent(value)
       }
       end && onEnd && onEnd(value)
     },
-    [current, format, onEnd, setCurrent]
+    [current, format, isRange, onEnd, setCurrent]
+  )
+
+  const handleClick = useCallback(
+    (event: any) => {
+      if (disabled || !root.current) return
+      setDragStatus('')
+      const rect = getRect(root.current)
+      let delta = event.clientX - rect.left
+      let total = rect.width
+      if (vertical) {
+        delta = event.clientY - rect.top
+        total = rect.height
+      }
+      const value = min + (delta / total) * scope
+      setExactValue(current)
+      if (isRange(current)) {
+        const [left, right] = current as any
+        const middle = (left + right) / 2
+        if (value <= middle) {
+          updateValue([value, right], true)
+        } else {
+          updateValue([left, value], true)
+        }
+      } else {
+        updateValue(value, true)
+      }
+    },
+    [current, disabled, isRange, min, scope, updateValue, vertical]
   )
 
   const onTouchStart = useCallback(
     (event: any) => {
+      if (disabled) return
       touch.start(event)
-      setStartValue(format(current as number))
+      setExactValue(current)
+      if (isRange(current)) {
+        setStartValue((current as number[]).map(format))
+      } else {
+        setStartValue(format(current as number))
+      }
 
       setDragStatus('start')
     },
-    [current, format, touch]
+    [current, disabled, format, isRange, touch]
   )
 
   const onTouchMove = useCallback(
     (event: TouchEvent<HTMLDivElement>) => {
       event.stopPropagation()
-      if (!nodeRef.current) {
+      if (disabled || !root.current) {
         return
       }
       if (dragStatus === 'start') {
@@ -150,7 +303,7 @@ export const Range: FunctionComponent<
       }
       touch.move(event)
       setDragStatus('draging')
-      const rect = getRect(nodeRef.current)
+      const rect = getRect(root.current)
       let delta = touch.deltaX.current
       let total = rect.width
       let diff = (delta / total) * scope
@@ -160,18 +313,182 @@ export const Range: FunctionComponent<
         total = rect.height
         diff = (delta / total) * scope
       }
-      const newValue = startValue + diff
+      let newValue
+      if (isRange(startValue)) {
+        newValue = (exactValue as number[]).slice()
+        newValue[buttonIndex] = startValue[buttonIndex] + diff
+      } else {
+        newValue = startValue + diff
+      }
+      setExactValue(newValue)
       updateValue(newValue)
     },
-    [dragStatus, onStart, rtl, scope, startValue, touch, updateValue, vertical]
+    [
+      buttonIndex,
+      disabled,
+      dragStatus,
+      exactValue,
+      isRange,
+      onStart,
+      rtl,
+      scope,
+      startValue,
+      touch,
+      updateValue,
+      vertical,
+    ]
   )
 
   const onTouchEnd = useCallback(() => {
+    if (disabled) {
+      return
+    }
     if (dragStatus === 'draging') {
       updateValue(current, true)
     }
     setDragStatus('')
-  }, [current, dragStatus, updateValue])
+  }, [current, disabled, dragStatus, updateValue])
+
+  const curValue = useCallback(
+    (idx?: number) => {
+      const modelVal = current as any
+      const value = typeof idx === 'number' ? modelVal[idx] : modelVal
+      return value
+    },
+    [current]
+  )
+
+  const renderButton = useCallback(
+    (index?: number) => {
+      const buttonNumberTransform = vertical
+        ? 'translate(100%, -50%)'
+        : 'translate(-50%, -100%)'
+
+      return (
+        <>
+          {button || (
+            <div
+              className={classNames(`${classPrefix}-button`, {
+                [`${verticalClassPrefix}-button`]: vertical,
+                [`${rtlClassPrefix}-button`]: rtl,
+              })}
+              style={{
+                transform: 'translate(-50%, -50%)',
+              }}
+            >
+              {currentDescription !== null && (
+                <div
+                  className={classNames(`${classPrefix}-button-number`, {
+                    [`${verticalClassPrefix}-button-number`]: vertical,
+                    [`${rtlClassPrefix}-button-number`]: rtl,
+                  })}
+                  style={{
+                    transform: buttonNumberTransform,
+                  }}
+                >
+                  {currentDescription
+                    ? currentDescription(curValue(index))
+                    : curValue(index)}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )
+    },
+    [button, curValue, currentDescription, rtl, rtlClassPrefix, vertical]
+  )
+  const renderMarks = useCallback(() => {
+    if (marksList.length <= 0) return null
+    const markcls = classNames(`${classPrefix}-mark`, {
+      [`${verticalClassPrefix}-mark`]: vertical,
+      [`${rtlClassPrefix}-mark`]: rtl,
+    })
+    const textcls = classNames(`${classPrefix}-mark-text`, {
+      [`${verticalClassPrefix}-mark-text`]: vertical,
+    })
+    return (
+      <div className={markcls}>
+        {marksList.map((mark: any) => {
+          return (
+            <span
+              key={mark}
+              className={markClassName(mark)}
+              style={marksStyle(mark)}
+            >
+              <span className={textcls}>
+                {Array.isArray(marks) ? marksRef.current[mark] : marks[mark]}
+              </span>
+              <span
+                className={classNames(
+                  `${vertical ? verticalClassPrefix : classPrefix}-tick`,
+                  {
+                    [`${vertical ? verticalClassPrefix : classPrefix}-tick-active`]:
+                      tickClass(mark),
+                    [`${rtlClassPrefix}-tick`]: rtl,
+                  }
+                )}
+              />
+            </span>
+          )
+        })}
+      </div>
+    )
+  }, [
+    markClassName,
+    marks,
+    marksList,
+    marksStyle,
+    rtl,
+    rtlClassPrefix,
+    tickClass,
+    vertical,
+  ])
+
+  const getWrapperTransform = useCallback(() => {
+    const wrapperTransform = 'translate(-50%, -50%)'
+    return wrapperTransform
+  }, [])
+
+  const renderRangeButton = useCallback(() => {
+    return [0, 1].map((item, index) => {
+      const isLeft = index === 0
+      const suffix = isLeft ? 'left' : 'right'
+      const transform = 'translate(-50%, -50%)'
+      const cls = classNames(`${classPrefix}-button-wrapper-${suffix}`, {
+        [`${verticalClassPrefix}-button-wrapper-${suffix}`]: vertical,
+        [`${rtlClassPrefix}-button-wrapper-${suffix}`]: rtl,
+      })
+
+      return (
+        <div
+          key={index}
+          className={cls}
+          style={{
+            transform,
+          }}
+          onTouchStart={(e) => {
+            setButtonIndex(index)
+            onTouchStart(e)
+          }}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchEnd}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {renderButton(index)}
+        </div>
+      )
+    })
+  }, [
+    onTouchEnd,
+    onTouchMove,
+    onTouchStart,
+    renderButton,
+    vertical,
+    rtl,
+    rtlClassPrefix,
+  ])
 
   const renderSingleButton = useCallback(() => {
     return (
@@ -181,27 +498,51 @@ export const Range: FunctionComponent<
         })}
         style={{
           // @ts-ignore
-          transform: 'translate(-50%, -50%)',
+          transform: getWrapperTransform(),
         }}
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
         onTouchCancel={onTouchEnd}
         onClick={(e) => e.stopPropagation()}
-      />
+      >
+        {renderButton()}
+      </div>
     )
-  }, [onTouchEnd, onTouchMove, onTouchStart, vertical])
+  }, [
+    getWrapperTransform,
+    onTouchEnd,
+    onTouchMove,
+    onTouchStart,
+    renderButton,
+    vertical,
+  ])
+
+  const renderButtonWrapper = useCallback(() => {
+    if (range) {
+      return renderRangeButton()
+    }
+    return renderSingleButton()
+  }, [renderRangeButton, renderSingleButton, range])
 
   return (
     <div className={containerClasses} style={style}>
-      <div ref={nodeRef} className={classes}>
+      {minDescription !== null && (
+        <div className={`${classPrefix}-min`}>{minDescription || min}</div>
+      )}
+      <div ref={root} className={classes} onClick={handleClick}>
+        {renderMarks()}
+
         <div
           className={`${classPrefix}-bar ${classPrefix}-bar-animate`}
           style={barStyle()}
         >
-          {renderSingleButton()}
+          {renderButtonWrapper()}
         </div>
       </div>
+      {maxDescription !== null && (
+        <div className={`${classPrefix}-max`}>{maxDescription || max}</div>
+      )}
     </div>
   )
 }

--- a/src/packages/range/range.tsx
+++ b/src/packages/range/range.tsx
@@ -2,7 +2,6 @@ import type { TouchEvent } from 'react'
 import React, {
   FunctionComponent,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -22,7 +21,6 @@ const defaultProps = {
   max: 100,
   step: 1,
   vertical: false,
-  marks: {},
 } as WebRangeProps
 
 const classPrefix = 'nut-range'
@@ -30,13 +28,6 @@ const verticalClassPrefix = `${classPrefix}-vertical`
 
 const isSameValue = (newValue: RangeValue, oldValue: RangeValue) => {
   return JSON.stringify(newValue) === JSON.stringify(oldValue)
-}
-
-const handleOverlap = (value: number[]) => {
-  if (value[0] > value[1]) {
-    return value.slice(0).reverse()
-  }
-  return value
 }
 
 export const Range: FunctionComponent<
@@ -50,14 +41,7 @@ export const Range: FunctionComponent<
   const {
     className,
     style,
-    range,
-    disabled,
-    button,
     vertical,
-    marks,
-    minDescription,
-    maxDescription,
-    currentDescription,
     min,
     max,
     step,
@@ -68,15 +52,9 @@ export const Range: FunctionComponent<
     onEnd,
   } = { ...defaultProps, ...props }
 
-  const rtlClassPrefix = useMemo(
-    () => `rtl-${vertical ? verticalClassPrefix : classPrefix}`,
-    [vertical]
-  )
-  const [buttonIndex, setButtonIndex] = useState(0)
   const [dragStatus, setDragStatus] = useState('start')
   const touch = useTouch()
-  const root = useRef<HTMLDivElement>(null)
-  const [marksList, setMarksList] = useState<number[]>([])
+  const nodeRef = useRef<HTMLDivElement>(null)
   const [startValue, setStartValue] = useState<any>(0)
   const scope = useMemo(() => {
     if (max < min || max === min) {
@@ -94,33 +72,8 @@ export const Range: FunctionComponent<
     finalValue: 0,
     onChange: handleChange,
   })
-  const [exactValue, setExactValue] = useState<RangeValue>(
-    () => value || defaultValue || 0
-  )
-  const marksRef = useRef<{ [key: string]: any }>({})
-  useEffect(() => {
-    if (marks) {
-      if (Array.isArray(marks)) {
-        const list = marks
-          .sort((a, b) => a.value - b.value)
-          .filter((point) => point.value >= min && point.value <= max)
-        setMarksList(list.map((mark) => mark.value))
-        list.forEach((mark) => {
-          marksRef.current[mark.value] =
-            mark.label !== undefined ? mark.label : mark.value
-        })
-      } else {
-        const marksKeys = Object.keys(marks)
-        const list: any = marksKeys
-          .map(parseFloat)
-          .sort((a, b) => a - b)
-          .filter((point) => point >= min && point <= max)
-        setMarksList(list)
-      }
-    }
-  }, [marks, max, min])
+
   const classes = classNames(classPrefix, {
-    [`${classPrefix}-disabled`]: disabled,
     [verticalClassPrefix]: vertical,
   })
 
@@ -131,57 +84,15 @@ export const Range: FunctionComponent<
     },
     className
   )
-  const markClassName = useCallback(
-    (mark: any) => {
-      const classPrefix = 'nut-range-mark'
-      const verticalClassPrefix = 'nut-range-vertical-mark'
-      let lowerBound = min
-      let upperBound = max
-      if (range && Array.isArray(current)) {
-        lowerBound = current[0]
-        upperBound = current[1]
-      } else {
-        upperBound = current as number
-      }
-      const isActive = mark <= upperBound && mark >= lowerBound
-      const classNames = [
-        `${classPrefix}-text-wrapper`,
-        `${isActive ? `${classPrefix}-text-wrapper-active` : ''}`,
-      ]
-
-      if (vertical) {
-        classNames.push(`${verticalClassPrefix}-text-wrapper`)
-        isActive &&
-          classNames.push(`${verticalClassPrefix}-text-active-wrapper`)
-      }
-
-      if (rtl) {
-        classNames.push(`${rtlClassPrefix}-mark-text-wrapper`)
-      }
-
-      return classNames.join(' ')
-    },
-    [min, max, range, current, vertical, rtl, rtlClassPrefix]
-  )
-
-  const isRange = useCallback(
-    (val: any) => {
-      return !!range && Array.isArray(val)
-    },
-    [range]
-  )
 
   const calcMainAxis = useCallback(() => {
     const modelVal = current as any
-    return isRange(modelVal)
-      ? `${((modelVal[1] - modelVal[0]) * 100) / scope}%`
-      : `${((modelVal - min) * 100) / scope}%`
-  }, [current, isRange, min, scope])
+    return `${((modelVal - min) * 100) / scope}%`
+  }, [current, min, scope])
 
   const calcOffset = useCallback(() => {
-    const modelVal = current as any
-    return isRange(modelVal) ? `${((modelVal[0] - min) * 100) / scope}%` : `0%`
-  }, [current, isRange, min, scope])
+    return `0%`
+  }, [])
 
   const barStyle = useCallback(() => {
     if (vertical) {
@@ -199,32 +110,6 @@ export const Range: FunctionComponent<
     }
   }, [calcMainAxis, calcOffset, dragStatus, rtl, vertical])
 
-  const marksStyle = useCallback(
-    (mark: any) => {
-      const dir = rtl ? 'right' : 'left'
-      let style: any = {
-        [dir]: `${((mark - min) / scope) * 100}%`,
-      }
-      if (vertical) {
-        style = {
-          top: `${((mark - min) / scope) * 100}%`,
-        }
-      }
-      return style
-    },
-    [min, rtl, scope, vertical]
-  )
-
-  const tickClass = useCallback(
-    (mark: any) => {
-      if (range && Array.isArray(current)) {
-        return mark <= current[1] && mark >= current[0]
-      }
-      return mark <= current
-    },
-    [current, range]
-  )
-
   const format = useCallback(
     (value: number) => {
       value = Math.max(+min, Math.min(value, +max))
@@ -235,67 +120,29 @@ export const Range: FunctionComponent<
 
   const updateValue = useCallback(
     (value: any, end?: boolean) => {
-      if (isRange(value)) {
-        value = handleOverlap(value).map(format)
-      } else {
-        value = format(value)
-      }
+      value = format(value)
       if (!isSameValue(value, current)) {
         setCurrent(value)
       }
       end && onEnd && onEnd(value)
     },
-    [current, format, isRange, onEnd, setCurrent]
-  )
-
-  const handleClick = useCallback(
-    (event: any) => {
-      if (disabled || !root.current) return
-      setDragStatus('')
-      const rect = getRect(root.current)
-      let delta = event.clientX - rect.left
-      let total = rect.width
-      if (vertical) {
-        delta = event.clientY - rect.top
-        total = rect.height
-      }
-      const value = min + (delta / total) * scope
-      setExactValue(current)
-      if (isRange(current)) {
-        const [left, right] = current as any
-        const middle = (left + right) / 2
-        if (value <= middle) {
-          updateValue([value, right], true)
-        } else {
-          updateValue([left, value], true)
-        }
-      } else {
-        updateValue(value, true)
-      }
-    },
-    [current, disabled, isRange, min, scope, updateValue, vertical]
+    [current, format, onEnd, setCurrent]
   )
 
   const onTouchStart = useCallback(
     (event: any) => {
-      if (disabled) return
       touch.start(event)
-      setExactValue(current)
-      if (isRange(current)) {
-        setStartValue((current as number[]).map(format))
-      } else {
-        setStartValue(format(current as number))
-      }
+      setStartValue(format(current as number))
 
       setDragStatus('start')
     },
-    [current, disabled, format, isRange, touch]
+    [current, format, touch]
   )
 
   const onTouchMove = useCallback(
     (event: TouchEvent<HTMLDivElement>) => {
       event.stopPropagation()
-      if (disabled || !root.current) {
+      if (!nodeRef.current) {
         return
       }
       if (dragStatus === 'start') {
@@ -303,7 +150,7 @@ export const Range: FunctionComponent<
       }
       touch.move(event)
       setDragStatus('draging')
-      const rect = getRect(root.current)
+      const rect = getRect(nodeRef.current)
       let delta = touch.deltaX.current
       let total = rect.width
       let diff = (delta / total) * scope
@@ -313,182 +160,18 @@ export const Range: FunctionComponent<
         total = rect.height
         diff = (delta / total) * scope
       }
-      let newValue
-      if (isRange(startValue)) {
-        newValue = (exactValue as number[]).slice()
-        newValue[buttonIndex] = startValue[buttonIndex] + diff
-      } else {
-        newValue = startValue + diff
-      }
-      setExactValue(newValue)
+      const newValue = startValue + diff
       updateValue(newValue)
     },
-    [
-      buttonIndex,
-      disabled,
-      dragStatus,
-      exactValue,
-      isRange,
-      onStart,
-      rtl,
-      scope,
-      startValue,
-      touch,
-      updateValue,
-      vertical,
-    ]
+    [dragStatus, onStart, rtl, scope, startValue, touch, updateValue, vertical]
   )
 
   const onTouchEnd = useCallback(() => {
-    if (disabled) {
-      return
-    }
     if (dragStatus === 'draging') {
       updateValue(current, true)
     }
     setDragStatus('')
-  }, [current, disabled, dragStatus, updateValue])
-
-  const curValue = useCallback(
-    (idx?: number) => {
-      const modelVal = current as any
-      const value = typeof idx === 'number' ? modelVal[idx] : modelVal
-      return value
-    },
-    [current]
-  )
-
-  const renderButton = useCallback(
-    (index?: number) => {
-      const buttonNumberTransform = vertical
-        ? 'translate(100%, -50%)'
-        : 'translate(-50%, -100%)'
-
-      return (
-        <>
-          {button || (
-            <div
-              className={classNames(`${classPrefix}-button`, {
-                [`${verticalClassPrefix}-button`]: vertical,
-                [`${rtlClassPrefix}-button`]: rtl,
-              })}
-              style={{
-                transform: 'translate(-50%, -50%)',
-              }}
-            >
-              {currentDescription !== null && (
-                <div
-                  className={classNames(`${classPrefix}-button-number`, {
-                    [`${verticalClassPrefix}-button-number`]: vertical,
-                    [`${rtlClassPrefix}-button-number`]: rtl,
-                  })}
-                  style={{
-                    transform: buttonNumberTransform,
-                  }}
-                >
-                  {currentDescription
-                    ? currentDescription(curValue(index))
-                    : curValue(index)}
-                </div>
-              )}
-            </div>
-          )}
-        </>
-      )
-    },
-    [button, curValue, currentDescription, rtl, rtlClassPrefix, vertical]
-  )
-  const renderMarks = useCallback(() => {
-    if (marksList.length <= 0) return null
-    const markcls = classNames(`${classPrefix}-mark`, {
-      [`${verticalClassPrefix}-mark`]: vertical,
-      [`${rtlClassPrefix}-mark`]: rtl,
-    })
-    const textcls = classNames(`${classPrefix}-mark-text`, {
-      [`${verticalClassPrefix}-mark-text`]: vertical,
-    })
-    return (
-      <div className={markcls}>
-        {marksList.map((mark: any) => {
-          return (
-            <span
-              key={mark}
-              className={markClassName(mark)}
-              style={marksStyle(mark)}
-            >
-              <span className={textcls}>
-                {Array.isArray(marks) ? marksRef.current[mark] : marks[mark]}
-              </span>
-              <span
-                className={classNames(
-                  `${vertical ? verticalClassPrefix : classPrefix}-tick`,
-                  {
-                    [`${vertical ? verticalClassPrefix : classPrefix}-tick-active`]:
-                      tickClass(mark),
-                    [`${rtlClassPrefix}-tick`]: rtl,
-                  }
-                )}
-              />
-            </span>
-          )
-        })}
-      </div>
-    )
-  }, [
-    markClassName,
-    marks,
-    marksList,
-    marksStyle,
-    rtl,
-    rtlClassPrefix,
-    tickClass,
-    vertical,
-  ])
-
-  const getWrapperTransform = useCallback(() => {
-    const wrapperTransform = 'translate(-50%, -50%)'
-    return wrapperTransform
-  }, [])
-
-  const renderRangeButton = useCallback(() => {
-    return [0, 1].map((item, index) => {
-      const isLeft = index === 0
-      const suffix = isLeft ? 'left' : 'right'
-      const transform = 'translate(-50%, -50%)'
-      const cls = classNames(`${classPrefix}-button-wrapper-${suffix}`, {
-        [`${verticalClassPrefix}-button-wrapper-${suffix}`]: vertical,
-        [`${rtlClassPrefix}-button-wrapper-${suffix}`]: rtl,
-      })
-
-      return (
-        <div
-          key={index}
-          className={cls}
-          style={{
-            transform,
-          }}
-          onTouchStart={(e) => {
-            setButtonIndex(index)
-            onTouchStart(e)
-          }}
-          onTouchMove={onTouchMove}
-          onTouchEnd={onTouchEnd}
-          onTouchCancel={onTouchEnd}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {renderButton(index)}
-        </div>
-      )
-    })
-  }, [
-    onTouchEnd,
-    onTouchMove,
-    onTouchStart,
-    renderButton,
-    vertical,
-    rtl,
-    rtlClassPrefix,
-  ])
+  }, [current, dragStatus, updateValue])
 
   const renderSingleButton = useCallback(() => {
     return (
@@ -498,51 +181,27 @@ export const Range: FunctionComponent<
         })}
         style={{
           // @ts-ignore
-          transform: getWrapperTransform(),
+          transform: 'translate(-50%, -50%)',
         }}
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
         onTouchCancel={onTouchEnd}
         onClick={(e) => e.stopPropagation()}
-      >
-        {renderButton()}
-      </div>
+      />
     )
-  }, [
-    getWrapperTransform,
-    onTouchEnd,
-    onTouchMove,
-    onTouchStart,
-    renderButton,
-    vertical,
-  ])
-
-  const renderButtonWrapper = useCallback(() => {
-    if (range) {
-      return renderRangeButton()
-    }
-    return renderSingleButton()
-  }, [renderRangeButton, renderSingleButton, range])
+  }, [onTouchEnd, onTouchMove, onTouchStart, vertical])
 
   return (
     <div className={containerClasses} style={style}>
-      {minDescription !== null && (
-        <div className={`${classPrefix}-min`}>{minDescription || min}</div>
-      )}
-      <div ref={root} className={classes} onClick={handleClick}>
-        {renderMarks()}
-
+      <div ref={nodeRef} className={classes}>
         <div
           className={`${classPrefix}-bar ${classPrefix}-bar-animate`}
           style={barStyle()}
         >
-          {renderButtonWrapper()}
+          {renderSingleButton()}
         </div>
       </div>
-      {maxDescription !== null && (
-        <div className={`${classPrefix}-max`}>{maxDescription || max}</div>
-      )}
     </div>
   )
 }

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.en-US.md
@@ -93,7 +93,12 @@ If your project uses these components, please read the documentation carefully a
 [//]: # '#### Icon'
 [//]: # '#### Image'
 [//]: # '#### Overlay'
-[//]: # '#### Popup'
+
+#### Popup
+
+- Added the resizable property for scrolling up and down when the bottom popup is active.
+- Added the minHeight property for setting the minimum height, which can be used with resizable.
+- Added the onTouchStart, onTouchMove, and onTouchEnd methods.
 
 ### Layout
 

--- a/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/react/migrate-from-v2.md
@@ -93,7 +93,12 @@ plugins: [
 [//]: # '#### Icon'
 [//]: # '#### Image'
 [//]: # '#### Overlay'
-[//]: # '#### Popup'
+
+#### Popup
+
+- 新增属性 resizable，用于底部弹出时，可上下滑动
+- 新增属性 minHeight，用于设置最小高度，可搭配 resizable 使用
+- 新增 onTouchStart、onTouchMove、onTouchEnd 方法
 
 ### 布局组件
 

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.en-US.md
@@ -93,7 +93,12 @@ If your project uses these components, please read the documentation carefully a
 [//]: # '#### Icon'
 [//]: # '#### Image'
 [//]: # '#### Overlay'
-[//]: # '#### Popup'
+
+#### Popup
+
+- Added the resizable property for scrolling up and down when the bottom popup is active.
+- Added the minHeight property for setting the minimum height, which can be used with resizable.
+- Added the onTouchStart, onTouchMove, and onTouchEnd methods.
 
 ### Layout
 

--- a/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
+++ b/src/sites/sites-react/doc/docs/taro/migrate-from-v2.md
@@ -93,7 +93,12 @@ plugins: [
 [//]: # '#### Icon'
 [//]: # '#### Image'
 [//]: # '#### Overlay'
-[//]: # '#### Popup'
+
+#### Popup
+
+- 新增属性 resizable，用于底部弹出时，可上下滑动
+- 新增属性 minHeight，用于设置最小高度，可搭配 resizable 使用
+- 新增 onTouchStart、onTouchMove、onTouchEnd 方法
 
 ### 布局组件
 

--- a/src/types/spec/popup/base.ts
+++ b/src/types/spec/popup/base.ts
@@ -21,8 +21,13 @@ export interface BasePopup extends BaseProps, BaseOverlay {
   destroyOnClose: boolean
   overlay: boolean
   round: boolean
+  resizable: boolean
+  minHeight: string
   onOpen: () => void
   onClose: () => void
   onOverlayClick: (e: any) => boolean | void
   onCloseIconClick: (e: any) => boolean | void
+  onTouchMove: (height: string, e: any, direction: 'up' | 'down') => void
+  onTouchStart: (height: string, e: any) => void
+  onTouchEnd: (height: string, e: any) => void
 }

--- a/src/types/spec/popup/base.ts
+++ b/src/types/spec/popup/base.ts
@@ -27,7 +27,7 @@ export interface BasePopup extends BaseProps, BaseOverlay {
   onClose: () => void
   onOverlayClick: (e: any) => boolean | void
   onCloseIconClick: (e: any) => boolean | void
-  onTouchMove: (height: string, e: any, direction: 'up' | 'down') => void
-  onTouchStart: (height: string, e: any) => void
-  onTouchEnd: (height: string, e: any) => void
+  onTouchMove: (height: number, e: any, direction: 'up' | 'down') => void
+  onTouchStart: (height: number, e: any) => void
+  onTouchEnd: (height: number, e: any) => void
 }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - Popup 支持底部可拖拽调整高度（resizable）与最小高度（minHeight），并新增触摸回调 onTouchStart/onTouchMove/onTouchEnd，恢复重开时高度。
- 示例
  - H5/Taro 示例新增普通与可调底部弹窗，触摸交互在示例中记录日志。
- 样式
  - 移除顶部/底部弹窗 87% 高度上限，支持更高展示。
- 文档
  - 更新中/英/Taro/繁体文档与迁移指南，补充新 props、触摸事件及 afterShow/afterClose 位置调整。
- 测试
  - 单元测试扩展以覆盖最小高度与触摸事件，改用更稳健的断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->