### PR TITLE
修复Cascader动态加载层级不存在报错导致不显示内容的问题，及Popup关闭按钮点穿的问题

### DIFF
--- a/src/packages/cascader/cascader.taro.tsx
+++ b/src/packages/cascader/cascader.taro.tsx
@@ -165,7 +165,7 @@ export const Cascader = forwardRef((props: Partial<TaroCascaderProps>, ref) => {
         await innerValue.reduce(async (promise: Promise<any>, val, key) => {
           const pane = await onLoad({ value: val }, key)
           const parent = await promise
-          parent.children = pane
+          if (parent) parent.children = pane
           if (key === innerValue.length - 1) {
             return Promise.resolve(parent)
           }

--- a/src/packages/popup/popup.taro.tsx
+++ b/src/packages/popup/popup.taro.tsx
@@ -169,6 +169,7 @@ export const Popup: FunctionComponent<
   }
 
   const handleCloseIconClick = (e: ITouchEvent) => {
+    e.stopPropagation()
     onCloseIconClick(e) && close()
   }
 


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 级联选择：修复懒加载过程中父节点未就绪导致的报错与选项渲染异常，提升稳定性与加载可靠性。
  - 弹窗：修复点击关闭图标会冒泡触发上层点击事件的问题，避免误触导致的意外关闭或重复回调，使交互更一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->