### PR TITLE
fix: 将calendar中icon的样式内置到scss

### DIFF
--- a/src/packages/calendarcard/calendarcard.scss
+++ b/src/packages/calendarcard/calendarcard.scss
@@ -30,6 +30,12 @@
     }
   }
 
+  &-icon {
+    width: 18px;
+    height: 18px;
+    display: block;
+  }
+
   &-days {
     display: flex;
     flex-direction: row;

--- a/src/packages/calendarcard/icon.taro.tsx
+++ b/src/packages/calendarcard/icon.taro.tsx
@@ -29,11 +29,7 @@ if (process.env.TARO_ENV === 'jdharmony_cpp') {
 }
 
 const Icon: FC<IconProps> = ({ url }) => {
-  const style = {
-    width: 18,
-    height: 18,
-  }
-  return <Image src={url} style={style} mode="aspectFit" />
+  return <Image className="nut-calendarcard-icon" src={url} mode="aspectFit" />
 }
 
 export const ArrowLeft: FC = () => <Icon url={left} />


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [✅] 日常 bug 修复

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅] 文档已补充或无须补充
- [✅] 代码演示已提供或无须提供
- [✅] TypeScript 定义已补充或无须补充
- [✅] fork仓库代码是否为最新避免文件冲突
- [✅] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 改进了日历卡片组件图标的样式处理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->