### PR TITLE
feat(theme): 升级8月份主题的微调，修订dialog 样式的鸿蒙适配等

### DIFF
--- a/src/packages/configprovider/types.ts
+++ b/src/packages/configprovider/types.ts
@@ -458,6 +458,7 @@ export type NutCSSVariables =
   | 'nutuiDialogMaxHeight'
   | 'nutuiDialogMinHeight'
   | 'nutuiDialogBorderRadius'
+  | 'nutuiDialogBackground'
   | 'nutuiDialogContentMargin'
   | 'nutuiDialogContentMaxHeight'
   | 'nutuiDialogContentLineHeight'

--- a/src/packages/dialog/dialog.scss
+++ b/src/packages/dialog/dialog.scss
@@ -18,7 +18,7 @@
   &-outer {
     position: fixed;
     max-height: 100%;
-    background-color: $white;
+    background-color: $dialog-background;
     transition:
       transform 0.2s,
       -webkit-transform 0.2s;

--- a/src/packages/dialog/dialog.scss
+++ b/src/packages/dialog/dialog.scss
@@ -130,12 +130,18 @@
     &-cancel.nut-dialog-footer-cancel {
       margin-right: $dialog-footer-cancel-margin-right;
       background: $dialog-footer-cancel-bg;
+      .nut-button-children {
+        color: $button-default-color;
+      }
     }
 
     &-ok {
       max-width: $dialog-footer-ok-max-width;
-      font-weight: $font-weight-bold;
+      .nut-button-children {
+        font-weight: $font-weight-bold;
+      }
     }
+
     &-block {
       &.nut-button {
         min-width: 100%;

--- a/src/packages/dialog/dialog.scss
+++ b/src/packages/dialog/dialog.scss
@@ -130,6 +130,7 @@
     &-cancel.nut-dialog-footer-cancel {
       margin-right: $dialog-footer-cancel-margin-right;
       background: $dialog-footer-cancel-bg;
+      color: $button-default-color;
       .nut-button-children {
         color: $button-default-color;
       }
@@ -137,6 +138,7 @@
 
     &-ok {
       max-width: $dialog-footer-ok-max-width;
+      font-weight: $font-weight-bold;
       .nut-button-children {
         font-weight: $font-weight-bold;
       }

--- a/src/styles/theme-dark.scss
+++ b/src/styles/theme-dark.scss
@@ -18,82 +18,48 @@ page {
   --nutui-brand-stop-1: #ff475d; // 渐变色起
   --nutui-brand-stop-2: #fa3725; // 渐变色止
 
-  // 品牌颜色语义化
-  // 品牌主色调默认态，主要功能控件的背景、边框、镂空状态下的文字等
-  --nutui-color-primary: var(--nutui-brand-6);
-  // 品牌渐变色左端
-  --nutui-color-primary-stop-1: var(--nutui-brand-stop-1);
-  // 品牌渐变色右端
-  --nutui-color-primary-stop-2: var(--nutui-brand-stop-2);
-  // 品牌主色调或其他深色背景下的文字
-  --nutui-color-primary-text: var(--nutui-color-background-gray-1);
-  // 品牌主色调点击态，背景、边框、镂空状态下的文字
-  --nutui-color-primary-pressed: var(--nutui-brand-7);
-  // 品牌主色调禁用态，背景、边框、镂空状态下的文字
-  --nutui-color-primary-disabled: var(--nutui-color-content-gray-1);
-  // 品牌主色调特殊禁用态，通过操作后可转位默认态
-  --nutui-color-primary-disabled-special: var(--nutui-brand-3);
-  // 品牌主色调镂空背景点击态
-  --nutui-color-primary-light-pressed: var(--nutui-brand-1);
-  --nutui-color-primary-specialdisabled: var(--nutui-red-3);
-
   // service color
-  --nutui-golden-1: #292725;
-  --nutui-golden-2: #4d4134;
-  --nutui-golden-3: #c59463;
-  --nutui-golden-4: #d18e54;
+  --nutui-golden-1: #fff4e8;
+  --nutui-golden-2: rgba(184, 124, 63, 0.04);
+  --nutui-golden-3: rgba(191, 130, 66, 0.2);
+  --nutui-golden-4: #b87c3f;
+  --nutui-golden-5: #4d3b2a;
+  --nutui-golden-6: #33271c;
+  --nutui-golden-7: #ccb8a3;
 
   --nutui-golden-stop-1: #fff9f0;
   --nutui-golden-stop-2: #ffe3c2;
-
-  // service color 语义化
-  --nutui-color-service: var(--nutui-golden-1);
-  --nutui-color-service-border: var(--nutui-golden-2);
-  --nutui-color-service-pressed: var(--nutui-golden-4);
-  --nutui-color-service-stop-1: var(--nutui-golden-stop-1);
-  --nutui-color-service-stop-2: var(--nutui-golden-stop-2);
-  --nutui-color-service-text: var(--nutui-golden-3);
 
   // success color
   --nutui-green-1: #1f2920;
   --nutui-green-2: #32c241;
   --nutui-green-3: #12b222;
 
-  // success color 语义化
-  --nutui-color-success: var(--nutui-green-2); // 深背景
-  --nutui-color-success-light: var(--nutui-green-1); // 浅背景
-  --nutui-color-success-pressed: var(--nutui-green-3); // 文字
+  // danger color 发现不一致 TODO
 
-  // danger color
-  --nutui-red-1: #2e2526;
-  --nutui-red-2: #ff3344;
-  --nutui-red-3: #ff3344;
-  --nutui-red-6: #ff3b3b;
-
-  // danger color 语义化
-  --nutui-color-danger: var(--nutui-red-2); // 背景或文字
-  --nutui-color-danger-light: var(--nutui-red-1); // 背景
+  // red color
+  --nutui-red-1: #4c1c20;
+  --nutui-red-2: #621a20;
+  --nutui-red-3: #603840;
+  --nutui-red-4: #893f49;
+  --nutui-red-5: #bc3139;
+  --nutui-red-6: #bc3139;
+  --nutui-red-7: #ed3b34;
+  --nutui-red-8: #ff5144;
+  --nutui-red-9: #ff9382;
+  --nutui-red-10: #ffccbf;
+  --nutui-red-11: #ffe7e0;
 
   // warning color
   --nutui-yellow-1: #29271f;
   --nutui-yellow-2: #faaf00;
-  --nutui-yellow-3: #c47600; //todo
-
-  // warning color 语义化
-  --nutui-color-warning: var(--nutui-yellow-2); // 深背景
-  --nutui-color-warning-light: var(--nutui-yellow-1); // 浅背景
-  --nutui-color-warning-pressed: var(--nutui-yellow-3); // 文字
+  --nutui-yellow-3: #cc8500;
 
   // info color
   --nutui-blue-1: #23292e;
   --nutui-blue-2: #3385ff;
 
-  // info color 语义化
-  --nutui-color-info: var(--nutui-blue-2); // 背景或文字，链接色
-  --nutui-color-info-light: var(--nutui-blue-1); // 背景
-
   --nutui-secondary-1: #14cc33; // 辅助色
-  --nutui-color-text-link: var(--nutui-blue-2);
 
   // 背景色
   // 卡片背景色
@@ -102,6 +68,8 @@ page {
   --nutui-gray-2: #141414;
   // 页面基底色，用于卡片式页面的兜底，永远置于页面最底层。
   --nutui-gray-3: #0a0a0a;
+  // 组件背景色，2025年新增
+  --nutui-gray-9: #333333;
   // 文字色
   // 四级文字色，不可操作内容色，用于预置内容、无效内容、特殊不可点击按钮、组件边框线等。
   --nutui-gray-4: #666666;
@@ -119,7 +87,7 @@ page {
   // 容错蒙层
   --nutui-black-2: rgba(0, 0, 0, 0.1);
   // 线条色
-  // 间隔线/容错线，用于结构或信息分割
+  // 间隔线/容错线，用于结构或信息分割，TODO @zhoufeng
   --nutui-black-3: rgba(255, 255, 255, 0.06);
   --nutui-black-4: rgba(20, 20, 20, 0.1);
   --nutui-black-5: rgba(20, 20, 20, 0.2);
@@ -150,6 +118,69 @@ page {
   --nutui-white-12: rgba(31, 31, 31, 0.9);
   // --nutui-white-13: rgba(255, 255, 255, 1);
 
+  // 品牌颜色语义化
+  // 品牌主色调默认态，主要功能控件的背景、边框、镂空状态下的文字等
+  --nutui-color-primary: var(--nutui-brand-6);
+  // 品牌渐变色左端
+  --nutui-color-primary-stop-1: var(--nutui-brand-stop-1);
+  // 品牌渐变色右端
+  --nutui-color-primary-stop-2: var(--nutui-brand-stop-2);
+  // 品牌主色调或其他深色背景下的文字
+  --nutui-color-primary-text: var(--nutui-color-background-gray-1);
+  // 品牌主色调点击态，背景、边框、镂空状态下的文字
+  --nutui-color-primary-pressed: var(--nutui-red-7);
+  // 品牌主色调禁用态，背景、边框、镂空状态下的文字
+  --nutui-color-primary-disabled: var(--nutui-color-content-gray-1);
+  // 品牌主色调特殊禁用态，通过操作后可转位默认态
+  --nutui-color-primary-disabled-special: var(--nutui-red-3);
+  // 2025 新增
+  --nutui-color-primary-light: var(--nutui-brand-1);
+  // 品牌主色调镂空背景点击态
+  --nutui-color-primary-light-pressed: var(--nutui-red-2);
+  // 看上去命名和上边重复，去掉
+  // --nutui-color-primary-specialdisabled: var(--nutui-red-3);
+
+  // service color 语义化
+  // 金色背景
+  --nutui-color-service: var(--nutui-golden-1);
+  // 填充标签边框
+  --nutui-color-service-border-1: var(--nutui-golden-2);
+  // 线框标签边框
+  --nutui-color-service-border-2: var(--nutui-golden-3);
+  // 废弃
+  //   --nutui-color-service-border: var(--nutui-golden-2);
+  --nutui-color-service-pressed: var(--nutui-golden-4);
+  // 金色文字
+  --nutui-color-service-text: var(--nutui-golden-4);
+  // 金色按钮背景
+  --nutui-color-service-btn-bg: var(--nutui-golden-5);
+  // 金色按钮点击态背景
+  --nutui-color-service-btn-bg-pressed: var(--nutui-golden-6);
+  // 金色按钮文字
+  --nutui-color-service-btn-text: var(--nutui-golden-7);
+
+  --nutui-color-service-stop-1: var(--nutui-golden-stop-1);
+  --nutui-color-service-stop-2: var(--nutui-golden-stop-2);
+
+  // success color 语义化
+  --nutui-color-success: var(--nutui-green-2); // 深背景
+  --nutui-color-success-light: var(--nutui-green-1); // 浅背景
+  --nutui-color-success-pressed: var(--nutui-green-3); // 文字
+
+  // danger color 语义化，待办，看上去目前非常的独立 @周峯
+  --nutui-color-danger: var(--nutui-red-2); // 背景或文字
+  --nutui-color-danger-light: var(--nutui-red-1); // 背景
+
+  // info color 语义化
+  --nutui-color-info: var(--nutui-blue-2); // 背景或文字，链接色
+  --nutui-color-info-light: var(--nutui-blue-1); // 背景
+  --nutui-color-text-link: var(--nutui-blue-2);
+
+  // warning color 语义化
+  --nutui-color-warning: var(--nutui-yellow-2); // 深背景
+  --nutui-color-warning-light: var(--nutui-yellow-1); // 浅背景
+  --nutui-color-warning-pressed: var(--nutui-yellow-3); // 文字
+
   // 文字颜色值 语义化
   --nutui-color-content-gray-1: var(--nutui-gray-4);
   --nutui-color-content-gray-2: var(--nutui-gray-5);
@@ -168,12 +199,15 @@ page {
   --nutui-color-background-gray-1: var(--nutui-gray-1);
   --nutui-color-background-gray-2: var(--nutui-gray-2);
   --nutui-color-background-gray-3: var(--nutui-gray-3);
+  --nutui-color-background-gray-4: var(--nutui-gray-9);
   // 页面背景
   --nutui-color-background: var(--nutui-color-background-gray-3);
   // 卡片背景
   --nutui-color-background-overlay: var(--nutui-color-background-gray-1);
   // 卡片内容器背景
   --nutui-color-background-sunken: var(--nutui-color-background-gray-2);
+  // 组件背景，2025年新增
+  --nutui-color-background-component: var(--nutui-color-background-gray-4);
 
   // 蒙层颜色值 语义化
   --nutui-color-mask-gray-1: var(--nutui-black-2);

--- a/src/styles/theme-dark.scss
+++ b/src/styles/theme-dark.scss
@@ -87,8 +87,8 @@ page {
   // 容错蒙层
   --nutui-black-2: rgba(0, 0, 0, 0.1);
   // 线条色
-  // 间隔线/容错线，用于结构或信息分割，TODO @zhoufeng
-  --nutui-black-3: rgba(255, 255, 255, 0.06);
+  // 间隔线/容错线，用于结构或信息分割
+  --nutui-black-3: rgba(255, 255, 255, 0.08);
   --nutui-black-4: rgba(20, 20, 20, 0.1);
   --nutui-black-5: rgba(20, 20, 20, 0.2);
   --nutui-black-6: rgba(20, 20, 20, 0.3);

--- a/src/styles/theme-default.scss
+++ b/src/styles/theme-default.scss
@@ -17,99 +17,67 @@ page {
   --nutui-brand-stop-1: #ff475d; // 渐变色起
   --nutui-brand-stop-2: #ff0f23; // 渐变色止
 
-  // 品牌颜色语义化
-  // 品牌主色调默认态，主要功能控件的背景、边框、镂空状态下的文字等
-  --nutui-color-primary: var(--nutui-brand-6);
-  // 品牌渐变色左端
-  --nutui-color-primary-stop-1: var(--nutui-brand-stop-1);
-  // 品牌渐变色右端
-  --nutui-color-primary-stop-2: var(--nutui-brand-stop-2);
-  // 品牌主色调或其他深色背景下的文字
-  --nutui-color-primary-text: var(--nutui-color-background-gray-1);
-  // 品牌主色调点击态，背景、边框、镂空状态下的文字
-  --nutui-color-primary-pressed: var(--nutui-brand-7);
-  // 品牌主色调禁用态，背景、边框、镂空状态下的文字
-  --nutui-color-primary-disabled: var(--nutui-color-content-gray-1);
-  // 品牌主色调特殊禁用态，通过操作后可转位默认态
-  --nutui-color-primary-disabled-special: var(--nutui-brand-3);
-  // 品牌主色调镂空背景点击态
-  --nutui-color-primary-light-pressed: var(--nutui-brand-1);
-  --nutui-color-primary-specialdisabled: var(--nutui-red-3);
-
   // service color
-  --nutui-golden-1: #fff2e0;
-  --nutui-golden-2: #ffd4a3;
-  --nutui-golden-3: #cc8241;
-  --nutui-golden-4: #994d00;
+  --nutui-golden-1: #fff4e8;
+  --nutui-golden-2: rgba(181, 105, 26, 0.02);
+  --nutui-golden-3: rgba(181, 105, 26, 0.2);
+  --nutui-golden-4: #b5691a;
+  --nutui-golden-5: #ffe7cc;
+  --nutui-golden-6: #ffd8ad;
+  --nutui-golden-7: #664100;
 
   --nutui-golden-stop-1: #fff9f0;
   --nutui-golden-stop-2: #ffe3c2;
-
-  // service color 语义化
-  --nutui-color-service: var(--nutui-golden-1);
-  --nutui-color-service-border: var(--nutui-golden-2);
-  --nutui-color-service-pressed: var(--nutui-golden-4);
-  --nutui-color-service-stop-1: var(--nutui-golden-stop-1);
-  --nutui-color-service-stop-2: var(--nutui-golden-stop-2);
-  --nutui-color-service-text: var(--nutui-golden-3);
 
   // success color
   --nutui-green-1: #ebfbeb;
   --nutui-green-2: #00d900;
   --nutui-green-3: #2aa32a;
 
-  // success color 语义化
-  --nutui-color-success: var(--nutui-green-2); // 深背景
-  --nutui-color-success-light: var(--nutui-green-1); // 浅背景
-  --nutui-color-success-pressed: var(--nutui-green-3); // 文字
+  // danger color 发现不一致TODO
 
-  // danger color
-  --nutui-red-1: #ffebef;
+  // red color
+  --nutui-red-1: #fff0f4;
+  --nutui-red-2: #ffd6e1;
   --nutui-red-3: #ffadbe;
-  --nutui-red-2: #ff0f23;
+  --nutui-red-4: #ff8595;
+  --nutui-red-5: #ff5c67;
   --nutui-red-6: #ff3333;
-
-  // danger color 语义化
-  --nutui-color-danger: var(--nutui-red-2); // 背景或文字
-  --nutui-color-danger-light: var(--nutui-red-1); // 背景
+  --nutui-red-7: #e53029;
+  --nutui-red-8: #cc2c21;
+  --nutui-red-9: #992412;
+  --nutui-red-10: #661b08;
+  --nutui-red-11: #330f02;
 
   // warning color
-  --nutui-yellow-1: #fff5cc;
+  --nutui-yellow-1: #fff9e0;
   --nutui-yellow-2: #ffbf00;
-  --nutui-yellow-3: #c47600;
-
-  // warning color 语义化
-  --nutui-color-warning: var(--nutui-yellow-2); // 深背景
-  --nutui-color-warning-light: var(--nutui-yellow-1); // 浅背景
-  --nutui-color-warning-pressed: var(--nutui-yellow-3); // 文字
+  --nutui-yellow-3: #b26b00;
 
   // info color
   --nutui-blue-1: #e5f5ff;
   --nutui-blue-2: #0073ff;
 
-  // info color 语义化
-  --nutui-color-info: var(--nutui-blue-2); // 背景或文字，链接色
-  --nutui-color-info-light: var(--nutui-blue-1); // 背景
-
   --nutui-secondary-1: #14cc33; // 辅助色
-  --nutui-color-text-link: var(--nutui-blue-2);
 
   // 背景色
   // 卡片背景色
   --nutui-gray-1: #ffffff;
   // 卡片内嵌背景色，用于卡片内部的信息包裹，感知较弱。
-  --nutui-gray-2: #f7f8fc;
+  --nutui-gray-2: #f5f6fa;
   // 页面基底色，用于卡片式页面的兜底，永远置于页面最底层。
-  --nutui-gray-3: #f2f3f5;
+  --nutui-gray-3: #f2f3f7;
+  // 组件背景色，2025年新增
+  --nutui-gray-9: #f5f6fa;
   // 文字色
   // 四级文字色，不可操作内容色，用于预置内容、无效内容、特殊不可点击按钮、组件边框线等。
   --nutui-gray-4: #c2c4cc;
   // 三级文字色（次要）
-  --nutui-gray-5: #888b94;
+  --nutui-gray-5: #828794;
   // 二级文字色（常规），用于次级标题、属性标示、非主要信息引导等。
-  --nutui-gray-6: #505259;
+  --nutui-gray-6: #3d414d;
   // 一级文字色（重要）主要内容用色，常用语常规标题内容、细文浏览、常规按钮文字以及图表引导。
-  --nutui-gray-7: #1a1a1a;
+  --nutui-gray-7: #171a26;
   // icon 未选中颜色
   --nutui-gray-8: #dadce0;
 
@@ -119,7 +87,7 @@ page {
   --nutui-black-2: rgba(0, 0, 0, 0.02);
   // 线条色
   // 间隔线/容错线，用于结构或信息分割
-  --nutui-black-3: rgba(0, 0, 0, 0.06);
+  --nutui-black-3: rgba(0, 0, 0, 0.08);
   --nutui-black-4: rgba(0, 0, 0, 0.1);
   --nutui-black-5: rgba(0, 0, 0, 0.2);
   --nutui-black-6: rgba(0, 0, 0, 0.3);
@@ -149,6 +117,69 @@ page {
   --nutui-white-12: rgba(255, 255, 255, 0.9);
   --nutui-white-13: rgba(255, 255, 255, 1);
 
+  // 品牌颜色语义化
+  // 品牌主色调默认态，主要功能控件的背景、边框、镂空状态下的文字等
+  --nutui-color-primary: var(--nutui-brand-6);
+  // 品牌渐变色左端
+  --nutui-color-primary-stop-1: var(--nutui-brand-stop-1);
+  // 品牌渐变色右端
+  --nutui-color-primary-stop-2: var(--nutui-brand-stop-2);
+  // 品牌主色调或其他深色背景下的文字
+  --nutui-color-primary-text: var(--nutui-color-background-gray-1);
+  // 品牌主色调点击态，背景、边框、镂空状态下的文字
+  --nutui-color-primary-pressed: var(--nutui-red-7);
+  // 品牌主色调禁用态，背景、边框、镂空状态下的文字
+  --nutui-color-primary-disabled: var(--nutui-color-content-gray-1);
+  // 品牌主色调特殊禁用态，通过操作后可转位默认态
+  --nutui-color-primary-disabled-special: var(--nutui-red-3);
+  // 2025 新增
+  --nutui-color-primary-light: var(--nutui-brand-1);
+  // 品牌主色调镂空背景点击态
+  --nutui-color-primary-light-pressed: var(--nutui-red-2);
+  // 看上去命名和上边重复，去掉
+  // --nutui-color-primary-specialdisabled: var(--nutui-red-3);
+
+  // service color 语义化
+  // 金色背景
+  --nutui-color-service: var(--nutui-golden-1);
+  // 填充标签边框
+  --nutui-color-service-border-1: var(--nutui-golden-2);
+  // 线框标签边框
+  --nutui-color-service-border-2: var(--nutui-golden-3);
+  // 废弃
+  //   --nutui-color-service-border: var(--nutui-golden-2);
+  --nutui-color-service-pressed: var(--nutui-golden-4);
+  // 金色文字
+  --nutui-color-service-text: var(--nutui-golden-4);
+  // 金色按钮背景
+  --nutui-color-service-btn-bg: var(--nutui-golden-5);
+  // 金色按钮点击态背景
+  --nutui-color-service-btn-bg-pressed: var(--nutui-golden-6);
+  // 金色按钮文字
+  --nutui-color-service-btn-text: var(--nutui-golden-7);
+
+  --nutui-color-service-stop-1: var(--nutui-golden-stop-1);
+  --nutui-color-service-stop-2: var(--nutui-golden-stop-2);
+
+  // success color 语义化
+  --nutui-color-success: var(--nutui-green-2); // 深背景
+  --nutui-color-success-light: var(--nutui-green-1); // 浅背景
+  --nutui-color-success-pressed: var(--nutui-green-3); // 文字
+
+  // danger color 语义化，待办，看上去目前非常的独立 TODO
+  --nutui-color-danger: var(--nutui-red-2); // 背景或文字
+  --nutui-color-danger-light: var(--nutui-red-1); // 背景
+
+  // info color 语义化
+  --nutui-color-info: var(--nutui-blue-2); // 背景或文字，链接色
+  --nutui-color-info-light: var(--nutui-blue-1); // 背景
+  --nutui-color-text-link: var(--nutui-blue-2);
+
+  // warning color 语义化
+  --nutui-color-warning: var(--nutui-yellow-2); // 深背景
+  --nutui-color-warning-light: var(--nutui-yellow-1); // 浅背景
+  --nutui-color-warning-pressed: var(--nutui-yellow-3); // 文字
+
   // 文字颜色值 语义化
   --nutui-color-content-gray-1: var(--nutui-gray-4);
   --nutui-color-content-gray-2: var(--nutui-gray-5);
@@ -167,12 +198,15 @@ page {
   --nutui-color-background-gray-1: var(--nutui-gray-1);
   --nutui-color-background-gray-2: var(--nutui-gray-2);
   --nutui-color-background-gray-3: var(--nutui-gray-3);
+  --nutui-color-background-gray-4: var(--nutui-gray-9);
   // 页面背景
   --nutui-color-background: var(--nutui-color-background-gray-3);
   // 卡片背景
   --nutui-color-background-overlay: var(--nutui-color-background-gray-1);
   // 卡片内容器背景
   --nutui-color-background-sunken: var(--nutui-color-background-gray-2);
+  // 组件背景，2025年新增
+  --nutui-color-background-component: var(--nutui-color-background-gray-4);
 
   // 蒙层颜色值 语义化
   --nutui-color-mask-gray-1: var(--nutui-black-2);

--- a/src/styles/variables-jmapp.scss
+++ b/src/styles/variables-jmapp.scss
@@ -1492,6 +1492,10 @@ $dialog-padding: var(
 ) !default;
 $dialog-min-height: var(--nutui-dialog-min-height, 60px) !default;
 $dialog-border-radius: var(--nutui-dialog-border-radius, $radius-base) !default;
+$dialog-background: var(
+  --nutui-dialog-background,
+  $color-background-overlay
+) !default;
 $dialog-footer-justify-content: var(
   --nutui-dialog-footer-justify-content,
   space-around

--- a/src/styles/variables-jrkf.scss
+++ b/src/styles/variables-jrkf.scss
@@ -1605,6 +1605,10 @@ $dialog-padding: var(
 ) !default;
 $dialog-min-height: var(--nutui-dialog-min-height, 60px) !default;
 $dialog-border-radius: var(--nutui-dialog-border-radius, $radius-base) !default;
+$dialog-background: var(
+  --nutui-dialog-background,
+  $color-background-overlay
+) !default;
 $dialog-footer-justify-content: var(
   --nutui-dialog-footer-justify-content,
   space-around

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1388,6 +1388,10 @@ $dialog-padding: var(--nutui-dialog-padding, 24px) !default;
 $dialog-max-height: var(--nutui-dialog-max-height, 420px) !default;
 $dialog-min-height: var(--nutui-dialog-min-height, 124px) !default;
 $dialog-border-radius: var(--nutui-dialog-border-radius, $radius-xl) !default;
+$dialog-background: var(
+  --nutui-dialog-background,
+  $color-background-overlay
+) !default;
 $dialog-content-margin: var(
   --nutui-dialog-content-margin,
   12px 0 16px 0


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 引入全新 2025 配色体系，默认与暗色/默认主题获得更丰富的品牌、服务、状态与背景语义色，支持更细粒度的主题定制。
  - 对话框背景新增主题可覆盖项，允许通过主题变量自定义对话框外层背景色。

- 样式
  - 对话框外层背景由纯白调整为主题化背景；对话框页脚取消/确定按钮的文字颜色与字重进行了视觉优化，提升可辨识性。
  - 扩展金色、红色、灰阶等色板并微调黑色透明度，整体对比度与可读性提升。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->