### PR TITLE
fix: uploader上传组件taro版本h5端支持文件选择

### DIFF
--- a/src/packages/uploader/chooseFile.ts
+++ b/src/packages/uploader/chooseFile.ts
@@ -1,0 +1,119 @@
+/**
+ * 从本地选择文件。
+ */
+export const chooseFile = (options: any) => {
+  const shouldBeObjectNative = (options: any) => {
+    const isObject =
+      options !== null && typeof options === 'object' && !Array.isArray(options)
+
+    if (!isObject) {
+      return {
+        flag: false,
+        msg: 'parameter should be Object',
+      }
+    }
+
+    return {
+      flag: true,
+      msg: '',
+    }
+  }
+  // options must be an Object
+  const isObject = shouldBeObjectNative(options)
+  if (!isObject.flag) {
+    const res = { errMsg: `taroChooseFile:fail ${isObject.msg}` }
+    console.error(res.errMsg)
+    return Promise.reject(res)
+  }
+  const {
+    count = 1,
+    success,
+    fail,
+    complete,
+    imageId = 'taroChooseFile',
+    sourceType = ['album', 'camera'],
+  } = options
+  const res: any = {
+    tempFilePaths: [],
+    tempFiles: [],
+    errMsg: '',
+  }
+  const handleSuccess = (
+    data: any = {},
+    resolve: (v: any) => any = Promise.resolve.bind(Promise)
+  ) => {
+    if (!data.errMsg) {
+      data.errMsg = 'taroChooseFile:ok'
+    }
+    typeof success === 'function' && success(data)
+    typeof complete === 'function' && complete(data)
+    return resolve(data)
+  }
+  const handleFail = (
+    data: any = {},
+    reject: (e: any) => any = Promise.reject.bind(Promise)
+  ) => {
+    if (!data.errMsg) {
+      data.errMsg = 'taroChooseFile:fail'
+    } else {
+      data.errMsg = `taroChooseFile:fail ${data.errMsg}`
+    }
+    console.error(data.errMsg)
+    typeof fail === 'function' && fail(data)
+    typeof complete === 'function' && complete(data)
+    return reject(data)
+  }
+  const sourceTypeString = sourceType && sourceType.toString()
+  const acceptableSourceType = ['user', 'environment', 'camera']
+  if (count && typeof count !== 'number') {
+    res.errMsg = `parameter error: count should be number, but got ${typeof count}`
+    return handleFail(res)
+  }
+  const el = document.getElementById(imageId)
+  if (!el) {
+    res.errMsg = 'taroChooseFile:fail element not found'
+    return handleFail(res)
+  }
+  if (count > 1) {
+    el.setAttribute('multiple', 'multiple')
+  } else {
+    el.removeAttribute('multiple')
+  }
+  if (acceptableSourceType.indexOf(sourceTypeString) > -1) {
+    el.setAttribute('capture', sourceTypeString)
+  } else {
+    el.removeAttribute('capture')
+  }
+  return new Promise((resolve) => {
+    if (el) {
+      const evt = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      })
+      el.dispatchEvent(evt)
+      el.onchange = (e: Event) => {
+        const target = e.target as HTMLInputElement | null
+        if (target) {
+          const files = target.files || []
+          const arr = Array.from(files)
+          arr.forEach((item) => {
+            const blob = new Blob([item], {
+              type: item.type,
+            })
+            const url = URL.createObjectURL(blob)
+            res.tempFilePaths.push(url)
+            res.tempFiles.push({
+              path: url,
+              size: item.size,
+              type: item.type,
+              originalFileObj: item,
+            })
+          })
+          handleSuccess(res, resolve)
+          target.value = ''
+        }
+      }
+    }
+  })
+}

--- a/src/packages/uploader/demo.taro.tsx
+++ b/src/packages/uploader/demo.taro.tsx
@@ -18,6 +18,7 @@ import Demo11 from './demos/taro/demo11'
 import Demo12 from './demos/taro/demo12'
 import Demo13 from './demos/taro/demo13'
 import Demo14 from './demos/taro/demo14'
+import Demo15 from './demos/taro/demo15'
 
 const UploaderDemo = () => {
   const [translated] = useTranslate({
@@ -35,6 +36,7 @@ const UploaderDemo = () => {
       manualExecution: '选中文件后，通过按钮手动执行上传',
       disabled: '禁用状态',
       customDeleteIcon: '自定义删除icon',
+      customFileType: '自定义文件类型（仅H5端生效）',
     },
     'zh-TW': {
       basic: '基础用法',
@@ -50,6 +52,7 @@ const UploaderDemo = () => {
       manualExecution: '選取檔後，通過按鈕手動執行上傳',
       disabled: '禁用狀態',
       customDeleteIcon: '自定義刪除icon',
+      customFileType: '自定義文件類型（僅H5端生效）',
     },
     'en-US': {
       basic: 'Basic usage',
@@ -67,6 +70,7 @@ const UploaderDemo = () => {
         'After selecting Chinese, manually perform the upload via the button',
       disabled: 'Disabled state',
       customDeleteIcon: 'Custom DeleteIcon',
+      customFileType: 'Custom file type (H5 only)',
     },
   })
 
@@ -102,6 +106,8 @@ const UploaderDemo = () => {
         <Demo13 />
         <h2>{translated.customDeleteIcon}</h2>
         <Demo14 />
+        <h2>{translated.customFileType}</h2>
+        <Demo15 />
       </div>
     </>
   )

--- a/src/packages/uploader/demos/taro/demo15.tsx
+++ b/src/packages/uploader/demos/taro/demo15.tsx
@@ -7,7 +7,7 @@ const Demo15 = () => {
     <Uploader
       previewType="list"
       url={uploadUrl}
-      needchooseFile
+      needChooseFile
       accept=".doc,.docx,.pdf,.jpg,.jpeg,.png,.bmp"
     />
   )

--- a/src/packages/uploader/demos/taro/demo15.tsx
+++ b/src/packages/uploader/demos/taro/demo15.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Uploader } from '@nutui/nutui-react-taro'
+
+const Demo15 = () => {
+  const uploadUrl = 'https://my-json-server.typicode.com/linrufeng/demo/posts'
+  return (
+    <Uploader
+      previewType="list"
+      url={uploadUrl}
+      needchooseFile
+      accept=".doc,.docx,.pdf,.jpg,.jpeg,.png,.bmp"
+    />
+  )
+}
+
+export default Demo15

--- a/src/packages/uploader/doc.taro.md
+++ b/src/packages/uploader/doc.taro.md
@@ -136,6 +136,14 @@ app.post('/upload', upload.single('file'), (req, res) => {
 
 :::
 
+### 自定义文件类型（仅 H5 端生效）
+
+::::demo
+
+<CodeBlock src='taro/demo15.tsx'></CodeBlock>
+
+::::
+
 ## Uploader
 
 ### Props
@@ -162,6 +170,7 @@ app.post('/upload', upload.single('file'), (req, res) => {
 | maxDuration | 拍摄视频最长拍摄时间，单位秒。时间范围为 3s 至 60s 之间。不限制相册。 | `number` | `10` |
 | headers | 设置上传的请求头部 | `object` | `{}` |
 | data | 附加上传的信息 formData | `object` | `{}` |
+| accept | H5 端 `input` 的 `accept` 属性，用于限制选择的文件类型（仅 H5 端生效） | `string` | `*` |
 | uploadIcon | 上传区域<a href="#/zh-CN/icon">图标名称</a> | `ReactNode` | `-` |
 | deleteIcon | 删除区域的图标名称 | `React.ReactNode` | `-` |
 | uploadLabel | 上传区域图片下方文字 | `string` | `&quot;&quot;` |
@@ -169,6 +178,7 @@ app.post('/upload', upload.single('file'), (req, res) => {
 | disabled | 是否禁用文件上传 | `boolean` | `false` |
 | multiple | 是否支持文件多选 | `boolean` | `false` |
 | timeout | 超时时间，单位为毫秒 | `number` \| `string` | `1000 * 30` |
+| needchooseFile | 是否在 H5 端使用原生 `input` 选择文件（配合 `accept` 自定义文件类型，仅 H5 端生效） | `boolean` | `false` |
 | beforeUpload | 上传前的函数需要返回一个`Promise`对象 | `(file: File[]) => Promise<File[] \| boolean>` | `-` |
 | beforeXhrUpload | 执行 XHR 上传时，自定义方式 | `(xhr: XMLHttpRequest, options: any) => void` | `-` |
 | beforeDelete | 除文件时的回调，返回值为 false 时不移除。支持返回一个 `Promise` 对象，`Promise` 对象 resolve(false) 或 reject 时不移除 | `(file: FileItem, files: FileItem[]) => boolean` | `-` |

--- a/src/packages/uploader/doc.taro.md
+++ b/src/packages/uploader/doc.taro.md
@@ -178,7 +178,7 @@ app.post('/upload', upload.single('file'), (req, res) => {
 | disabled | 是否禁用文件上传 | `boolean` | `false` |
 | multiple | 是否支持文件多选 | `boolean` | `false` |
 | timeout | 超时时间，单位为毫秒 | `number` \| `string` | `1000 * 30` |
-| needchooseFile | 是否在 H5 端使用原生 `input` 选择文件（配合 `accept` 自定义文件类型，仅 H5 端生效） | `boolean` | `false` |
+| needChooseFile | 是否在 H5 端使用原生 `input` 选择文件（配合 `accept` 自定义文件类型，仅 H5 端生效） | `boolean` | `false` |
 | beforeUpload | 上传前的函数需要返回一个`Promise`对象 | `(file: File[]) => Promise<File[] \| boolean>` | `-` |
 | beforeXhrUpload | 执行 XHR 上传时，自定义方式 | `(xhr: XMLHttpRequest, options: any) => void` | `-` |
 | beforeDelete | 除文件时的回调，返回值为 false 时不移除。支持返回一个 `Promise` 对象，`Promise` 对象 resolve(false) 或 reject 时不移除 | `(file: FileItem, files: FileItem[]) => boolean` | `-` |

--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -27,6 +27,7 @@ import { funcInterceptor } from '@/utils/interceptor'
 import { BasicComponent, ComponentDefaults } from '@/utils/typings'
 import { FileItem } from './file-item'
 import { usePropsValue } from '@/utils/use-props-value'
+import { chooseFile } from './chooseFile'
 import { Preview } from '@/packages/uploader/preview.taro'
 
 interface sizeType {
@@ -245,13 +246,13 @@ const InternalUploader: ForwardRefRenderFunction<
       return
     }
     if (Taro.getEnv() === 'WEB') {
-      const el = document.getElementById('taroChooseImage')
+      const el = document.getElementById('taroChooseFile')
       if (el) {
         el?.setAttribute('accept', accept)
       } else {
         const obj = document.createElement('input')
         obj.setAttribute('type', 'file')
-        obj.setAttribute('id', 'taroChooseImage')
+        obj.setAttribute('id', 'taroChooseFile')
         obj.setAttribute('accept', accept)
         obj.setAttribute(
           'style',
@@ -259,8 +260,17 @@ const InternalUploader: ForwardRefRenderFunction<
         )
         document.body.appendChild(obj)
       }
-    }
-    if (['WEAPP', 'JD'].includes(getEnv()) && chooseMedia) {
+      chooseFile({
+        count: multiple ? (maxCount as number) * 1 - fileList.length : 1,
+        // 可以指定是原图还是压缩图，默认二者都有
+        sizeType,
+        sourceType,
+        success: onChangeImage,
+        fail: (res: any) => {
+          onFailure && onFailure(res)
+        },
+      })
+    } else if (['WEAPP', 'JD'].includes(getEnv()) && chooseMedia) {
       // 其余端全部使用 chooseImage API
       chooseMedia({
         count: multiple ? (maxCount as number) * 1 - fileList.length : 1,

--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -120,6 +120,7 @@ export interface UploaderProps extends BasicComponent {
   beforeXhrUpload?: (xhr: XMLHttpRequest, options: any) => void
   beforeDelete?: (file: FileItem, files: FileItem[]) => boolean
   onFileItemClick?: (file: FileItem, index: number) => void
+  needchooseFile?: boolean
 }
 
 const defaultProps = {
@@ -203,6 +204,7 @@ const InternalUploader: ForwardRefRenderFunction<
     beforeUpload,
     beforeXhrUpload,
     beforeDelete,
+    needchooseFile,
     ...restProps
   } = { ...defaultProps, ...props }
   const [fileList, setFileList] = usePropsValue({
@@ -245,7 +247,7 @@ const InternalUploader: ForwardRefRenderFunction<
     if (disabled) {
       return
     }
-    if (Taro.getEnv() === 'WEB') {
+    if (Taro.getEnv() === 'WEB' && needchooseFile) {
       const el = document.getElementById('taroChooseFile')
       if (el) {
         el?.setAttribute('accept', accept)
@@ -270,7 +272,7 @@ const InternalUploader: ForwardRefRenderFunction<
           onFailure && onFailure(res)
         },
       })
-    } else if (['WEAPP', 'JD'].includes(getEnv()) && chooseMedia) {
+    } else if (['WEAPP', 'JD', 'WEB'].includes(getEnv()) && chooseMedia) {
       // 其余端全部使用 chooseImage API
       chooseMedia({
         count: multiple ? (maxCount as number) * 1 - fileList.length : 1,

--- a/src/packages/uploader/uploader.taro.tsx
+++ b/src/packages/uploader/uploader.taro.tsx
@@ -120,7 +120,7 @@ export interface UploaderProps extends BasicComponent {
   beforeXhrUpload?: (xhr: XMLHttpRequest, options: any) => void
   beforeDelete?: (file: FileItem, files: FileItem[]) => boolean
   onFileItemClick?: (file: FileItem, index: number) => void
-  needchooseFile?: boolean
+  needChooseFile?: boolean
 }
 
 const defaultProps = {
@@ -204,7 +204,7 @@ const InternalUploader: ForwardRefRenderFunction<
     beforeUpload,
     beforeXhrUpload,
     beforeDelete,
-    needchooseFile,
+    needChooseFile,
     ...restProps
   } = { ...defaultProps, ...props }
   const [fileList, setFileList] = usePropsValue({
@@ -247,7 +247,7 @@ const InternalUploader: ForwardRefRenderFunction<
     if (disabled) {
       return
     }
-    if (Taro.getEnv() === 'WEB' && needchooseFile) {
+    if (Taro.getEnv() === 'WEB' && needChooseFile) {
       const el = document.getElementById('taroChooseFile')
       if (el) {
         el?.setAttribute('accept', accept)


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [✅] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
升级NutUI时，Taro版本编译为H5端上传组件无法支持文件类型的选择，排查问题后是Taro底层chooseImageAPI根据小程序的规范，无法支持这一能力。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.Taro版本上传组件在H5端支持文件类型选择
2、针对web环境封装chooseFileAPI，不再依赖于TaroAPI
3、不涉及UI改动

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ✅] 文档已补充或无须补充
- [ ✅] 代码演示已提供或无须提供
- [ ✅] TypeScript 定义已补充或无须补充
- [ ✅] fork仓库代码是否为最新避免文件冲突
- [ ✅] Files changed 没有 package.json lock 等无关文件
