### PR TITLE
Fix calendar radiogroup

### DIFF
--- a/src/packages/calendaritem/calendaritem.taro.tsx
+++ b/src/packages/calendaritem/calendaritem.taro.tsx
@@ -170,6 +170,10 @@ export const CalendarItem = React.forwardRef<
     currDateArray: [],
   })
 
+  const isSameRange = (range: number[], start: number, end: number) => {
+    return range[0] === start && range[1] === end
+  }
+
   const resetDefaultValue = () => {
     if (
       defaultValue ||
@@ -193,8 +197,6 @@ export const CalendarItem = React.forwardRef<
   const monthsRef = useRef<HTMLDivElement>(null)
   const monthsPanel = useRef<HTMLDivElement>(null)
   const viewAreaRef = useRef<HTMLDivElement>(null)
-  const isProgrammaticScrollRef = useRef(false)
-  const scrollReleaseTimerRef = useRef<number>()
   const [avgHeight, setAvgHeight] = useState(0)
   let viewHeight = 0
 
@@ -268,7 +270,9 @@ export const CalendarItem = React.forwardRef<
       start = 0
       end = monthNum + 2
     }
-    setMonthDefaultRange([start, end])
+    setMonthDefaultRange((range) => {
+      return isSameRange(range, start, end) ? range : [start, end]
+    })
     setTranslateY(monthsData[start].scrollTop)
     setReachedYearMonthInfo(current)
   }
@@ -421,16 +425,6 @@ export const CalendarItem = React.forwardRef<
     return monthsRef.current as HTMLDivElement
   }
 
-  const markProgrammaticScroll = () => {
-    isProgrammaticScrollRef.current = true
-    if (scrollReleaseTimerRef.current) {
-      clearTimeout(scrollReleaseTimerRef.current)
-    }
-    scrollReleaseTimerRef.current = window.setTimeout(() => {
-      isProgrammaticScrollRef.current = false
-    }, 450)
-  }
-
   const requestAniFrameFunc = (current: number, monthNum: number) => {
     const lastItem = monthsData[monthsData.length - 1]
     const containerHeight = lastItem.cssHeight + lastItem.scrollTop
@@ -440,9 +434,11 @@ export const CalendarItem = React.forwardRef<
         viewHeight = getMonthsRef().clientHeight
         getMonthsPanel().style.height = `${containerHeight}px`
         const currTop = monthsData[current].scrollTop
-        getMonthsRef().scrollTop = currTop
-        markProgrammaticScroll()
-        setScrollTop(currTop)
+        const maxScrollTop =
+          getMonthsRef().scrollHeight - getMonthsRef().clientHeight
+        const targetScrollTop = Math.min(currTop, maxScrollTop)
+        getMonthsRef().scrollTop = targetScrollTop
+        setScrollTop(targetScrollTop)
         nextTick(() => setScrollWithAnimation(true))
       }
     })
@@ -491,14 +487,6 @@ export const CalendarItem = React.forwardRef<
     popup && resetRender()
   }, [currentDate])
 
-  useEffect(() => {
-    return () => {
-      if (scrollReleaseTimerRef.current) {
-        clearTimeout(scrollReleaseTimerRef.current)
-      }
-    }
-  }, [])
-
   // 暴露出的API
   const scrollToDate = (date: string) => {
     if (compareDate(date, propStartDate)) {
@@ -511,7 +499,6 @@ export const CalendarItem = React.forwardRef<
       if (item.title === monthTitle(dateArr[0], dateArr[1])) {
         const currTop = monthsData[index].scrollTop
         if (monthsRef.current) {
-          markProgrammaticScroll()
           const distance = currTop - monthsRef.current.scrollTop
           if (scrollAnimation) {
             let flag = 0
@@ -541,9 +528,8 @@ export const CalendarItem = React.forwardRef<
   const monthsViewScroll = (e: any) => {
     if (monthsData.length <= 1) return
     const scrollTop = (e.target as HTMLElement).scrollTop
-    Taro.getEnv() === 'WEB' &&
-      !isProgrammaticScrollRef.current &&
-      setScrollTop(scrollTop)
+    console.log('🚀 ~ monthsViewScroll ~ scrollTop:', scrollTop)
+    Taro.getEnv() === 'WEB' && setScrollTop(scrollTop)
     let current = Math.floor(scrollTop / avgHeight)
     if (current < 0) return
     if (!monthsData[current + 1]) return

--- a/src/packages/radiogroup/radiogroup.taro.tsx
+++ b/src/packages/radiogroup/radiogroup.taro.tsx
@@ -53,7 +53,7 @@ export const RadioGroup = React.forwardRef(
     const cls = classNames(
       classPrefix,
       {
-        [`${classPrefix}-${props.direction}`]: props.direction,
+        [`${classPrefix}-${direction}`]: direction,
       },
       className
     )


### PR DESCRIPTION
<!--
非常感谢您的贡献 维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [✅ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
内部反馈

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
具体问题：
1.Taro版本日历组件在点击最后一个月日期时无法正常滚动到对应月份
2.Radio.Group组件在不传direction='vertical'时，样式丢失
问题定位：
1.在web环境下，ScrollView组件采用受控模式，最后一个月设置的目标滚动距离不可达，在滚动过程中又频繁设置state触发视图更新，导致出现闪动
2.虽然合并了默认属性值，但是在写类名时还是用的props.direction,没有用解构出来的direction，导致默认不存在nut-radiogroup-direction类名，其下面的样式失效
问题解决：
1.滚动时判断不可达时，计算其能滚动到的最大距离，避免设置一个不可达值，同时在滚动时判断区间是否变化，当变化时才出发区间更新，减少视图渲染
2.将props.direction改为direction
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅] 文档已补充或无须补充
- [ ✅] 代码演示已提供或无须提供
- [ ✅] TypeScript 定义已补充或无须补充
- [✅ ] fork仓库代码是否为最新避免文件冲突
- [✅ ] Files changed 没有 package.json lock 等无关文件
