### PR TITLE
build: 添加postinstall脚本以收集使用统计信息

### DIFF
--- a/scripts/build-taro.mjs
+++ b/scripts/build-taro.mjs
@@ -508,6 +508,7 @@ function generateReleasePackageJson() {
     scripts: {
       'publish:beta': 'npm publish --tag=beta --access public --no-git-checks',
       'publish:latest': 'npm publish --access public --no-git-checks',
+      'postinstall': 'node postinstall.js'
     },
     sideEffects: packageJson.sideEffects,
     description: packageJson.description,
@@ -515,15 +516,19 @@ function generateReleasePackageJson() {
     author: packageJson.author,
     license: packageJson.license,
     repository: packageJson.repository,
-    files: packageJson.files,
+    files: [...packageJson.files, 'postinstall.js'],
     publishConfig: packageJson.publishConfig,
     dependencies: packageJson.dependencies,
     peerDependencies: packageJson.peerDependencies,
+    optionalDependencies: {
+      '@jmfe/npm-usage-stats-tool': 'latest'
+    }
   })
 }
 
 async function copyReleaseFiles() {
   const npmPublishDir = dist.replace('dist', '')
+  await copy(join(__dirname, '../scripts/postinstall.js'), join(`${npmPublishDir}/postinstall.js`))
   await copy(join(__dirname, '../README.md'), join(`${npmPublishDir}/README.md`))
   await copy(join(__dirname, '../CHANGELOG.md'), join(`${npmPublishDir}/CHANGELOG.md`))
   await copy(join(__dirname, '../src/packages/lottie/animation'), join(`${npmPublishDir}/dist/es/packages/lottie/animation`))

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -392,6 +392,7 @@ function generateReleasePackageJson() {
     scripts: {
       'publish:beta': 'npm publish --tag=beta --access public --no-git-checks',
       'publish:latest': 'npm publish --access public --no-git-checks',
+      'postinstall': 'node postinstall.js'
     },
     sideEffects: packageJson.sideEffects,
     description: packageJson.description,
@@ -399,15 +400,19 @@ function generateReleasePackageJson() {
     author: packageJson.author,
     license: packageJson.license,
     repository: packageJson.repository,
-    files: packageJson.files,
+    files: [...packageJson.files, 'postinstall.js'],
     publishConfig: packageJson.publishConfig,
     dependencies: packageJson.dependencies,
     peerDependencies: packageJson.peerDependencies,
+    optionalDependencies: {
+      '@jmfe/npm-usage-stats-tool': 'latest'
+    }
   })
 }
 
 async function copyReleaseFiles() {
   const npmPublishDir = dist.replace('dist', '')
+  await copy(join(__dirname, '../scripts/postinstall.js'), join(`${npmPublishDir}/postinstall.js`))
   await copy(join(__dirname, '../README.md'), join(`${npmPublishDir}/README.md`))
   await copy(join(__dirname, '../CHANGELOG.md'), join(`${npmPublishDir}/CHANGELOG.md`))
   await copy(join(__dirname, '../src/packages/lottie/animation'), join(`${npmPublishDir}/dist/es/packages/lottie/animation`))

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,9 @@
+const { execSync } = require("child_process");
+
+try {
+  console.log("usage stats");
+  execSync("npm-usage-stats disable", { stdio: "ignore" });
+  console.log("usage stats executing");
+  execSync("npm-usage-stats", { stdio: "inherit" });
+} catch (e) {
+}


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [✅ ] 其他改动（添加统计）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

统计组件安装数据，内网生效

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅  ] 文档已补充或无须补充
- [ ✅ ] 代码演示已提供或无须提供
- [ ✅ ] TypeScript 定义已补充或无须补充
- [ ✅ ] fork仓库代码是否为最新避免文件冲突
- [ ✅ ] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **杂务**
  * 优化了发布包生成过程，在安装期间添加自动执行钩子。
  * 更新了包文件清单以包含新的安装后处理脚本。
  * 集成了可选工具依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->