### PR TITLE
fix(swipe): resolve infinite re-render loop causing page freeze

### DIFF
--- a/src/packages/swipe/__tests__/swipe.spec.tsx
+++ b/src/packages/swipe/__tests__/swipe.spec.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Swipe from '../index'
 import Cell from '../../cell'
 import Button from '../../button'
 import InputNumber from '../../inputnumber'
+import * as getRectModule from '@/utils/get-rect'
 
 test('base swipe', () => {
   const { container } = render(
@@ -95,4 +96,197 @@ test('base swipe content', async () => {
   expect(
     container.querySelector('.nut-swipe .nut-swipe-right .nut-button-wrap')
   ).toHaveTextContent('购物车')
+})
+
+test('swipe right to open via touch', () => {
+  const spy = jest.spyOn(getRectModule, 'getRect').mockReturnValue({
+    width: 80,
+    height: 40,
+    top: 0,
+    left: 0,
+    right: 80,
+    bottom: 40,
+  })
+
+  const onOpen = jest.fn()
+  const { container } = render(
+    <Swipe
+      rightAction={
+        <Button type="primary" shape="square">
+          删除
+        </Button>
+      }
+      onOpen={onOpen}
+    >
+      <Cell title="滑动" radius={0} />
+    </Swipe>
+  )
+
+  const wrapper = container.querySelector('.nut-swipe') as HTMLElement
+
+  act(() => {
+    fireEvent.touchStart(wrapper, {
+      touches: [{ clientX: 200, clientY: 0, pageX: 200, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchMove(wrapper, {
+      touches: [{ clientX: 100, clientY: 0, pageX: 100, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchEnd(wrapper, {
+      changedTouches: [{ clientX: 100, clientY: 0 }],
+    })
+  })
+
+  expect(onOpen).toHaveBeenCalled()
+  spy.mockRestore()
+})
+
+test('swipe left to open via touch', () => {
+  const spy = jest.spyOn(getRectModule, 'getRect').mockReturnValue({
+    width: 80,
+    height: 40,
+    top: 0,
+    left: 0,
+    right: 80,
+    bottom: 40,
+  })
+
+  const onOpen = jest.fn()
+  const { container } = render(
+    <Swipe
+      leftAction={
+        <Button type="success" shape="square">
+          选择
+        </Button>
+      }
+      onOpen={onOpen}
+    >
+      <Cell title="滑动" radius={0} />
+    </Swipe>
+  )
+
+  const wrapper = container.querySelector('.nut-swipe') as HTMLElement
+
+  act(() => {
+    fireEvent.touchStart(wrapper, {
+      touches: [{ clientX: 100, clientY: 0, pageX: 100, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchMove(wrapper, {
+      touches: [{ clientX: 200, clientY: 0, pageX: 200, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchEnd(wrapper, {
+      changedTouches: [{ clientX: 200, clientY: 0 }],
+    })
+  })
+
+  expect(onOpen).toHaveBeenCalled()
+  spy.mockRestore()
+})
+
+test('swipe close after opened', () => {
+  const spy = jest.spyOn(getRectModule, 'getRect').mockReturnValue({
+    width: 80,
+    height: 40,
+    top: 0,
+    left: 0,
+    right: 80,
+    bottom: 40,
+  })
+
+  const onClose = jest.fn()
+  const { container } = render(
+    <Swipe
+      rightAction={
+        <Button type="primary" shape="square">
+          删除
+        </Button>
+      }
+      onClose={onClose}
+    >
+      <Cell title="滑动" radius={0} />
+    </Swipe>
+  )
+
+  const wrapper = container.querySelector('.nut-swipe') as HTMLElement
+
+  // Open first
+  act(() => {
+    fireEvent.touchStart(wrapper, {
+      touches: [{ clientX: 200, clientY: 0, pageX: 200, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchMove(wrapper, {
+      touches: [{ clientX: 100, clientY: 0, pageX: 100, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchEnd(wrapper, {
+      changedTouches: [{ clientX: 100, clientY: 0 }],
+    })
+  })
+
+  // Close by swiping back
+  act(() => {
+    fireEvent.touchStart(wrapper, {
+      touches: [{ clientX: 100, clientY: 0, pageX: 100, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchMove(wrapper, {
+      touches: [{ clientX: 200, clientY: 0, pageX: 200, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchEnd(wrapper, {
+      changedTouches: [{ clientX: 200, clientY: 0 }],
+    })
+  })
+
+  expect(onClose).toHaveBeenCalled()
+  spy.mockRestore()
+})
+
+test('disabled swipe should not respond to touch', () => {
+  const onOpen = jest.fn()
+  const { container } = render(
+    <Swipe
+      disabled
+      rightAction={
+        <Button type="primary" shape="square">
+          删除
+        </Button>
+      }
+      onOpen={onOpen}
+    >
+      <Cell title="禁用" radius={0} />
+    </Swipe>
+  )
+
+  const wrapper = container.querySelector('.nut-swipe') as HTMLElement
+
+  act(() => {
+    fireEvent.touchStart(wrapper, {
+      touches: [{ clientX: 200, clientY: 0, pageX: 200, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchMove(wrapper, {
+      touches: [{ clientX: 100, clientY: 0, pageX: 100, pageY: 0 }],
+    })
+  })
+  act(() => {
+    fireEvent.touchEnd(wrapper, {
+      changedTouches: [{ clientX: 100, clientY: 0 }],
+    })
+  })
+
+  expect(onOpen).not.toHaveBeenCalled()
 })

--- a/src/packages/swipe/swipe.taro.tsx
+++ b/src/packages/swipe/swipe.taro.tsx
@@ -142,7 +142,8 @@ export const Swipe = forwardRef<
     if (touch.isHorizontal()) {
       lockClick.current = true
       const newState = { ...state, dragging: true }
-      const isEdge = !opened || touch.deltaX.current * startOffset.current < 0
+      const isEdge =
+        !opened.current || touch.deltaX.current * startOffset.current < 0
       if (isEdge) {
         preventDefault(event, true)
       }
@@ -170,7 +171,7 @@ export const Swipe = forwardRef<
   const toggle = (side: PositionX) => {
     const offset = Math.abs(state.offset)
     const base = 0.3
-    const baseNum = opened ? 1 - base : base
+    const baseNum = opened.current ? 1 - base : base
     const width =
       side === 'left' ? actionWidth.current.left : actionWidth.current.right
     if (width && offset > Number(width) * baseNum) {

--- a/src/packages/swipe/swipe.tsx
+++ b/src/packages/swipe/swipe.tsx
@@ -52,6 +52,8 @@ export const Swipe = forwardRef<
     left: 0,
     right: 0,
   })
+  const actionWidthRef = useRef(actionWidth)
+  actionWidthRef.current = actionWidth
   const wrapperStyle = {
     transform: `translate3d(${state.offset}px, 0, 0)`,
     transitionDuration: state.dragging ? '0s' : '.6s',
@@ -78,7 +80,8 @@ export const Swipe = forwardRef<
     if (touch.isHorizontal()) {
       lockClick.current = true
       const newState = { ...state, dragging: true }
-      const isEdge = !opened || touch.deltaX.current * startOffset.current < 0
+      const isEdge =
+        !opened.current || touch.deltaX.current * startOffset.current < 0
       if (isEdge) {
         preventDefault(event, true)
       }
@@ -108,7 +111,7 @@ export const Swipe = forwardRef<
   const toggle = (side: PositionX) => {
     const offset = Math.abs(state.offset)
     const base = 0.3
-    const baseNum = opened ? 1 - base : base
+    const baseNum = opened.current ? 1 - base : base
     const width = side === 'left' ? leftWidth : rightWidth
 
     if (width && offset > Number(width) * baseNum) {
@@ -151,22 +154,22 @@ export const Swipe = forwardRef<
     }
     return 0
   }
-  const leftRef = useCallback(
-    (node: Element | null) => {
-      if (node !== null) {
-        setActionWidth((v) => ({ ...v, left: getNodeWidth(node) }))
+  const leftRef = useCallback((node: Element | null) => {
+    if (node !== null) {
+      const width = getNodeWidth(node)
+      if (width !== actionWidthRef.current.left) {
+        setActionWidth((v) => ({ ...v, left: width }))
       }
-    },
-    [props.leftAction]
-  )
-  const rightRef = useCallback(
-    (node: Element | null) => {
-      if (node !== null) {
-        setActionWidth((v) => ({ ...v, right: getNodeWidth(node) }))
+    }
+  }, [])
+  const rightRef = useCallback((node: Element | null) => {
+    if (node !== null) {
+      const width = getNodeWidth(node)
+      if (width !== actionWidthRef.current.right) {
+        setActionWidth((v) => ({ ...v, right: width }))
       }
-    },
-    [props.rightAction]
-  )
+    }
+  }, [])
   const renderActionContent = (side: PositionX, measuredRef: any) => {
     if (props[`${side}Action`]) {
       return (


### PR DESCRIPTION
## fix(swipe): resolve infinite re-render loop causing page freeze

Closes #3433

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

- #3433 Swipe组件卡死

### 💡 需求背景和解决方案

#### 问题现象

用户在 H5 环境下使用 Swipe 组件，进入页面即卡死（无限重渲染导致页面冻结）。

#### 根因分析

修复涉及两类 bug：

**Bug 1：`useCallback` 依赖不稳定导致无限循环（仅 H5 端 `swipe.tsx`）**

`leftRef` / `rightRef` 使用了 `useCallback` + ref callback 模式来测量左右操作区域宽度，但依赖数组写的是 `[props.leftAction]` / `[props.rightAction]`。这两个 prop 是 React 元素（JSX），每次父组件渲染都会产生新的引用。导致：

1. 父组件渲染 → `props.leftAction` 新引用 → `leftRef` callback 重建
2. `leftRef` 变化 → React 调用 ref callback → `setActionWidth` 触发 state 更新
3. state 更新 → 重渲染 → 回到步骤 1 → **无限循环**

**Bug 2：`opened` ref 误用为布尔值（H5 + Taro 双端）**

`opened` 是 `useRef(false)` 创建的 ref 对象，代码中有两处直接使用了 `!opened` 和 `opened` 而非 `opened.current`。ref 对象本身是一个永远存在的对象（truthy），所以 `!opened` 永远是 `false`，`opened` 永远是 `true`，导致：

- `onTouchMove` 中 `isEdge` 判断逻辑错误，滑动边界检测失效
- `toggle` 中 `baseNum` 始终为 `1 - 0.3 = 0.7`，开合阈值判断不随 open/close 状态变化

#### 修复方案

| 改动 | 文件 | 说明 |
|------|------|------|
| `useCallback` 依赖改为 `[]` | `swipe.tsx` | 稳定 callback 引用，阻断无限循环 |
| 新增 `actionWidthRef` | `swipe.tsx` | 用 ref 追踪最新 actionWidth，在 callback 内做等值比较，宽度不变时不触发 setState |
| `!opened` → `!opened.current` | `swipe.tsx` + `swipe.taro.tsx` | 修正 ref 取值（2 处） |
| `opened` → `opened.current` | `swipe.tsx` + `swipe.taro.tsx` | 修正 ref 取值（2 处） |

#### 兼容性说明

- **API 无变化**：不涉及任何 props、回调、ref 暴露方法的变更，纯内部逻辑修正
- **行为修正**：修复后 `opened` 状态判断恢复正确，滑动开合阈值（30% / 70%）会随组件状态正确切换。之前始终按已打开状态计算阈值（0.7），修复后未打开时用 30%、已打开时用 70%
- **Taro 端**：Taro 端的宽度测量走的是 `createSelectorQuery`（不是 ref callback），不存在无限循环问题，但 `opened` 的 ref 误用同样存在，本次一并修复
- **向后兼容**：修复不改变任何公开 API，不影响现有使用方式

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了滑动手势中的状态判定逻辑，确保边缘识别和打开/关闭状态正确
  * 优化了动作区域宽度的状态管理，消除了回调闭包中的陈旧值问题

* **Tests**
  * 扩展了滑动交互的测试覆盖，新增左右滑动触发、关闭状态验证和禁用状态处理等场景测试

<!-- end of auto-generated comment: release notes by coderabbit.ai -->