### PR TITLE
fix: 修复日历组件滚动问题

### DIFF
--- a/src/packages/calendaritem/calendaritem.taro.tsx
+++ b/src/packages/calendaritem/calendaritem.taro.tsx
@@ -193,6 +193,8 @@ export const CalendarItem = React.forwardRef<
   const monthsRef = useRef<HTMLDivElement>(null)
   const monthsPanel = useRef<HTMLDivElement>(null)
   const viewAreaRef = useRef<HTMLDivElement>(null)
+  const isProgrammaticScrollRef = useRef(false)
+  const scrollReleaseTimerRef = useRef<number>()
   const [avgHeight, setAvgHeight] = useState(0)
   let viewHeight = 0
 
@@ -419,6 +421,16 @@ export const CalendarItem = React.forwardRef<
     return monthsRef.current as HTMLDivElement
   }
 
+  const markProgrammaticScroll = () => {
+    isProgrammaticScrollRef.current = true
+    if (scrollReleaseTimerRef.current) {
+      clearTimeout(scrollReleaseTimerRef.current)
+    }
+    scrollReleaseTimerRef.current = window.setTimeout(() => {
+      isProgrammaticScrollRef.current = false
+    }, 450)
+  }
+
   const requestAniFrameFunc = (current: number, monthNum: number) => {
     const lastItem = monthsData[monthsData.length - 1]
     const containerHeight = lastItem.cssHeight + lastItem.scrollTop
@@ -429,6 +441,7 @@ export const CalendarItem = React.forwardRef<
         getMonthsPanel().style.height = `${containerHeight}px`
         const currTop = monthsData[current].scrollTop
         getMonthsRef().scrollTop = currTop
+        markProgrammaticScroll()
         setScrollTop(currTop)
         nextTick(() => setScrollWithAnimation(true))
       }
@@ -478,6 +491,14 @@ export const CalendarItem = React.forwardRef<
     popup && resetRender()
   }, [currentDate])
 
+  useEffect(() => {
+    return () => {
+      if (scrollReleaseTimerRef.current) {
+        clearTimeout(scrollReleaseTimerRef.current)
+      }
+    }
+  }, [])
+
   // 暴露出的API
   const scrollToDate = (date: string) => {
     if (compareDate(date, propStartDate)) {
@@ -490,6 +511,7 @@ export const CalendarItem = React.forwardRef<
       if (item.title === monthTitle(dateArr[0], dateArr[1])) {
         const currTop = monthsData[index].scrollTop
         if (monthsRef.current) {
+          markProgrammaticScroll()
           const distance = currTop - monthsRef.current.scrollTop
           if (scrollAnimation) {
             let flag = 0
@@ -519,7 +541,9 @@ export const CalendarItem = React.forwardRef<
   const monthsViewScroll = (e: any) => {
     if (monthsData.length <= 1) return
     const scrollTop = (e.target as HTMLElement).scrollTop
-    Taro.getEnv() === 'WEB' && setScrollTop(scrollTop)
+    Taro.getEnv() === 'WEB' &&
+      !isProgrammaticScrollRef.current &&
+      setScrollTop(scrollTop)
     let current = Math.floor(scrollTop / avgHeight)
     if (current < 0) return
     if (!monthsData[current + 1]) return


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ✅] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
nutui-reactTarov2.7.15版本的Calendar组件，编译为h5，在点击某个日期后无法滚动到特定位置，出现先滚动后回弹的问题

https://github.com/user-attachments/assets/76db1712-cb8a-468a-9d04-4da03e9f5db2



### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.点击某个日期能正常滚动
2.初步排查原因是点击日期的程序化滚动和手动滚动同步scrollTop的state冲突，解决方案为在程序化滚动期间，在web环境下不再每次设回scrollTop，程序化滚动结束后再恢复
3.解决后效果


https://github.com/user-attachments/assets/581a431c-7160-4450-b59b-8d3aec4b6e36




### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ✅] 文档已补充或无须补充
- [✅ ] 代码演示已提供或无须提供
- [ ✅] TypeScript 定义已补充或无须补充
- [ ]✅ fork仓库代码是否为最新避免文件冲突
- [ ✅] Files changed 没有 package.json lock 等无关文件
