### PR TITLE
fix: 兼容nextjs ssr，Col组件初始状态class=""元素会闪一下

### DIFF
--- a/src/packages/col/col.tsx
+++ b/src/packages/col/col.tsx
@@ -27,8 +27,6 @@ export const Col: FunctionComponent<
       ...defaultProps,
       ...props,
     }
-  const [colName, setColName] = useState('')
-  const [colStyle, setColStyle] = useState({})
   const { gutter } = useContext(DataContext) as any
 
   const classs = () => {
@@ -49,6 +47,8 @@ export const Col: FunctionComponent<
     }
     return style
   }
+  const [colName, setColName] = useState(classs())
+  const [colStyle, setColStyle] = useState(getStyle())
   useEffect(() => {
     setColName(classs)
     setColStyle(getStyle)


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

兼容nextjs ssr，Col组件的class初始状态为`class=""`元素会闪一下

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 重构
  - 初始化列组件的类名与样式基于当前属性即时计算，避免首次渲染的额外更新。
  - 依赖变更时改用更新器方式刷新类名与样式，确保栅格布局与间距准确同步。
  - 影响：初始加载更流畅、渲染更一致；对外用法不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->