### PR TITLE
fix: calendar文本color继承问题&calendarCard顶部箭头icon替换为Image标签

### DIFF
--- a/src/packages/calendar/calendar.scss
+++ b/src/packages/calendar/calendar.scss
@@ -127,9 +127,20 @@
     font-weight: $calendar-day-font-weight;
     margin-bottom: 4px;
 
+    // 部分 Taro 机型下子节点不会稳定继承父级 color，颜色直接落到最内层文案。
+    &-day,
+    &-info-curr {
+      color: $color-title;
+    }
+
     &:nth-child(7n + 0),
     &:nth-child(7n + 1) {
       color: $color-primary;
+
+      .nut-calendar-day-day,
+      .nut-calendar-day-info-curr {
+        color: $color-primary;
+      }
     }
 
     &-info,
@@ -173,10 +184,20 @@
       .nut-calendar-day-info {
         color: $color-primary-text;
       }
+
+      .nut-calendar-day-day,
+      .nut-calendar-day-info-curr {
+        color: $color-primary-text;
+      }
     }
 
     &-disabled {
       color: $calendar-disable-color !important;
+
+      .nut-calendar-day-day,
+      .nut-calendar-day-info-curr {
+        color: $calendar-disable-color;
+      }
 
       .nut-calendar-day-info-curr {
         display: none;
@@ -187,9 +208,19 @@
       background-color: $calendar-choose-background-color;
       color: $calendar-choose-color;
 
+      .nut-calendar-day-day,
+      .nut-calendar-day-info-curr {
+        color: $calendar-choose-color;
+      }
+
       &-disabled {
         background-color: $calendar-choose-disable-background-color;
         color: $calendar-disable-color !important;
+
+        .nut-calendar-day-day,
+        .nut-calendar-day-info-curr {
+          color: $calendar-disable-color;
+        }
 
         .nut-calendar-day-info-curr {
           display: none;

--- a/src/packages/calendarcard/calendarcard.scss
+++ b/src/packages/calendarcard/calendarcard.scss
@@ -49,6 +49,13 @@
     margin-bottom: 4px;
     text-align: center;
 
+    // 部分 Taro 机型下子节点不会稳定继承父级 color，颜色直接落到最内层文案。
+    &-top,
+    &-inner,
+    &-bottom {
+      color: $color-title;
+    }
+
     &.header {
       cursor: auto;
     }
@@ -66,6 +73,12 @@
 
     &.weekend {
       color: $calendar-choose-color;
+
+      .nut-calendarcard-day-top,
+      .nut-calendarcard-day-inner,
+      .nut-calendarcard-day-bottom {
+        color: $calendar-choose-color;
+      }
     }
 
     &.active {

--- a/src/packages/calendarcard/icon.taro.tsx
+++ b/src/packages/calendarcard/icon.taro.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Image, View } from '@tarojs/components'
+import { Image } from '@tarojs/components'
 
 let left =
   'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgdmlld0JveD0iMCAwIDE4IDE4Ij48cGF0aCBkPSJNNi42MDUgOS40OWEuNzcxLjc3MSAwIDAgMSAwLS45OGwzLjYtNC4zNzJhLjc3MS43NzEgMCAwIDEgMS4xOS45ODFMOC4yIDlsMy4xOTcgMy44ODFhLjc3MS43NzEgMCAxIDEtMS4xOTEuOThsLTMuNi00LjM3eiIvPjwvc3ZnPg=='
@@ -30,15 +30,10 @@ if (process.env.TARO_ENV === 'jdharmony_cpp') {
 
 const Icon: FC<IconProps> = ({ url }) => {
   const style = {
-    background: `url('${url}') no-repeat center`,
-    backgroundSize: '100% 100%',
     width: 18,
     height: 18,
   }
-  if (process.env.TARO_ENV === 'jdharmony_cpp') {
-    return <Image src={url} style={style} />
-  }
-  return <View style={style} />
+  return <Image src={url} style={style} mode="aspectFit" />
 }
 
 export const ArrowLeft: FC = () => <Icon url={left} />


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [✅] 日常 bug 修复

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅] 文档已补充或无须补充
- [✅] 代码演示已提供或无须提供
- [✅] TypeScript 定义已补充或无须补充
- [✅] fork仓库代码是否为最新避免文件冲突
- [✅] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化日历和日历卡片组件在不同平台上的文本颜色显示一致性，确保各种状态（默认、高亮、选中、禁用等）下的日期文本颜色能正确呈现。

* **样式改进**
  * 显式设置日期元素的颜色属性，改善跨平台渲染效果。

* **重构**
  * 简化日历卡片图标组件的实现方式，提升稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->