### PR TITLE
feat: enhance SafeArea with className/style props and constant() iOS fallback

### DIFF
--- a/src/packages/safearea/safearea.scss
+++ b/src/packages/safearea/safearea.scss
@@ -4,11 +4,17 @@
 
   &-position-top {
     padding-top: calc(
+      constant(safe-area-inset-top) * var(--nutui-safe-area-multiple, 1)
+    );
+    padding-top: calc(
       env(safe-area-inset-top) * var(--nutui-safe-area-multiple, 1)
     );
   }
 
   &-position-bottom {
+    padding-bottom: calc(
+      constant(safe-area-inset-bottom) * var(--nutui-safe-area-multiple, 1)
+    );
     padding-bottom: calc(
       env(safe-area-inset-bottom) * var(--nutui-safe-area-multiple, 1)
     );

--- a/src/packages/safearea/safearea.taro.tsx
+++ b/src/packages/safearea/safearea.taro.tsx
@@ -5,13 +5,20 @@ import { TaroSafeAreaProps } from '@/types'
 
 const classPrefix = 'nut-safe-area'
 export const SafeArea: FC<TaroSafeAreaProps> = (props) => {
+  const { className, style, position, children, ...rest } = props
+
   return (
     <View
+      {...rest}
       className={classNames(
         classPrefix,
-        `${classPrefix}-position-${props.position}`
+        `${classPrefix}-position-${position}`,
+        className
       )}
-    />
+      style={style}
+    >
+      {children}
+    </View>
   )
 }
 

--- a/src/packages/safearea/safearea.taro.tsx
+++ b/src/packages/safearea/safearea.taro.tsx
@@ -5,7 +5,7 @@ import { TaroSafeAreaProps } from '@/types'
 
 const classPrefix = 'nut-safe-area'
 export const SafeArea: FC<TaroSafeAreaProps> = (props) => {
-  const { className, style, position, children, ...rest } = props
+  const { className, style, position, ...rest } = props
 
   return (
     <View
@@ -16,9 +16,7 @@ export const SafeArea: FC<TaroSafeAreaProps> = (props) => {
         className
       )}
       style={style}
-    >
-      {children}
-    </View>
+    />
   )
 }
 

--- a/src/packages/safearea/safearea.tsx
+++ b/src/packages/safearea/safearea.tsx
@@ -4,7 +4,7 @@ import { WebSafeAreaProps } from '@/types'
 
 const classPrefix = 'nut-safe-area'
 export const SafeArea: FC<WebSafeAreaProps> = (props) => {
-  const { className, style, position, children, ...rest } = props
+  const { className, style, position, ...rest } = props
 
   return (
     <div
@@ -15,9 +15,7 @@ export const SafeArea: FC<WebSafeAreaProps> = (props) => {
         className
       )}
       style={style}
-    >
-      {children}
-    </div>
+    />
   )
 }
 

--- a/src/packages/safearea/safearea.tsx
+++ b/src/packages/safearea/safearea.tsx
@@ -4,13 +4,20 @@ import { WebSafeAreaProps } from '@/types'
 
 const classPrefix = 'nut-safe-area'
 export const SafeArea: FC<WebSafeAreaProps> = (props) => {
+  const { className, style, position, children, ...rest } = props
+
   return (
     <div
+      {...rest}
       className={classNames(
         classPrefix,
-        `${classPrefix}-position-${props.position}`
+        `${classPrefix}-position-${position}`,
+        className
       )}
-    />
+      style={style}
+    >
+      {children}
+    </div>
   )
 }
 


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. Use the legacy `constant(safe-area-inset-*) function `as a fallback before `env(safe-area-inset-*) `so that the SafeArea component works correctly on older iOS versions that only support `constant().
`
 <img width="1341" height="578" alt="image" src="https://github.com/user-attachments/assets/ef3c1d43-79b7-4bdc-9781-04465bb54d79" />
2. Update the SafeArea component to forward `className` and `style` to its root element, allowing external customization (for example, adding extra spacing or custom background styles for specific devices/browsers).

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * SafeArea 组件现支持通过 className 和 style 自定义外观，提升灵活性
  * 改进了 props 转发与位置类名的处理，增强跨平台兼容性与可配置性
* **样式**
  * 增加对 constant(safe-area-inset-*) 的安全区填充计算，改善部分环境下的安全区适配效果
<!-- end of auto-generated comment: release notes by coderabbit.ai -->