### PR TITLE
fix(toast): toast cannot be cleared in strict mode

### DIFF
--- a/src/packages/toast/Notification.tsx
+++ b/src/packages/toast/Notification.tsx
@@ -156,13 +156,14 @@ Notification.newInstance = (properties, callback) => {
 
   let called = false
 
-  function ref(instance: any) {
+  function ref(instance: Notification | null) {
     if (called) {
       return
     }
     called = true
     callback({
       component: instance,
+      id,
       destroy() {
         unmount(element)
         element && element.parentNode && element.parentNode.removeChild(element)

--- a/src/packages/toast/__test__/toast.spec.tsx
+++ b/src/packages/toast/__test__/toast.spec.tsx
@@ -29,6 +29,12 @@ const onClickToast = vi.fn((type, msg, options?) => {
   }
 })
 
+const waitTimeout = (delay: number) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay)
+  })
+}
+
 test('event click-show-toast test', async () => {
   const { getByTestId } = render(
     <Cell
@@ -152,19 +158,87 @@ test('manually close in strict mode', async () => {
   await waitFor(() => {
     fireEvent.click(getByTestId('emit-click'))
     expect(onClickToast).toBeCalled()
-    expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(content)
+    expect(document.querySelectorAll('.nut-toast-text')?.length).toBe(2)
   })
 
   Toast.clear()
 
-  await waitFor(
-    () => {
-      expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(
-        undefined
-      )
-    },
-    {
-      timeout: time,
-    }
+  await waitTimeout(time)
+  expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(undefined)
+})
+
+test('no content', async () => {
+  const { getByTestId } = render(
+    <Cell
+      data-testid="emit-click"
+      onClick={() => {
+        Toast.show({})
+      }}
+    />
   )
+  await waitFor(() => {
+    fireEvent.click(getByTestId('emit-click'))
+    expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(undefined)
+  })
+})
+
+test('string option', async () => {
+  const content = 'string option'
+  const { getByTestId } = render(
+    <Cell
+      data-testid="emit-click"
+      onClick={() => {
+        Toast.show(content)
+      }}
+    />
+  )
+  await waitFor(() => {
+    fireEvent.click(getByTestId('emit-click'))
+    expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(content)
+  })
+})
+
+test('global config', async () => {
+  const content = 'global config'
+  const contentClassName = 'content-demo'
+  Toast.config({ contentClassName })
+  const { getByTestId } = render(
+    <Cell
+      data-testid="emit-click"
+      onClick={() => {
+        onClickToast('text', content)
+      }}
+    />
+  )
+  await waitFor(() => {
+    fireEvent.click(getByTestId('emit-click'))
+    expect(document.querySelector(`.${contentClassName}`)).toBeTruthy()
+    expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(content)
+  })
+})
+
+test('1s after close', async () => {
+  const content = '1'
+  let isCalledClose = false
+  const { getByTestId } = render(
+    <Cell
+      data-testid="emit-click"
+      onClick={() => {
+        onClickToast('text', content, {
+          duration: 1,
+          onClose: () => {
+            isCalledClose = true
+          },
+        })
+      }}
+    />
+  )
+  await waitFor(() => {
+    fireEvent.click(getByTestId('emit-click'))
+    expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(content)
+  })
+
+  await waitTimeout(2000)
+  expect(document.querySelector('.nut-toast-text')).toBe(null)
+  expect(isCalledClose).toBeTruthy()
 })

--- a/src/packages/toast/__test__/toast.spec.tsx
+++ b/src/packages/toast/__test__/toast.spec.tsx
@@ -136,3 +136,35 @@ test('event show-loading-toast', async () => {
     expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe('loading')
   })
 })
+
+test('manually close in strict mode', async () => {
+  const time = 2000
+  const content = 'strict mode loading'
+  const { getByTestId } = render(
+    <Cell
+      data-testid="emit-click"
+      onClick={() => {
+        onClickToast('loading', content)
+        onClickToast('loading', content)
+      }}
+    />
+  )
+  await waitFor(() => {
+    fireEvent.click(getByTestId('emit-click'))
+    expect(onClickToast).toBeCalled()
+    expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(content)
+  })
+
+  Toast.clear()
+
+  await waitFor(
+    () => {
+      expect(document.querySelector('.nut-toast-text')?.innerHTML).toBe(
+        undefined
+      )
+    },
+    {
+      timeout: time,
+    }
+  )
+})

--- a/src/packages/toast/toast.tsx
+++ b/src/packages/toast/toast.tsx
@@ -6,12 +6,12 @@ import { clone } from '@/utils'
 
 type NotificationInstance = {
   component: Notification
-  id: number
+  id: string
   destroy: () => void
 }
 
 let messageInstance: NotificationInstance | null = null
-const messageInstaceSet = new Set<NotificationInstance>()
+const messageInstanceSet = new Set<NotificationInstance>()
 
 let defaultProps: WebToastProps = {
   ...defaultOverlayProps,
@@ -58,7 +58,7 @@ function notice(opts: ToastNativeProps) {
   getInstance(opts2, (notification: NotificationInstance) => {
     const oldInstance = messageInstance ? clone(messageInstance) : null
     if (notification.id === oldInstance?.id) {
-      messageInstaceSet.add(oldInstance)
+      messageInstanceSet.add(oldInstance)
     }
     messageInstance = notification
   })
@@ -92,11 +92,11 @@ export default {
     if (messageInstance) {
       messageInstance.destroy()
       messageInstance = null
-      if (messageInstaceSet?.size) {
-        messageInstaceSet.forEach((instance: NotificationInstance) => {
+      if (messageInstanceSet?.size) {
+        messageInstanceSet.forEach((instance: NotificationInstance) => {
           instance?.destroy()
         })
-        messageInstaceSet.clear()
+        messageInstanceSet.clear()
       }
     }
   },

--- a/src/packages/toast/toast.tsx
+++ b/src/packages/toast/toast.tsx
@@ -1,8 +1,17 @@
+import { ReactNode } from 'react'
 import Notification from './Notification'
 import { WebToastProps } from '@/types'
 import { defaultOverlayProps } from '@/packages/overlay/overlay'
+import { clone } from '@/utils'
 
-let messageInstance: any = null
+type NotificationInstance = {
+  component: Notification
+  id: number
+  destroy: () => void
+}
+
+let messageInstance: NotificationInstance | null = null
+const messageInstaceSet = new Set<NotificationInstance>()
 
 let defaultProps: WebToastProps = {
   ...defaultOverlayProps,
@@ -26,18 +35,18 @@ type ToastNativeProps = Partial<WebToastProps>
 
 function getInstance(
   props: ToastNativeProps,
-  callback: (notification: any) => void
+  callback: (notification: NotificationInstance) => void
 ) {
   if (messageInstance) {
     messageInstance.destroy()
     messageInstance = null
   }
-  Notification.newInstance(props, (notification: any) => {
+  Notification.newInstance(props, (notification: NotificationInstance) => {
     return callback && callback(notification)
   })
 }
 
-function notice(opts: any) {
+function notice(opts: ToastNativeProps) {
   function close() {
     if (messageInstance) {
       messageInstance.destroy()
@@ -46,12 +55,16 @@ function notice(opts: any) {
     }
   }
   const opts2 = { ...defaultProps, ...opts, onClose: close }
-  getInstance(opts2, (notification: any) => {
+  getInstance(opts2, (notification: NotificationInstance) => {
+    const oldInstance = messageInstance ? clone(messageInstance) : null
+    if (notification.id === oldInstance?.id) {
+      messageInstaceSet.add(oldInstance)
+    }
     messageInstance = notification
   })
 }
 
-const errorMsg = (msg: any) => {
+const errorMsg = (msg: ReactNode) => {
   if (!msg) {
     console.warn('[NutUI Toast]: msg cannot be null')
   }
@@ -79,6 +92,12 @@ export default {
     if (messageInstance) {
       messageInstance.destroy()
       messageInstance = null
+      if (messageInstaceSet?.size) {
+        messageInstaceSet.forEach((instance: NotificationInstance) => {
+          instance?.destroy()
+        })
+        messageInstaceSet.clear()
+      }
     }
   },
 }


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

Solve the problem that toast cannot be cleared in strict mode

[Reproduction link](https://codesandbox.io/p/devbox/relaxed-cdn-w3h4cm)

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] fork仓库代码是否为最新避免文件冲突
- [ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 改进通知的创建、清除与销毁逻辑，修复多实例管理与生命周期不一致的问题。

* **Tests**
  * 新增多项测试：严格模式手动关闭、空内容、字符串内容、全局配置、自定义时长与 onClose 回调等场景，增强覆盖率。

* **Chores / 公共 API**
  * 缩窄了通知相关回调的类型并将通知 id 作为回调负载公开，提升类型安全与实例可识别性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->