### PR TITLE
fix: dialog.taro中defaultProps使用ts断言确认类型

### DIFF
--- a/src/packages/dialog/dialog.taro.tsx
+++ b/src/packages/dialog/dialog.taro.tsx
@@ -44,7 +44,7 @@ const defaultProps = {
   onClose: () => {},
   onConfirm: () => {},
   onOverlayClick: () => true,
-}
+} as TaroDialogProps
 
 export const BaseDialog: FunctionComponent<Partial<TaroDialogProps>> & {
   open: typeof open


### PR DESCRIPTION
Dialog.open方法的第二个参数类型和dialog支持的属性不同，现修复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 重构
  * 调整内部类型注解以提升类型安全与可维护性；不影响现有功能、界面或性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->