### PR TITLE
feat(avatar): support image fill mode in taro avatar component

### DIFF
--- a/src/packages/avatar/avatar.taro.tsx
+++ b/src/packages/avatar/avatar.taro.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
   icon: '',
   background: '#eee',
   color: '#666',
+  fit: 'cover',
   mode: 'scaleToFill',
   src: '',
   alt: '',
@@ -41,6 +42,7 @@ export const Avatar: FunctionComponent<Partial<TaroAvatarProps>> & {
     src,
     icon,
     mode,
+    fit,
     avatarIndex,
     className,
     style,
@@ -129,6 +131,7 @@ export const Avatar: FunctionComponent<Partial<TaroAvatarProps>> & {
                 <Image
                   className={`nut-avatar-img nut-avatar-${groupSize || size || 'normal'}-img`}
                   src={src}
+                  style={{ objectFit: fit }}
                   mode={mode}
                   onError={errorEvent}
                 />

--- a/src/packages/avatar/avatar.taro.tsx
+++ b/src/packages/avatar/avatar.taro.tsx
@@ -22,7 +22,7 @@ const defaultProps = {
   icon: '',
   background: '#eee',
   color: '#666',
-  fit: 'cover',
+  mode: 'scaleToFill',
   src: '',
   alt: '',
   avatarIndex: 0,
@@ -40,7 +40,7 @@ export const Avatar: FunctionComponent<Partial<TaroAvatarProps>> & {
     color,
     src,
     icon,
-    fit,
+    mode,
     avatarIndex,
     className,
     style,
@@ -129,7 +129,7 @@ export const Avatar: FunctionComponent<Partial<TaroAvatarProps>> & {
                 <Image
                   className={`nut-avatar-img nut-avatar-${groupSize || size || 'normal'}-img`}
                   src={src}
-                  style={{ objectFit: fit }}
+                  mode={mode}
                   onError={errorEvent}
                 />
               )}

--- a/src/packages/avatar/demo.taro.tsx
+++ b/src/packages/avatar/demo.taro.tsx
@@ -13,6 +13,7 @@ import Demo6 from './demos/taro/demo6'
 import Demo7 from './demos/taro/demo7'
 import Demo8 from './demos/taro/demo8'
 import Demo9 from './demos/taro/demo9'
+import Demo10 from './demos/taro/demo10'
 
 const AvatarDemo = () => {
   const [translated] = useTranslate({
@@ -26,6 +27,7 @@ const AvatarDemo = () => {
       f645fc65: '组合头像可控制层级方向',
       '43f00872': '点击头像触发事件',
       f645fc66: '列表展示',
+      imageMode: '图片填充模式',
     },
     'zh-TW': {
       '67f78db5': '支持三種尺寸：small、normal、large',
@@ -37,6 +39,7 @@ const AvatarDemo = () => {
       f645fc65: '組合頭像可控制層級方向',
       '43f00872': '點擊頭像觸發事件',
       f645fc66: '列表展示',
+      imageMode: '圖片填充模式',
     },
     'en-US': {
       '67f78db5': 'Support three sizes: small, normal, large',
@@ -49,6 +52,7 @@ const AvatarDemo = () => {
       f645fc65: 'Combining avatars to control hierarchy direction',
       '43f00872': 'Click on the avatar to trigger the event',
       f645fc66: 'list',
+      imageMode: 'Image fill mode',
     },
   })
 
@@ -76,6 +80,8 @@ const AvatarDemo = () => {
         <Demo8 />
         <View className="h2">{translated.f645fc66}</View>
         <Demo9 />
+        <View className="h2">{translated.imageMode}</View>
+        <Demo10 />
       </ScrollView>
     </>
   )

--- a/src/packages/avatar/demos/taro/demo10.tsx
+++ b/src/packages/avatar/demos/taro/demo10.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Avatar, Cell } from '@nutui/nutui-react-taro'
+
+const Demo10 = () => {
+  const src =
+    'https://storage.360buyimg.com/imgtools/e067cd5b69-07c864c0-dd02-11ed-8b2c-d7f58b17086a.png'
+  return (
+    <Cell>
+      <Avatar src={src} mode="scaleToFill" style={{ marginRight: 10 }} />
+      <Avatar src={src} mode="aspectFit" style={{ marginRight: 10 }} />
+      <Avatar src={src} mode="aspectFill" style={{ marginRight: 10 }} />
+      <Avatar src={src} mode="widthFix" />
+    </Cell>
+  )
+}
+export default Demo10

--- a/src/packages/avatar/doc.taro.md
+++ b/src/packages/avatar/doc.taro.md
@@ -90,6 +90,14 @@ Icon 和字符型可以自定义图标颜色及背景色
 
 :::
 
+### 图片填充模式
+
+:::demo
+
+<CodeBlock src='taro/demo10.tsx'></CodeBlock>
+
+:::
+
 ## Avatar
 
 ### Props
@@ -101,8 +109,9 @@ Icon 和字符型可以自定义图标颜色及背景色
 | background | 设置 Icon、字符类型头像的背景色 | `string` | `#eee` |
 | color | 设置 Icon、字符类型头像的颜色 | `string` | `#666` |
 | src | 设置图片类型头像的地址 | `string` | `-` |
+| mode | 图片裁剪、缩放模式，同 Taro Image 的 mode 属性 | `scaleToFill` \| `aspectFit` \| `aspectFill` \| `widthFix` \| `heightFix` \| `top` \| `bottom` \| `center` \| `left` \| `right` \| `top left` \| `top right` \| `bottom left` \| `bottom right` | `scaleToFill` |
 | icon | 设置 Icon 类型头像图标 | `ReactNode` | `-` |
-| onClick | 点击头像触发事件 | `(e: MouseEvent<HTMLDivElement>) => void` | `-` |
+| onClick | 点击头像触发事件 | `(e: ITouchEvent) => void` | `-` |
 | onError | 图片加载失败的事件 | `() => void` | `-` |
 
 ## Avatar.Group

--- a/src/types/spec/avatar/taro.ts
+++ b/src/types/spec/avatar/taro.ts
@@ -1,8 +1,10 @@
-import { ITouchEvent } from '@tarojs/components'
+import { ITouchEvent, ImageProps } from '@tarojs/components'
 import { BaseAvatar, BaseAvatarGroup } from './base'
 
-export interface TaroAvatarProps extends Omit<BaseAvatar, 'onClick'> {
+export interface TaroAvatarProps extends Omit<BaseAvatar, 'onClick' | 'fit'> {
   avatarIndex: number
+  /** 图片裁剪、缩放的模式，同 Taro Image 的 mode 属性 */
+  mode: keyof ImageProps.Mode
   onClick: (e: ITouchEvent) => void
 }
 

--- a/src/types/spec/avatar/taro.ts
+++ b/src/types/spec/avatar/taro.ts
@@ -1,10 +1,14 @@
 import { ITouchEvent, ImageProps } from '@tarojs/components'
 import { BaseAvatar, BaseAvatarGroup } from './base'
 
-export interface TaroAvatarProps extends Omit<BaseAvatar, 'onClick' | 'fit'> {
+export interface TaroAvatarProps extends Omit<BaseAvatar, 'onClick'> {
   avatarIndex: number
   /** 图片裁剪、缩放的模式，同 Taro Image 的 mode 属性 */
   mode: keyof ImageProps.Mode
+  /**
+   * @deprecated 请使用 mode 属性代替
+   */
+  fit: BaseAvatar['fit']
   onClick: (e: ITouchEvent) => void
 }
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
--

### 💡 需求背景和解决方案

#### 需求背景
Taro 版本的 Avatar 组件中，fit 属性使用 style={{ objectFit: fit }} 实现，但 Taro Image 组件在小程序端不支持 CSS object-fit，需要使用原生的 mode 属性，因此当前 fit 属性不生效。但鉴于这是一个常用的能力，所以需要支持。

#### 解决方案
通过Taro中的 Image mode 属性来支持Avatar组件的图片填充模式。

Taro官方文档中 Image mode 属性相关信息如下：
<img width="1280" height="756" alt="image" src="https://github.com/user-attachments/assets/64d7183a-6959-47b4-ac1d-9b99468246f1" />
<img width="1280" height="769" alt="image" src="https://github.com/user-attachments/assets/96e11ac2-544e-4f32-82eb-d219e0606fb7" />
<img width="1280" height="482" alt="image" src="https://github.com/user-attachments/assets/1ad02178-60a7-4a92-bc4a-00bd7d156f68" />
<img width="1280" height="310" alt="image" src="https://github.com/user-attachments/assets/4c1446df-98ac-4c79-961e-2d5a9b4eed70" />

**可以看到API支持程度很好**

#### 其他说明
1. 属性名为 mode 是为了对齐Taro，并且mode 默认值为 scaleToFill（与 Taro Image 默认值保持一致，避免 breaking change）
2. 移除了无效的 fit 属性



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Avatar 组件新增 mode 属性，支持多种图片缩放/裁剪模式（默认 scaleToFill），提升图片显示灵活性。

* **文档**
  * 增加模式演示示例，展示不同 image mode 效果。
  * 更新组件文档和属性表，新增 mode，标注旧的 fit 使用为已弃用并调整 onClick 事件类型为触摸事件签名。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->