### PR TITLE
fix(input): 兼容h5和小程序获取原生input标签

### DIFF
--- a/src/packages/input/input.taro.tsx
+++ b/src/packages/input/input.taro.tsx
@@ -81,7 +81,7 @@ export const Input = forwardRef((props: Partial<TaroInputProps>, ref) => {
   const getNativeInput = () => {
     if (Taro.getEnv() === 'WEB') {
       const taroInputCoreEl = inputRef.current as HTMLElement
-      const inputEl = taroInputCoreEl?.querySelector?.('input')
+      const inputEl = taroInputCoreEl.querySelector('input')
       return inputEl
     }
     return inputRef.current

--- a/src/packages/input/input.taro.tsx
+++ b/src/packages/input/input.taro.tsx
@@ -83,7 +83,13 @@ export const Input = forwardRef((props: Partial<TaroInputProps>, ref) => {
         setValue('')
       },
       focus: () => {
-        inputRef.current?.focus()
+        console.error('inputRef', inputRef.current)
+        console.error('inputRef focus method', inputRef.current?.focus)
+        const taroInputCoreDom = inputRef.current as HTMLDivElement
+        console.error('taroInputCoreDom', taroInputCoreDom)
+        const inputDom = taroInputCoreDom.querySelector('input')
+        console.error('inputDom', inputDom)
+        inputDom?.focus()
       },
       blur: () => {
         inputRef.current?.blur()

--- a/src/packages/input/input.taro.tsx
+++ b/src/packages/input/input.taro.tsx
@@ -77,22 +77,28 @@ export const Input = forwardRef((props: Partial<TaroInputProps>, ref) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [active, setActive] = useState(false)
 
+  // 兼容H5和小程序获取原生input标签
+  const getNativeInput = () => {
+    if (Taro.getEnv() === 'WEB') {
+      const taroInputCoreEl = inputRef.current as HTMLElement
+      const inputEl = taroInputCoreEl?.querySelector?.('input')
+      return inputEl
+    }
+    return inputRef.current
+  }
+
   useImperativeHandle(ref, () => {
     return {
       clear: () => {
         setValue('')
       },
       focus: () => {
-        console.error('inputRef', inputRef.current)
-        console.error('inputRef focus method', inputRef.current?.focus)
-        const taroInputCoreDom = inputRef.current as HTMLDivElement
-        console.error('taroInputCoreDom', taroInputCoreDom)
-        const inputDom = taroInputCoreDom.querySelector('input')
-        console.error('inputDom', inputDom)
-        inputDom?.focus()
+        const nativeInput = getNativeInput()
+        nativeInput?.focus()
       },
       blur: () => {
-        inputRef.current?.blur()
+        const nativeInput = getNativeInput()
+        nativeInput?.blur()
       },
       get nativeElement() {
         return inputRef.current


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
@nutui/nutui-react-taro在h5点应用场景下，如果直接获取Taro组件库的Input元素调用focus方法会失效，应为Taro在外层保留一个taro-input-core
<img width="1539" height="464" alt="image" src="https://github.com/user-attachments/assets/a729daab-28d9-4901-a3b7-634d8c339c8d" />


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
解决h5环境下无法正确获取input原生标签

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新增功能
  - 无
- Bug 修复
  - 修复 Web 环境下输入框无法正确聚焦/失焦的问题，提升跨平台聚焦行为一致性，减少无法唤起软键盘等异常。
- 重构
  - 统一各平台对输入框聚焦/失焦的处理逻辑，改善稳定性与可维护性，不改变公开接口与使用方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->