### PR TITLE
fix(Cascader): preserve normalized option keys

### DIFF
--- a/src/packages/cascader/__tests__/cascader.spec.tsx
+++ b/src/packages/cascader/__tests__/cascader.spec.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { CascaderOption } from '@nutui/nutui-react'
 import { Cascader } from '../cascader'
+import { normalizeOptions } from '../utils'
 
 const mockOptions = [
   {
@@ -86,6 +87,26 @@ const mockConvertOptions = [
 ]
 
 describe('Cascader', () => {
+  it('normalizes mapped fields after preserving unrelated option fields', () => {
+    const options = [{ text: '北京', value: '021' }]
+
+    expect(
+      normalizeOptions(options, {
+        textKey: 'text',
+        valueKey: 'text',
+        childrenKey: 'children',
+      })
+    ).toEqual([{ text: '北京', value: '北京', children: undefined }])
+
+    expect(
+      normalizeOptions(options, {
+        textKey: 'value',
+        valueKey: 'value',
+        childrenKey: 'children',
+      })
+    ).toEqual([{ text: '021', value: '021', children: undefined }])
+  })
+
   it('options', async () => {
     const { container } = render(
       <Cascader value={['福建', '福州', '鼓楼区']} options={mockOptions} />

--- a/src/packages/cascader/utils.ts
+++ b/src/packages/cascader/utils.ts
@@ -13,10 +13,10 @@ export const normalizeOptions = (
       ...others
     } = opt
     return {
+      ...others,
       text,
       value,
       children: normalizeOptions(children, keyMap),
-      ...others,
     } as CascaderOption
   })
 }


### PR DESCRIPTION
### 🤔 这个变动的性质是？
- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue
Closes #3429

### 💡 需求背景和解决方案
当 `optionKey` 将 `textKey` 和 `valueKey` 映射到同一原始字段时，`others` 会在归一化字段之后展开并覆盖 `text` 或 `value`。

调整字段展开顺序，先保留其他属性，再写入归一化后的 `text`、`value` 和 `children`。同时补充两种同字段映射的回归用例。

### ☑️ 请求合并前的自查清单
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] fork仓库代码是否为最新避免文件冲突
- [x] Files changed 没有 package.json lock 等无关文件

### ✅ 验证
- `pnpm test`
- `pnpm build`
- `pnpm build:taro`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复级联选择器选项字段规范化问题，确保自定义文本和值字段正确映射。
  * 确保标准化后的字段覆盖原始同名属性，并保留 `children: undefined` 状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->