### PR TITLE
feat(toast): add functionality to make toast persistent until manuall…

### DIFF
--- a/src/packages/toast/demos/h5/demo2.tsx
+++ b/src/packages/toast/demos/h5/demo2.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Toast, Cell, Button } from '@nutui/nutui-react'
 
 const Demo2 = () => {
@@ -16,6 +16,17 @@ const Demo2 = () => {
     })
   }
 
+  const [neverDisappear, setNeverDisappear] = useState(false)
+
+  const hideToastStyle: React.CSSProperties = neverDisappear
+    ? {
+        position: 'fixed',
+        top: '53%',
+        left: '35%',
+        zIndex: 9999,
+      }
+    : {}
+
   return (
     <>
       <Cell
@@ -28,18 +39,24 @@ const Demo2 = () => {
         title="Toast 不消失"
         onClick={(
           event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
-        ) => permanentToast('Toast 不消失')}
-      />
-      <Button
-        style={{ margin: 8 }}
-        type="primary"
-        shape="round"
-        onClick={() => {
-          Toast.clear()
+        ) => {
+          setNeverDisappear(true)
+          permanentToast('Toast 不消失')
         }}
-      >
-        隐藏Toast
-      </Button>
+      />
+      <div style={hideToastStyle}>
+        <Button
+          style={{ margin: 8 }}
+          type="primary"
+          shape="round"
+          onClick={() => {
+            setNeverDisappear(false)
+            Toast.clear()
+          }}
+        >
+          隐藏Toast
+        </Button>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
…y cleared

<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

To optimize h5 documents, you can manually turn off toast

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了Toast组件中"永不消失"功能的交互流程，优化了隐藏Toast按钮的呈现方式和用户操作体验。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->