### PR TITLE
fix(uploader): 处理非图片文件类型问题

### DIFF
--- a/src/packages/uploader/__tests__/uploader.spec.tsx
+++ b/src/packages/uploader/__tests__/uploader.spec.tsx
@@ -93,6 +93,50 @@ test('should render base uploader other props', () => {
   expect(fileItemClick).toBeCalled()
 })
 
+test('should render no-image file uploader list', () => {
+  const App = () => {
+    const defaultFileList: FileItem[] = [
+      {
+        name: '文件1.txt',
+        url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',
+        status: 'success',
+        message: '上传成功',
+        type: 'list',
+        uid: '123',
+      },
+      {
+        name: '文件2.ppt',
+        url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',
+        status: 'error',
+        message: '上传失败',
+        type: 'list',
+        uid: '124',
+      },
+      {
+        name: '文件3.cpp',
+        url: 'https://m.360buyimg.com/babel/jfs/t1/164410/22/25162/93384/616eac6cE6c711350/0cac53c1b82e1b05.gif',
+        status: 'uploading',
+        message: '上传中...',
+        type: 'list',
+        uid: '125',
+      },
+    ]
+
+    return (
+      <Uploader
+        defaultValue={defaultFileList}
+        uploadIcon="dongdong"
+        previewType="list"
+      />
+    )
+  }
+
+  const { container } = render(<App />)
+  const toast1 = container.querySelectorAll('.list')
+  expect(toast1).toBeTruthy()
+  expect(toast1.length).toBe(3)
+})
+
 test('should render base uploader list', () => {
   const App = () => {
     const defaultFileList: FileItem[] = [

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -186,7 +186,7 @@ const InternalUploader: ForwardRefRenderFunction<
       if (preview) {
         // 如果是图片类型的预览且上传的文件非图片则不放入文件列表中
         if (previewType === 'picture' && !file.type?.includes('image')) {
-          return
+          return info
         }
         const reader = new FileReader()
         reader.onload = (event: ProgressEvent<FileReader>) => {

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -183,19 +183,22 @@ const InternalUploader: ForwardRefRenderFunction<
         name: file.name,
         type: file.type,
       }
-      if (preview) {
+      fileListRef.current = [...fileListRef.current, info]
+
+      if (preview && file.type?.includes('image')) {
         const reader = new FileReader()
         reader.onload = (event: ProgressEvent<FileReader>) => {
-          fileListRef.current = [
-            ...fileListRef.current,
-            {
-              ...info,
-              url: (event.target as FileReader).result as string,
-            },
-          ]
-          setFileList(fileListRef.current)
+          const updatedList = fileListRef.current.map((item) =>
+            item.uid === info.uid
+              ? { ...item, url: (event.target as FileReader).result as string }
+              : item
+          )
+          fileListRef.current = updatedList
+          setFileList(updatedList)
         }
         reader.readAsDataURL(file)
+      } else {
+        setFileList(fileListRef.current)
       }
       return info
     })

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -183,22 +183,19 @@ const InternalUploader: ForwardRefRenderFunction<
         name: file.name,
         type: file.type,
       }
-      fileListRef.current = [...fileListRef.current, info]
-
-      if (preview && file.type?.includes('image')) {
+      if (preview) {
         const reader = new FileReader()
         reader.onload = (event: ProgressEvent<FileReader>) => {
-          const updatedList = fileListRef.current.map((item) =>
-            item.uid === info.uid
-              ? { ...item, url: (event.target as FileReader).result as string }
-              : item
-          )
-          fileListRef.current = updatedList
-          setFileList(updatedList)
+          fileListRef.current = [
+            ...fileListRef.current,
+            {
+              ...info,
+              url: (event.target as FileReader).result as string,
+            },
+          ]
+          setFileList(fileListRef.current)
         }
         reader.readAsDataURL(file)
-      } else {
-        setFileList(fileListRef.current)
       }
       return info
     })

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -183,7 +183,11 @@ const InternalUploader: ForwardRefRenderFunction<
         name: file.name,
         type: file.type,
       }
-      if (preview && file.type?.includes('image')) {
+      if (preview) {
+        // 如果是图片类型的预览且上传的文件非图片则不放入文件列表中
+        if (previewType === 'picture' && !file.type?.includes('image')) {
+          return
+        }
         const reader = new FileReader()
         reader.onload = (event: ProgressEvent<FileReader>) => {
           fileListRef.current = [

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -183,7 +183,7 @@ const InternalUploader: ForwardRefRenderFunction<
         name: file.name,
         type: file.type,
       }
-      if (preview && previewType === 'picture') {
+      if (preview) {
         const reader = new FileReader()
         reader.onload = (event: ProgressEvent<FileReader>) => {
           fileListRef.current = [

--- a/src/packages/uploader/uploader.tsx
+++ b/src/packages/uploader/uploader.tsx
@@ -183,11 +183,7 @@ const InternalUploader: ForwardRefRenderFunction<
         name: file.name,
         type: file.type,
       }
-      if (preview) {
-        // 如果是图片类型的预览且上传的文件非图片则不放入文件列表中
-        if (previewType === 'picture' && !file.type?.includes('image')) {
-          return info
-        }
+      if (preview && previewType === 'picture') {
         const reader = new FileReader()
         reader.onload = (event: ProgressEvent<FileReader>) => {
           fileListRef.current = [


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/jdf2e/nutui-react/issues/3333
上传非图片无法进行预览列表

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：在设置文件列表时，校验非图片直接拦截，导致无法预览
解决：在拦截时，校验预览类型为图片且非图片才拦截

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复 / 行为变更**
  - 预览逻辑从仅图片扩展为所有启用预览的文件：在启用预览时会为所有文件生成并显示预览 URL，已存在列表项会被更新为包含该 URL；上传流程与对外接口保持不变。

- **Tests**
  - 新增用例验证列表预览模式下能正确渲染多种非图片文件项（不同状态，共三项）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->